### PR TITLE
fix: replace LICENSE with canonical Apache-2.0 text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -137,8 +138,8 @@
 
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
    7. Disclaimer of Warranty. Unless required by applicable law or
       agreed to in writing, Licensor provides the Work (and each
@@ -163,14 +164,15 @@
       has been advised of the possibility of such damages.
 
    9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may accept support,
-      warranty, indemnity, or other liability obligations and/or rights
-      consistent with this License. However, in accepting such obligations,
-      You may only act on Your own behalf and on Your sole responsibility,
-      not on behalf of any other Contributor, and only if You agree to
-      indemnify, defend, and hold each Contributor harmless for any
-      liability incurred by, or claims asserted against, such Contributor
-      by reason of your accepting any such warranty or additional liability.
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
 
@@ -185,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 duktig666
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Problem

GitHub shows this repo as **Other** instead of **Apache-2.0** in the sidebar because the `LICENSE` file deviates from the canonical template. GitHub's [licensee](https://github.com/licensee/licensee) tool requires a near-exact match to recognize a known license.

## Diagnosed deviations vs canonical Apache-2.0

1. **§4(c)** (attribution scope): missing phrase `"reasonable and customary use in"` — materially narrows the attribution exception wording
2. **§9** (Accepting Warranty): missing phrase `"choose to offer, and charge a fee for, acceptance of"` — changes how third-party support terms are described
3. **APPENDIX**: template placeholders `[yyyy]` / `[name of copyright owner]` filled with `2026 duktig666` — that section is the *template* users copy into source headers, not the project's own copyright notice
4. Leading blank line missing

Deviations 1 and 2 are material alterations of the license body (not just cosmetic), which is why licensee declines to detect.

## Fix

Replace `LICENSE` with verbatim text from https://www.apache.org/licenses/LICENSE-2.0.txt (202 lines, 11358 bytes). `diff LICENSE vs canonical` is now empty.

## Project copyright

The project's own copyright attribution (if needed) belongs in:
- `README.md` header or footer
- Source file headers (`SPDX-License-Identifier: Apache-2.0`)
- Optional `NOTICE` file for third-party attributions

Not in the `LICENSE` file body — that must remain the pristine canonical text.

## Test plan

- [x] `diff LICENSE <canonical>` returns empty
- [x] `wc -c LICENSE` = 11358 bytes (matches canonical)
- [ ] After merge, GitHub re-fetches the repo's licensee result and the sidebar updates to "Apache-2.0" (usually within minutes)

## Related

- Orthogonal to PR #3 (INDEX auto-maintenance)
- Not related to issue #2 (friction #8 architecture change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)