### PR TITLE
fix(lint): extend orphan detection to all 7 index categories (#5)

### DIFF
--- a/commands/lint.md
+++ b/commands/lint.md
@@ -45,7 +45,14 @@ Do NOT use the `Skill` tool to activate the underscore-prefixed helper.
 - 没有 frontmatter 的文档列为"缺少元数据"
 
 ### 3. 孤儿检测
-- 找出没有被 `INDEX.md`、`decision-log.md` 或其他文档引用的 design-docs / analyze
+- 找出没有被 `INDEX.md` / `decision-log.md` 或其他文档引用的文件，覆盖 `commands/workflow.md` §Step 7 索引的全部类别：
+  - `analyze/[slug].md`
+  - `design-docs/[slug].md`
+  - `exec-plans/active/[slug]-plan.md`
+  - `exec-plans/completed/[slug]-plan.md`
+  - `testing/[slug].md` / `testing/[slug]-<type>.md`
+  - `reviews/[YYYY-MM-DD]-[slug].md` / `reviews/[YYYY-MM-DD]-db-[slug].md`
+  - `api-docs/[slug].md`
 - 找出 `INDEX.md` 中列出但文件已不存在的条目（断链）
 
 ### 4. 断链检查


### PR DESCRIPTION
## Summary
- `commands/lint.md` §3 孤儿检测原仅覆盖 `design-docs/` + `analyze/`；PR #3 后 `INDEX.md` 实际索引 7 类产出
- 扩表对齐 `commands/workflow.md` §Step 7 authoritative category list：`analyze` / `design-docs` / `exec-plans/{active,completed}` / `testing` / `reviews` / `api-docs`
- ~8 line addition；其他检查项未改动；lint_cmd 0 命中

Closes #5

## Test plan
- [x] `grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` → 0 hits
- [ ] Optional smoke：在 roundtable 自身或 gleanforge 跑 `/roundtable:lint`，确认 7 类目录下未索引文件被 flag 成 orphan

🤖 Generated with [Claude Code](https://claude.com/claude-code)