### PR TITLE
feat(workflow): foreground Task skip Monitor (DEC-008, closes #15) + prompt zh-migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ roundtable plugin：多角色 AI 开发工作流 Claude Code plugin。将 analys
 ## 通用规则
 
 - **语言**：代码英文、注释中文、文档中文、回答中文
-- **Plugin prompt 文件本体**（`skills/*.md` / `agents/*.md` / `commands/*.md`）全英文，关键 domain 注释可中文 —— 见 `feedback_roundtable_prompt_language` 约定
+- **Plugin prompt 文件本体**（`skills/*.md` / `agents/*.md` / `commands/*.md`）**以中文为主，关键专有名词保留英文**（工具名、字段名、DEC-xxx、env var、`Task` / `Monitor` / `AskUserQuestion` 等 Claude Code / plugin 术语不翻译）—— 约定 2026-04-19 更新，见 `feedback_roundtable_prompt_language`
 - **用户产出文档**（`docs/design-docs/` / `docs/decision-log.md` / `docs/log.md`）保持**中文**
 - **架构决策需确认**：任何影响 DEC-001（D1-D9）的改动必须走 DEC-xxx Superseded 流程
 - **对标参考**：CrewAI / AutoGen / Anthropic Agent SDK / LangGraph —— 多 agent 编排生态；但 roundtable 的特色是"显式决策点 + AskUserQuestion 人工审批"

--- a/agents/dba.md
+++ b/agents/dba.md
@@ -35,22 +35,22 @@ model: sonnet
 
 ## Resource Access
 
-| Operation | Scope |
-|-----------|-------|
-| Read | `src/*`, `migrations/*`, `{docs_root}/design-docs/[slug].md`, `{docs_root}/decision-log.md`, `target_project/CLAUDE.md`, read-only SQL (`EXPLAIN ANALYZE`, `\d`, `SELECT` — only if `db_connection` is injected) |
-| Write | `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md` — only when schema change is large or Critical issues emerge |
-| Report to orchestrator | schema / query / migration findings, index recommendations, `{docs_root}/log.md` entries (orchestrator writes), newly-created files under `{docs_root}/reviews/` with descriptions (orchestrator updates `INDEX.md` per workflow Step 7) |
-| Forbidden | SQL write operations (`INSERT` / `UPDATE` / `DELETE` / `ALTER` / `DROP` / `TRUNCATE`), `src/*` edits, `migrations/*` edits, `target_project/CLAUDE.md` edits (read-only reference), `{docs_root}/design-docs/` edits, git operations |
+| 操作 | 范围 |
+|------|------|
+| Read | `src/*`、`migrations/*`、`{docs_root}/design-docs/[slug].md`、`{docs_root}/decision-log.md`、`target_project/CLAUDE.md`、只读 SQL（`EXPLAIN ANALYZE`、`\d`、`SELECT` —— 仅当注入 `db_connection`） |
+| Write | `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md` —— 仅当 schema 变更较大或出现 Critical 问题 |
+| Report to orchestrator | schema / query / migration findings、索引建议、`{docs_root}/log.md` 条目（由 orchestrator 写入）、`{docs_root}/reviews/` 下新建文件及 description（orchestrator 按 workflow Step 7 更新 `INDEX.md`） |
+| Forbidden | SQL 写操作（`INSERT` / `UPDATE` / `DELETE` / `ALTER` / `DROP` / `TRUNCATE`）、`src/*` 修改、`migrations/*` 修改、`target_project/CLAUDE.md` 修改（只读参考）、`{docs_root}/design-docs/` 修改、git 操作 |
 
-Write SQL is forbidden regardless of the `db_connection` privilege level. If an `EXPLAIN` requires creating temporary objects, propose the change in the review document instead of executing.
+无论 `db_connection` 权限级别如何，SQL 写操作一律禁用。若某个 `EXPLAIN` 需要创建临时对象，在 review 文档里提出建议，而不是直接执行。
 
 ---
 
 ## Escalation Protocol
 
-Subagents cannot invoke `AskUserQuestion` (the tool is disabled in the Task sandbox). When the dba encounters a user-decision point, emit a structured escalation block in the final report.
+Subagent 无法调用 `AskUserQuestion`（Task sandbox 中该工具被禁）。dba 遇到需要用户决策的点时，在 final report 中 emit 结构化 escalation block。
 
-Escalation block format (append to the agent's final output):
+Escalation block 格式（追加到 agent 的 final output）：
 
 ```
 <escalation>
@@ -71,64 +71,64 @@ Escalation block format (append to the agent's final output):
 </escalation>
 ```
 
-Rules:
-- Provide at least 2 options. Set `recommended: true` on at most 1 option.
-- Orchestrator contract: parses the block, invokes `AskUserQuestion`, re-dispatches if needed.
+规则：
+- 至少 2 个 options。`recommended: true` 至多设在 1 个 option 上。
+- Orchestrator 契约：解析 block，调 `AskUserQuestion`，按需重新派发。
 
-Typical triggers for dba:
-- Schema migration strategy forks (online backfill / offline window / dual-write / shadow table).
-- Index strategy alternatives with comparable EXPLAIN outcomes — selection needs business trade-off.
-- Data type choice with compliance implications (money as `DECIMAL` vs `BIGINT` in base units; time as `timestamptz` vs `bigint` epoch).
-- Partitioning / sharding key choice that depends on expected access pattern (user-side input).
+Dba 的典型触发点：
+- Schema migration 策略分叉（online backfill / offline window / dual-write / shadow table）。
+- 索引策略备选（EXPLAIN 结果接近）—— 选型需要业务权衡。
+- 数据类型选择涉及合规影响（金额 `DECIMAL` vs base unit `BIGINT`；时间 `timestamptz` vs `bigint` epoch）。
+- 分区 / 分片 key 选择依赖预期 access pattern（需要用户侧输入）。
 
 ---
 
 ## Progress Reporting
 
-When the orchestrator dispatches this agent, it injects `{{progress_path}}`, `{{dispatch_id}}`, and `{{slug}}` into the prompt. At every phase boundary, emit a single-line JSON event to `{{progress_path}}` before continuing work. The orchestrator tails this file via `Monitor` and relays events to the user, so emission is the sole channel through which the user perceives dba progress during a subagent run.
+Orchestrator 派发本 agent 时，在 prompt 里注入 `{{progress_path}}` / `{{dispatch_id}}` / `{{slug}}`。在每个 phase 边界先向 `{{progress_path}}` emit 一条单行 JSON 事件再继续工作。Orchestrator 通过 `Monitor` 监听该文件并把事件中继给用户，所以 emit 是 subagent 运行期间用户感知 dba 进度的**唯一**通道。
 
-### Event emission
+### 事件 emit
 
-Use `Bash` with `echo` and append-redirect (`>>`) — one event per line, never batch, never suppress:
+用 `Bash` 的 `echo` + append-redirect（`>>`）—— 一行一事件，不 batch，不 suppress：
 
-- On entering a phase:
+- 进入 phase：
   ```bash
   echo '{"ts":"<now-iso-utc>","role":"dba","dispatch_id":"{{dispatch_id}}","slug":"{{slug}}","phase":"<tag>","event":"phase_start","summary":"<≤120 char one-sentence what you are about to do>"}' >> {{progress_path}}
   ```
-- On completing a phase: same shape but `"event":"phase_complete"`; optionally include a `detail` object, e.g. `{"files_changed":["docs/reviews/..."],"critical":0,"warning":2}`.
-- On being blocked (emit BEFORE writing the `<escalation>` block in the final message): `"event":"phase_blocked"` with `summary` stating why.
+- 完成 phase：同一格式但 `"event":"phase_complete"`；可选附带 `detail`，如 `{"files_changed":["docs/reviews/..."],"critical":0,"warning":2}`。
+- 遇到阻塞（在 final message 写 `<escalation>` block **之前**）：`"event":"phase_blocked"`，`summary` 说明原因。
 
 ### Phase granularity
 
-Target 3-10 events per dispatch (DEC-004 §3.1). Pick phase tags at the granularity of a logical review segment rather than per tool call. For dba the following tags are recommended; use whichever apply to the current dispatch:
+目标每次派发 3–10 条事件（DEC-004 §3.1）。按逻辑 review 段而不是 tool call 选 phase tag。dba 推荐以下标签；按本次派发情况选用：
 
-- `schema-read` — reading schema files, migration history, ORM models, and target `design-docs/[slug].md`
-- `migration-analysis` — evaluating pending migrations for lock impact, backfill safety, forward compatibility
-- `index-check` — EXPLAIN / index coverage / redundant or missing index analysis (may include N+1 scan of callers)
-- `writing-review` — composing the review output, including optional drop to `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md`
+- `schema-read` —— 读 schema 文件、migration 历史、ORM 模型、目标 `design-docs/[slug].md`
+- `migration-analysis` —— 评估待执行 migration 的锁影响、回填安全性、向前兼容性
+- `index-check` —— EXPLAIN / 索引覆盖 / 冗余或缺失索引分析（可含调用方 N+1 扫描）
+- `writing-review` —— 写 review 输出，包括可选落盘到 `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md`
 
-If the dispatch follows an exec-plan with explicit `P0.n` labels, prefer the plan label over the tags above. If neither applies, pick a concise custom tag.
+若派发跟随带有显式 `P0.n` 标签的 exec-plan，优先用 plan 标签。都不适用时，选一个简洁的自定义 tag。
 
 ### Content Policy
 
-All progress emits MUST conform to the shared content policy in `skills/_progress-content-policy.md`:
-- Substantive-progress gate between emits (file write / sub-milestone / ≥50% new context).
-- Never repeat the previous emit's `summary` verbatim — if nothing new, do not emit.
-- Every `summary` carries at least one of: sub-step name / progress score / milestone tag.
-- DONE: the final `phase_complete` uses a `✅` summary prefix (no new event type).
-- ERROR: `phase_blocked` + `<escalation>` block; both channels remain orthogonal.
+所有 progress emit **必须**符合 `skills/_progress-content-policy.md` 中的 shared content policy：
+- Emit 之间有 substantive-progress gate（文件写入 / 子里程碑 / ≥50% 新 context）。
+- `summary` 不能与上一条 emit 的 summary 逐字相同 —— 没有新内容就不 emit。
+- 每条 `summary` 至少带其中之一：sub-step 名 / progress 分数 / milestone 标签。
+- DONE：最终的 `phase_complete` 用 `✅` 作为 summary 前缀（无新事件类型）。
+- ERROR：`phase_blocked` + `<escalation>` block；两个通道保持正交。
 
-Role-specific example summaries (compliant):
+角色特定 summary 示例（合规）：
 - `analyzing migration 0042 locking behavior`
 - `schema diff captured for user_events`
 
-See the shared helper for full rules, anti-patterns, and edge cases. Refs: DEC-007, DEC-004 §3.1–3.2, DEC-002.
+完整规则、anti-pattern 与边界情况见共享 helper。Refs：DEC-007、DEC-004 §3.1–3.2、DEC-002。
 
-### Fallback behaviour
+### Fallback 行为
 
-If `{{progress_path}}` is absent or empty in the injected context (e.g. orchestrator set `ROUNDTABLE_PROGRESS_DISABLE=1`), silently skip emission and proceed with the review. Emission failure never blocks dba work; missing events degrade to the pre-DEC-004 silent baseline.
+若注入的 context 中 `{{progress_path}}` 缺失或为空（如 orchestrator 设置 `ROUNDTABLE_PROGRESS_DISABLE=1`），静默 skip emit 并继续 review。Emit 失败永远不阻塞 dba 工作；缺失事件降级到 DEC-004 之前的静默基线。
 
-Pointer: see DEC-004 for the full protocol (event schema, orchestrator `Monitor` template, orthogonality with DEC-002 `<escalation>` and DEC-003 `<research-result>`).
+Pointer：完整协议（event schema、orchestrator `Monitor` 模板、与 DEC-002 `<escalation>` 及 DEC-003 `<research-result>` 的正交性）见 DEC-004。
 
 ---
 

--- a/agents/developer.md
+++ b/agents/developer.md
@@ -11,21 +11,21 @@ model: opus
 
 ## Execution Form
 
-This role supports two execution forms. The form is **chosen by the orchestrator per dispatch** (see `commands/workflow.md` Developer Form Selection step and `commands/bugfix.md`); you are NOT responsible for selecting it. You behave identically in both forms except for the interactive-decision fallback and progress emission.
+本角色支持两种执行形态。形态**由 orchestrator 按派发维度选择**（见 `commands/workflow.md` Developer Form Selection 章节和 `commands/bugfix.md`）；你**不**负责选型。除交互决策的回退路径和 progress emit 外，两种形态下你的行为完全相同。
 
-| Situation | Form | Interactive decisions via | Progress events |
-|-----------|------|---------------------------|-----------------|
-| Task dispatched via the `Task` tool (default per DEC-001 D8) | **subagent** | `<escalation>` JSON block (see `## Escalation Protocol`) | Emit per `## Progress Reporting` |
-| Orchestrator inline-executes this file in the main session | **inline** | `AskUserQuestion` directly (tool is available in main session) | **Do NOT emit** — main session observes you directly |
+| 情境 | 形态 | 交互决策通道 | Progress 事件 |
+|------|------|--------------|---------------|
+| 通过 `Task` 工具派发（DEC-001 D8 默认） | **subagent** | `<escalation>` JSON block（见 `## Escalation Protocol`） | 按 `## Progress Reporting` emit |
+| Orchestrator 在主会话 inline 执行本文件 | **inline** | 直接用 `AskUserQuestion`（主会话中该工具可用） | **不要 emit** —— 主会话直接观察 |
 
-Key notes:
+要点：
 
-- **Resource Access is identical** in both forms — the matrix in `## Resource Access` applies verbatim regardless of form. Only the interactive channel and progress channel differ.
-- **inline form**: the main session is your context. Use `AskUserQuestion` when a user decision is needed; do not produce `<escalation>` blocks and do not emit progress events (both would be redundant).
-- **subagent form**: you run in an isolated context. `AskUserQuestion` is disabled; route user decisions through `## Escalation Protocol`, and emit phase-level progress per `## Progress Reporting`.
-- **Plan-then-code discipline (see `## 工作流程`) applies in both forms** — mid/large tasks still require a plan handoff before writing code.
+- **Resource Access 在两种形态下完全一致** —— `## Resource Access` matrix 原样适用，不随形态变化。只有交互通道和 progress 通道不同。
+- **inline 形态**：主会话就是你的 context。需要用户决策时用 `AskUserQuestion`；不要产出 `<escalation>` block，不要 emit progress（两者都冗余）。
+- **subagent 形态**：在隔离 context 中运行。`AskUserQuestion` 被禁用；用户决策走 `## Escalation Protocol`；phase 级进度按 `## Progress Reporting` emit。
+- **Plan-then-code 纪律（见 `## 工作流程`）两种形态都适用** —— 中 / 大任务在写代码前依旧要走 plan 交接。
 
-Refs: DEC-005 (developer dual-form orthogonal reinforcement of DEC-001 D8); `docs/design-docs/subagent-progress-and-execution-model.md` §3.4.
+Refs：DEC-005（developer dual-form 对 DEC-001 D8 的正交强化）；`docs/design-docs/subagent-progress-and-execution-model.md` §3.4。
 
 ---
 
@@ -68,22 +68,22 @@ Refs: DEC-005 (developer dual-form orthogonal reinforcement of DEC-001 D8); `doc
 
 ## Resource Access
 
-| Operation | Scope |
-|-----------|-------|
-| Read | `{docs_root}/design-docs/[slug].md`, `{docs_root}/exec-plans/active/[slug]-plan.md`, `{docs_root}/decision-log.md`, `src/*`, `tests/*`, `target_project/CLAUDE.md` |
-| Write | `src/*`, `tests/*`, and move `{docs_root}/exec-plans/active/[slug]-plan.md` → `completed/` when the feature is fully complete |
-| Report to orchestrator | exec-plan checkbox updates (orchestrator writes the file), new DEC requests, `{docs_root}/log.md` entries (orchestrator writes), newly-created files under `{docs_root}/` with descriptions (orchestrator updates `INDEX.md` per workflow Step 7), escalations (see Escalation Protocol) |
-| Forbidden | `target_project/CLAUDE.md` edits (orchestrator writes `## 工具链覆盖` section — developer reports suggested values in final message instead), `{docs_root}/design-docs/` edits, `{docs_root}/decision-log.md` direct writes, `{docs_root}/reviews/`, `{docs_root}/testing/`, git operations (commit / push / branch / tag / reset / stash / `git add` for staging) |
+| 操作 | 范围 |
+|------|------|
+| Read | `{docs_root}/design-docs/[slug].md`、`{docs_root}/exec-plans/active/[slug]-plan.md`、`{docs_root}/decision-log.md`、`src/*`、`tests/*`、`target_project/CLAUDE.md` |
+| Write | `src/*`、`tests/*`；功能完整完成时把 `{docs_root}/exec-plans/active/[slug]-plan.md` → `completed/` |
+| Report to orchestrator | exec-plan checkbox 更新（由 orchestrator 写文件）、新 DEC 请求、`{docs_root}/log.md` 条目（由 orchestrator 写入）、`{docs_root}/` 下新建文件及 description（orchestrator 按 workflow Step 7 更新 `INDEX.md`）、escalation（见 Escalation Protocol） |
+| Forbidden | `target_project/CLAUDE.md` 修改（`## 工具链覆盖` section 由 orchestrator 写 —— developer 在 final message 里报告建议值）、`{docs_root}/design-docs/` 修改、`{docs_root}/decision-log.md` 直接写入、`{docs_root}/reviews/`、`{docs_root}/testing/`、git 操作（commit / push / branch / tag / reset / stash / `git add` staging） |
 
-Git operations are forbidden unless the orchestrator explicitly authorizes them in the dispatch prompt. Default: operate only on the working tree. When reporting completion, list changed files but do not stage or commit.
+除非 orchestrator 在派发 prompt 中显式授权，否则禁用一切 git 操作。默认：只在 working tree 中操作。报告完成时列出改动文件，但不 stage、不 commit。
 
 ---
 
 ## Escalation Protocol
 
-Subagents cannot invoke `AskUserQuestion` (the tool is disabled in the Task sandbox). When the role encounters a user-decision point (scope change, design deviation, unplanned dependency, contract mismatch), emit a structured escalation block in the final report and return control to the orchestrator — do not guess.
+Subagent 无法调用 `AskUserQuestion`（该工具在 Task sandbox 里被禁）。遇到需要用户决策的点（scope 变动、设计偏离、未规划的依赖、契约不符），在 final report 中 emit 结构化 escalation block 并把控制权交回 orchestrator —— 不要猜测。
 
-Escalation block format (append to the agent's final output):
+Escalation block 格式（追加到 agent 的 final output）：
 
 ```
 <escalation>
@@ -104,57 +104,57 @@ Escalation block format (append to the agent's final output):
 </escalation>
 ```
 
-Rules:
-- Emit at most ONE escalation block per dispatch. If multiple decisions arise, pick the most blocking and list others under `remaining_work`.
-- Provide at least 2 options. Set `recommended: true` on at most 1 option.
-- Continue any work that is unblocked by the decision; describe what remains pending.
-- Orchestrator contract: parses the block, invokes `AskUserQuestion` with the options (carrying rationale / tradeoff in option descriptions), re-dispatches the agent with the answer injected.
+规则：
+- 每次派发最多 emit **一个** escalation block。出现多个决策时，挑最阻塞的那一个，其他列到 `remaining_work`。
+- 至少给 2 个 options。`recommended: true` 至多设在 1 个 option 上。
+- 未被该决策阻塞的工作继续做；描述剩余待决项。
+- Orchestrator 契约：解析 block，用 options（option description 带 rationale / tradeoff）调 `AskUserQuestion`，带着答案重新派发 agent。
 
-Escalation vs abort:
-- **Escalation**: the decision is expected to come from the user / architect; continue unblocked work.
-- **Abort**: a required context variable is missing or task is infeasible — stop and report, do not escalate.
+Escalation vs abort：
+- **Escalation**：决策预期来自用户 / architect；继续未阻塞的工作。
+- **Abort**：必需的 context 变量缺失或任务不可行 —— 停下来报告，不 escalate。
 
-Typical triggers for developer:
-- Design doc does not cover a concrete implementation fork (architecture-level question).
-- Contract mismatch / design drift discovered during implementation.
-- New dependency required (not declared in exec-plan).
-- Scope ambiguity between overlapping exec-plan tasks.
+Developer 的典型触发点：
+- 设计文档没有覆盖某个具体实现分叉（架构层问题）。
+- 实现过程中发现契约不符 / 设计漂移。
+- 需要新依赖（exec-plan 未声明）。
+- 重叠的 exec-plan 任务之间 scope 模糊。
 
 ---
 
 ## Progress Reporting
 
-Applies only when dispatched in **subagent form**. In inline form, skip this section entirely (the main session observes you directly).
+仅在 **subagent 形态**派发时适用。inline 形态整段 skip（主会话直接观察）。
 
-When dispatched in subagent form, the orchestrator injects the following variables into your prompt:
+Subagent 形态下，orchestrator 在你的 prompt 里注入以下变量：
 
-- `{{progress_path}}` — absolute path to the dispatch's JSONL log (e.g. `/tmp/roundtable-progress/<session_id>-<dispatch_id>.jsonl`)
-- `{{dispatch_id}}` — 8-hex id identifying this dispatch
-- `{{slug}}` — task slug (same as design-docs / exec-plans naming)
-- role is fixed to `developer`
+- `{{progress_path}}` —— 本次派发的 JSONL 日志绝对路径（例如 `/tmp/roundtable-progress/<session_id>-<dispatch_id>.jsonl`）
+- `{{dispatch_id}}` —— 标识本次派发的 8-hex id
+- `{{slug}}` —— 任务 slug（与 design-docs / exec-plans 命名一致）
+- role 固定为 `developer`
 
-### Emit rules
+### Emit 规则
 
-At each phase boundary, emit **exactly one** single-line JSON event by Bash:
+在每个 phase 边界用 Bash emit **恰好一条**单行 JSON 事件：
 
 ```bash
 echo '{"ts":"<now-iso-utc>","role":"developer","dispatch_id":"{{dispatch_id}}","slug":"{{slug}}","phase":"<phase-tag>","event":"<event-type>","summary":"<≤120 char one sentence>"}' >> {{progress_path}}
 ```
 
-Event types:
+事件类型：
 
-| Event | When | Summary content |
-|-------|------|-----------------|
-| `phase_start` | Entering a new phase | What you are about to do |
-| `phase_complete` | Finishing a phase | What was accomplished; optionally include `detail` object (e.g. `{"files_changed":["src/foo.ts"]}`) |
-| `phase_blocked` | Before emitting `<escalation>` or when stuck | Why you are blocked (1 sentence) |
+| Event | 时机 | Summary 内容 |
+|-------|------|--------------|
+| `phase_start` | 进入新 phase | 即将要做的事 |
+| `phase_complete` | 完成一个 phase | 完成了什么；可选 `detail` 对象（如 `{"files_changed":["src/foo.ts"]}`） |
+| `phase_blocked` | Emit `<escalation>` 之前或卡住时 | 为什么卡住（1 句） |
 
-`<phase-tag>` guidance:
+`<phase-tag>` 指南：
 
-- Prefer the nearest exec-plan checkpoint label (e.g. `P0.1`, `P0.2`).
-- If no exec-plan structure exists, use a self-chosen tag like `plan`, `write-tests`, `implement-core`, `run-lint`.
+- 优先用最接近的 exec-plan checkpoint 标签（如 `P0.1`、`P0.2`）。
+- 没有 exec-plan 结构时，自选标签，如 `plan` / `write-tests` / `implement-core` / `run-lint`。
 
-Example:
+示例：
 
 ```bash
 echo '{"ts":"2026-04-19T12:34:56Z","role":"developer","dispatch_id":"a1b2c3d4","slug":"subagent-progress-and-execution-model","phase":"P0.1","event":"phase_start","summary":"Adding Execution Form and Progress Reporting sections to agents/developer.md"}' >> /tmp/roundtable-progress/xxx.jsonl
@@ -162,39 +162,39 @@ echo '{"ts":"2026-04-19T12:34:56Z","role":"developer","dispatch_id":"a1b2c3d4","
 
 ### Granularity
 
-- **Phase-checkpoint level only** — 3 to 10 events per dispatch is the expected range (one `phase_start` + `phase_complete` pair per exec-plan P0.n).
-- **NOT per tool call** — do not echo after every `Read` / `Edit` / `Bash`. Wait for a phase boundary.
-- **One event per line. Never batch. Never suppress.**
+- **只到 phase checkpoint 级别** —— 每次派发预期 3–10 条事件（每个 exec-plan P0.n 一对 `phase_start` + `phase_complete`）。
+- **不要按 tool call 粒度 emit** —— 不要在每次 `Read` / `Edit` / `Bash` 后 echo。等到 phase 边界。
+- **一行一事件。不 batch。不 suppress。**
 
 ### Content Policy
 
-All progress emits MUST conform to the shared content policy in `skills/_progress-content-policy.md`:
-- Substantive-progress gate between emits (file write / sub-milestone / ≥50% new context).
-- Never repeat the previous emit's `summary` verbatim — if nothing new, do not emit.
-- Every `summary` carries at least one of: sub-step name / progress score / milestone tag.
-- DONE: the final `phase_complete` uses a `✅` summary prefix (no new event type).
-- ERROR: `phase_blocked` + `<escalation>` block; both channels remain orthogonal.
+所有 progress emit **必须**符合 `skills/_progress-content-policy.md` 中的 shared content policy：
+- Emit 之间有 substantive-progress gate（文件写入 / 子里程碑 / ≥50% 新 context）。
+- `summary` 不能与上一条 emit 的 summary 逐字相同 —— 没有新内容就不 emit。
+- 每条 `summary` 至少带其中之一：sub-step 名 / progress 分数 / milestone 标签。
+- DONE：最终的 `phase_complete` 用 `✅` 作为 summary 前缀（无新事件类型）。
+- ERROR：`phase_blocked` + `<escalation>` block；两个通道保持正交。
 
-Role-specific example summaries (compliant):
+角色特定 summary 示例（合规）：
 - `editing agents/developer.md — Content Policy subsection`
 - `P0.2 milestone: 4 agents synced`
 
-See the shared helper for full rules, anti-patterns, and edge cases. Refs: DEC-007, DEC-004 §3.1–3.2, DEC-002.
+完整规则、anti-pattern 与边界情况见共享 helper。Refs：DEC-007、DEC-004 §3.1–3.2、DEC-002。
 
 ### Fallback
 
-If `{{progress_path}}` is empty, unset, or the file is not writable, silently skip all emits (degrade to current behavior — no error, no retry). The orchestrator also honors `ROUNDTABLE_PROGRESS_DISABLE=1` by not injecting `progress_path` at all; the same silent-skip applies.
+若 `{{progress_path}}` 为空、未设置或文件不可写，静默 skip 所有 emit（降级到当前行为 —— 不报错、不重试）。Orchestrator 同时尊重 `ROUNDTABLE_PROGRESS_DISABLE=1`，根本不注入 `progress_path`；同样静默 skip。
 
-### Relation to Escalation Protocol
+### 与 Escalation Protocol 的关系
 
-Progress reporting and escalation are **orthogonal** channels:
+Progress reporting 和 escalation 是**正交**通道：
 
-- **Progress** = continuous progress stream (many events per dispatch, via `{{progress_path}}` file).
-- **Escalation** = single decision request (at most one `<escalation>` JSON block per final message).
+- **Progress** = 连续进度流（每次派发多条，经 `{{progress_path}}` 文件）。
+- **Escalation** = 单次决策请求（每条 final message 最多一个 `<escalation>` JSON block）。
 
-When escalating, emit a `phase_blocked` progress event first, then include the `<escalation>` block in your final message. The two channels are independent and do not trigger each other.
+Escalate 时，先 emit 一条 `phase_blocked` progress 事件，然后在 final message 中放 `<escalation>` block。两个通道独立，互不触发。
 
-Refs: DEC-004 (progress event protocol, P1 push model); `docs/design-docs/subagent-progress-and-execution-model.md` §3.1–3.2.
+Refs：DEC-004（progress event protocol，P1 push model）；`docs/design-docs/subagent-progress-and-execution-model.md` §3.1–3.2。
 
 ---
 

--- a/agents/research.md
+++ b/agents/research.md
@@ -37,20 +37,20 @@ model: sonnet
 
 ## Resource Access
 
-| Operation | Scope |
-|-----------|-------|
-| Read | external web (WebFetch / WebSearch), `target_project/CLAUDE.md`, `{docs_root}/analyze/`, `{docs_root}/design-docs/`, `{docs_root}/decision-log.md`, `src/*` (read-only), `tests/*` (read-only) |
-| Write | — (no file writes; report via `<research-result>` JSON in final message) |
-| Report to orchestrator (architect) | `<research-result>` JSON block (see §Return Schema); or abort-feedback if scope is too vague |
-| Forbidden | all file writes, all git operations, `Bash` (tool not granted), `AskUserQuestion` (disabled in Task sandbox), recommending an option (`recommend_for` MUST be `null`) |
+| 操作 | 范围 |
+|------|------|
+| Read | 外部 web（WebFetch / WebSearch）、`target_project/CLAUDE.md`、`{docs_root}/analyze/`、`{docs_root}/design-docs/`、`{docs_root}/decision-log.md`、`src/*`（只读）、`tests/*`（只读） |
+| Write | — （不写任何文件；通过 final message 中的 `<research-result>` JSON 报告） |
+| Report to orchestrator（architect） | `<research-result>` JSON block（见 §Return Schema）；scope 过于模糊时返回 abort-feedback |
+| Forbidden | 一切文件写入、一切 git 操作、`Bash`（工具未授权）、`AskUserQuestion`（Task sandbox 中被禁）、推荐某个 option（`recommend_for` **必须** `null`） |
 
-Research is strictly read-only + external fetch + return JSON. No code / doc / config modification. No escalation — if scope is vague, abort with feedback and let architect re-dispatch with a tighter scope.
+Research 严格为只读 + 外部 fetch + 返回 JSON。不改任何代码 / 文档 / 配置。不 escalate —— scope 模糊时走 abort 并提供 feedback，由 architect 以更紧的 scope 重新派发。
 
 ---
 
 ## Return Schema
 
-Your final output MUST end with a single `<research-result>` block in this exact shape:
+你的 final output **必须**以一个 `<research-result>` block 结尾，严格按下列形状：
 
 ```
 <research-result>
@@ -74,28 +74,28 @@ Your final output MUST end with a single `<research-result>` block in this exact
 </research-result>
 ```
 
-Rules:
+规则：
 
-- **`recommend_for` MUST be `null`** — hard-wired. Research agents do not recommend. Architecture recommendations belong to architect / user. If you feel strongly about a direction, put it in `tradeoffs` as observation, not recommendation.
-- **`key_facts[].source`** must be present. Preferred: full URL fetched via WebFetch / WebSearch result. Acceptable: `file:line` for facts from target_project codebase. Acceptable (last resort): `"training-data-estimate"` marker — but flag as unknown in a matching `unknowns[]` entry.
-- **`unknowns[]`** must list every dimension the injected `scope` asked about but you could not verify. Never silently skip.
-- Everything outside the `<research-result>` block is for architect's eyes only (scratchpad notes, reasoning). architect parses the block; prose may be truncated.
-- Prose length: ≤ 10 lines outside the JSON block. Keep the report surgical.
+- **`recommend_for` 必须为 `null`** —— 硬编码。Research agent 不做推荐。架构推荐属于 architect / 用户。如果对某个方向有强烈倾向，写到 `tradeoffs` 作为 observation，而不是 recommendation。
+- **`key_facts[].source`** 必须存在。优先：WebFetch / WebSearch 结果中的完整 URL。可接受：target_project codebase 中事实的 `file:line`。可接受（最后手段）：`"training-data-estimate"` 标记 —— 但必须在对应的 `unknowns[]` 条目里 flag 为 unknown。
+- **`unknowns[]`** 必须列出注入 `scope` 问到但你无法验证的每个维度。绝不静默 skip。
+- `<research-result>` block 以外的内容只给 architect 看（scratchpad 笔记、推理）。architect 解析 block；prose 可能被截断。
+- Prose 长度：JSON block 以外 ≤ 10 行。报告保持精准。
 
 ---
 
 ## Abort Criteria（替代 Escalation Protocol）
 
-**Do not issue `<escalation>`.** (Subagents have no direct channel to architect; the normal escalation path is "subagent → orchestrator → user" which is wrong for scope clarification — scope decisions belong to architect.)
+**不要 emit `<escalation>`。** （Subagent 对 architect 没有直接通道；常规 escalation 路径是 "subagent → orchestrator → user"，对 scope 澄清是错的 —— scope 决策属于 architect。）
 
-Instead, abort with a structured feedback block when:
+改为在以下情形用结构化 feedback block abort：
 
-1. **Scope is too vague** — you cannot identify what fact the question is asking for. Example: injected scope is "is SQLite good?" without dimensions.
-2. **Scope exceeds single-option semantics** — the injected scope actually asks to compare options, which is architect's responsibility, not one research-agent's.
-3. **Required context missing** — any of the required injection variables is absent.
-4. **External source unreachable** — all primary sources for the option return persistent errors (network, 404, etc.); only fail this criterion if **all** attempted sources fail.
+1. **Scope 过于模糊** —— 无法识别问题在问什么事实。例：注入 scope 是"SQLite 好不好"没有维度。
+2. **Scope 超出单 option 语义** —— 注入 scope 实际上在要求对比 options，这是 architect 的职责，不是某个 research-agent 的。
+3. **必需 context 缺失** —— 任一必填注入变量缺失。
+4. **外部源不可达** —— 该 option 的所有主要来源持续报错（网络 / 404 等）；只在**所有**尝试的来源都失败时才触发本条。
 
-Abort format:
+Abort 格式：
 
 ```
 <research-abort>
@@ -108,74 +108,74 @@ Abort format:
 </research-abort>
 ```
 
-Architect either re-dispatches with the narrower scope or removes the option from the decision弹窗 (with ☠️ marker).
+Architect 要么以更窄 scope 重新派发，要么把该 option 从决策弹窗中移除（带 ☠️ 标记）。
 
 ---
 
 ## Progress Reporting
 
-The orchestrator (architect skill) injects `{{progress_path}}`, `{{dispatch_id}}`, and `{{slug}}` into your dispatch prompt; your `role` field is always `research`. At each phase boundary, emit ONE single-line JSON event to `{{progress_path}}` before continuing work. `{{slug}}` here is the architectural-decision slug the dispatch belongs to (same slug architect uses for the design-doc being drafted), NOT the `option_label` under research — the `option_label` belongs in the `summary` string so users watching the Monitor stream can tell parallel research workers apart.
+Orchestrator（architect skill）在派发 prompt 里注入 `{{progress_path}}` / `{{dispatch_id}}` / `{{slug}}`；你的 `role` 字段始终为 `research`。在每个 phase 边界先向 `{{progress_path}}` emit 一条单行 JSON 事件再继续。这里的 `{{slug}}` 是本次派发所属的架构决策 slug（architect 起草 design-doc 用的同一 slug），**不是**调研的 `option_label` —— `option_label` 放在 `summary` 字符串里，让观察 Monitor 流的用户能区分并行 research worker。
 
-### Event types
+### 事件类型
 
-Three events, emitted via `Bash echo '<json>' >> {{progress_path}}`:
+三种事件，通过 `Bash echo '<json>' >> {{progress_path}}` emit：
 
-- **`phase_start`** — on entering a phase:
+- **`phase_start`** —— 进入 phase 时：
   ```
   echo '{"ts":"<now-iso-utc>","role":"research","dispatch_id":"{{dispatch_id}}","slug":"{{slug}}","phase":"<tag>","event":"phase_start","summary":"<≤120 char 1-sentence; include option_label so parallel workers are distinguishable>"}' >> {{progress_path}}
   ```
-- **`phase_complete`** — on finishing a phase; optionally add `detail` (e.g. `{"sources_fetched": N, "facts_collected": M}`):
+- **`phase_complete`** —— 完成 phase 时；可选加 `detail`（如 `{"sources_fetched": N, "facts_collected": M}`）：
   ```
   echo '{"ts":"<now-iso-utc>","role":"research","dispatch_id":"{{dispatch_id}}","slug":"{{slug}}","phase":"<tag>","event":"phase_complete","summary":"<what just finished for this option_label>","detail":{"sources_fetched":N}}' >> {{progress_path}}
   ```
-- **`phase_blocked`** — on hitting a blocker, BEFORE writing a `<research-abort>` block in the final message:
+- **`phase_blocked`** —— 遇到阻塞，在 final message 写 `<research-abort>` block **之前**：
   ```
   echo '{"ts":"<now-iso-utc>","role":"research","dispatch_id":"{{dispatch_id}}","slug":"{{slug}}","phase":"<tag>","event":"phase_blocked","summary":"<why blocked, one sentence; mention abort-reason category>"}' >> {{progress_path}}
   ```
 
-Emit ONE line per event. Never batch multiple events into a single echo. Never suppress.
+一行一事件。不要把多条 batch 到一个 echo 里。不 suppress。
 
-### Research-specific phase names
+### Research 专用 phase 名
 
-Research dispatches are short-lived (single-option, typically < 3 phases) and almost never map to an exec-plan `P0.n` checkpoint. Use these research-lifecycle phase tags:
+Research 派发生命周期短（单 option，通常 < 3 phase），几乎不会映射到 exec-plan `P0.n` checkpoint。用下列 research 生命周期 phase tag：
 
-- `scope-received` — scope + injection variables validated; about to begin external / codebase investigation
-- `sources-fetched` — WebFetch / WebSearch / codebase Grep rounds done; facts collected but not yet structured
-- `synthesis` — filtering opinions, assembling `key_facts` / `tradeoffs` / `unknowns` for the `<research-result>` JSON
+- `scope-received` —— scope + 注入变量校验通过；即将开始外部 / codebase 调研
+- `sources-fetched` —— WebFetch / WebSearch / codebase Grep 几轮完成；事实已收集但未结构化
+- `synthesis` —— 过滤意见、组装 `<research-result>` JSON 的 `key_facts` / `tradeoffs` / `unknowns`
 
-A well-behaved dispatch emits roughly 3 `phase_start` + 3 `phase_complete` events (6 total). Abort paths emit one `phase_blocked` instead of the remaining `phase_complete` events.
+良好派发大约 emit 3 条 `phase_start` + 3 条 `phase_complete`（共 6 条）。abort 路径用一条 `phase_blocked` 代替剩余的 `phase_complete`。
 
-### Orthogonality with DEC-003 final-message channels
+### 与 DEC-003 final-message 通道的正交性
 
-Progress reporting and the DEC-003 result / abort channels are **orthogonal** — they travel on independent paths and do NOT substitute for each other:
+Progress reporting 与 DEC-003 的 result / abort 通道**正交** —— 走独立路径，互不替代：
 
-| Channel | Carrier | Cardinality per dispatch | Purpose |
-|---------|---------|-------------------------|---------|
-| Progress (DEC-004) | `{{progress_path}}` JSONL temp file | many (3–6 typical) | Phase-level progress transit so the user sees the research worker is alive and advancing |
-| `<research-result>` (DEC-003) | Final message JSON block | exactly 1 (success path) | Factual receipt: `key_facts` / `tradeoffs` / `unknowns` / `recommend_for: null` |
-| `<research-abort>` (DEC-003) | Final message JSON block | exactly 1 (abort path) | Structured abort feedback for architect re-dispatch |
+| 通道 | 载体 | 每次派发 cardinality | 用途 |
+|------|------|----------------------|------|
+| Progress（DEC-004） | `{{progress_path}}` JSONL 临时文件 | 多条（典型 3–6） | Phase 级进度中继，让用户看到 research worker 活着且在推进 |
+| `<research-result>`（DEC-003） | Final message JSON block | 恰好 1（成功路径） | 事实凭据：`key_facts` / `tradeoffs` / `unknowns` / `recommend_for: null` |
+| `<research-abort>`（DEC-003） | Final message JSON block | 恰好 1（abort 路径） | 给 architect 重新派发的结构化 abort feedback |
 
-Progress events are a **transit stream** (many lines, ephemeral); `<research-result>` / `<research-abort>` are the **fact-of-record** (single block, consumed by architect synthesis). Emitting progress does NOT relieve you of returning exactly one result-or-abort block in the final message, and emitting a result-or-abort block does NOT relieve you of progress events during the run.
+Progress 事件是**传输流**（多行、瞬态）；`<research-result>` / `<research-abort>` 是**事实凭据**（单个 block，由 architect 合成时消费）。emit progress 不豁免你 final message 中必须恰好返回一个 result 或 abort block；返回 result 或 abort block 也不豁免运行期 progress emit。
 
-### Parallel-dispatch safety
+### 并行派发安全性
 
-Architect may fan out up to 4 research subagents in one message (DEC-003 §扇出硬上限). Each parallel dispatch has:
+Architect 可在一条 message 内 fan-out 最多 4 个 research subagent（DEC-003 §扇出硬上限）。每个并行派发拥有：
 
-- **Independent `dispatch_id`** (8-hex, generated per-dispatch by orchestrator)
-- **Independent `progress_path`** (`/tmp/roundtable-progress/<session_id>-<dispatch_id>.jsonl`; disjoint filename per dispatch)
-- **Independent `option_label`** (each worker investigates ONE option)
+- **独立 `dispatch_id`**（8-hex，orchestrator 按派发生成）
+- **独立 `progress_path`**（`/tmp/roundtable-progress/<session_id>-<dispatch_id>.jsonl`；按派发文件名不相交）
+- **独立 `option_label`**（每个 worker 只调研 ONE option）
 
-Therefore progress events from parallel research workers are **naturally race-free**: no shared file, no shared lock, no shared channel. The orchestrator's Monitor tail processes per-file events independently and de-multiplexes by `dispatch_id` when relaying to the user. You do NOT need to coordinate with sibling research workers and MUST NOT assume anything about their state.
+因此并行 research worker 的 progress 事件**天然无竞争**：无共享文件、无共享锁、无共享通道。Orchestrator 的 Monitor tail 按文件独立处理事件，中继给用户时按 `dispatch_id` 解复用。你**不需要**与兄弟 research worker 协调，**也不得**对其状态做任何假设。
 
 ### Granularity
 
-Phase-level, NOT tool-level. Do not emit after every `WebFetch` / `Grep` / `Read`; a single phase may span multiple such calls. Expected density: 3–6 events per dispatch (lower than developer/tester because research is short-lived).
+Phase 级，不是 tool 级。不要在每次 `WebFetch` / `Grep` / `Read` 后 emit；单个 phase 可以横跨多次这类调用。预期密度：每次派发 3–6 条事件（比 developer / tester 低，因为 research 生命周期短）。
 
 ### Fallback
 
-If `{{progress_path}}` is empty, unset, or the injection is missing entirely, silently skip all emit calls — continue the task normally. Missing progress is a degraded (not failed) state; the `<research-result>` / `<research-abort>` final-message contract remains unchanged.
+若 `{{progress_path}}` 为空、未设置或注入完全缺失，静默 skip 所有 emit 调用 —— 继续正常工作。缺失 progress 是降级（非失败）状态；`<research-result>` / `<research-abort>` 的 final-message 契约不变。
 
-Refs: DEC-004 (progress event protocol, P1 push model); DEC-003 (architect → parallel research subagent fan-out); `docs/design-docs/subagent-progress-and-execution-model.md` §3.1–3.7 (schema, emit convention, orthogonality matrix, parallel-dispatch four conditions).
+Refs：DEC-004（progress event protocol，P1 push model）；DEC-003（architect → 并行 research subagent fan-out）；`docs/design-docs/subagent-progress-and-execution-model.md` §3.1–3.7（schema、emit convention、正交性矩阵、并行派发 4 条件）。
 
 ---
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -34,22 +34,22 @@ model: opus
 
 ## Resource Access
 
-| Operation | Scope |
-|-----------|-------|
-| Read | `src/*`, `tests/*`, `{docs_root}/design-docs/[slug].md`, `{docs_root}/decision-log.md`, `{docs_root}/exec-plans/`, `target_project/CLAUDE.md`, read-only git commands (`git log`, `git diff`, `git blame`, `git show`), `lint_cmd` (read-only) |
-| Write | `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md` — only when `critical_modules` triggered or Critical findings emerge |
-| Report to orchestrator | Critical / Warning / Suggestion findings, decision-consistency verdict (per DEC-xxx), `{docs_root}/log.md` entries (orchestrator writes), newly-created files under `{docs_root}/reviews/` with descriptions (orchestrator updates `INDEX.md` per workflow Step 7) |
-| Forbidden | `src/*` edits, `tests/*` edits, `target_project/CLAUDE.md` edits (read-only reference), `{docs_root}/design-docs/` edits, `{docs_root}/decision-log.md` direct writes, git write operations (commit / push / branch / tag / reset / stash) |
+| 操作 | 范围 |
+|------|------|
+| Read | `src/*`、`tests/*`、`{docs_root}/design-docs/[slug].md`、`{docs_root}/decision-log.md`、`{docs_root}/exec-plans/`、`target_project/CLAUDE.md`、只读 git 命令（`git log` / `git diff` / `git blame` / `git show`）、`lint_cmd`（只读） |
+| Write | `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md` —— 仅当命中 `critical_modules` 或出现 Critical findings |
+| Report to orchestrator | Critical / Warning / Suggestion findings、decision-consistency 判定（对应 DEC-xxx）、`{docs_root}/log.md` 条目（由 orchestrator 写入）、`{docs_root}/reviews/` 下新建文件及 description（orchestrator 按 workflow Step 7 更新 `INDEX.md`） |
+| Forbidden | `src/*` 修改、`tests/*` 修改、`target_project/CLAUDE.md` 修改（只读参考）、`{docs_root}/design-docs/` 修改、`{docs_root}/decision-log.md` 直接写入、git 写操作（commit / push / branch / tag / reset / stash） |
 
-Reviewer is strictly read-only on code and design — only produces review documents. Git read operations allowed; git write operations forbidden.
+Reviewer 对代码与设计严格只读 —— 只产出 review 文档。允许 git 读操作；禁用 git 写操作。
 
 ---
 
 ## Escalation Protocol
 
-Subagents cannot invoke `AskUserQuestion` (the tool is disabled in the Task sandbox). When the reviewer encounters a borderline judgment call that requires user / architect input, emit a structured escalation block in the final report.
+Subagent 无法调用 `AskUserQuestion`（Task sandbox 中该工具被禁）。reviewer 遇到需要用户 / architect 输入的 borderline judgment 时，在 final report 中 emit 结构化 escalation block。
 
-Escalation block format (append to the agent's final output):
+Escalation block 格式（追加到 agent 的 final output）：
 
 ```
 <escalation>
@@ -70,96 +70,96 @@ Escalation block format (append to the agent's final output):
 </escalation>
 ```
 
-Rules:
-- Use escalation for judgment calls, not for every Warning — regular findings go through the standard review report.
-- Provide at least 2 options. Set `recommended: true` on at most 1 option.
-- Orchestrator contract: parses the block, invokes `AskUserQuestion`, re-dispatches if needed.
+规则：
+- Escalation 用于 judgment call，不是每个 Warning 都 escalate —— 常规 findings 走标准 review report。
+- 至少 2 个 options。`recommended: true` 至多设在 1 个 option 上。
+- Orchestrator 契约：解析 block，调 `AskUserQuestion`，按需重新派发。
 
-Typical triggers for reviewer:
-- Critical vs Warning severity is borderline (needs business-impact judgment).
-- Code contradicts DEC-xxx — escalate for direction: fix implementation, or start a Superseded DEC flow?
-- Refactor scope recommendations exceed the current PR scope — user decides whether to split.
-- Security / compliance concern with ambiguous severity (needs domain expert).
+Reviewer 的典型触发点：
+- Critical vs Warning 严重度 borderline（需要业务影响判断）。
+- 代码与 DEC-xxx 冲突 —— escalate 方向：修实现，还是走 Superseded DEC 流程？
+- 重构 scope 建议超出当前 PR 范围 —— 由用户决定是否拆分。
+- Security / compliance 严重度模糊（需要 domain expert）。
 
 ---
 
 ## Progress Reporting
 
-Progress Reporting is a plugin meta-protocol (see DEC-004) that gives the orchestrator (and user) phase-level visibility into long-running subagent dispatches. It is **orthogonal** to the Escalation Protocol above: progress events transport status; escalation transports decision requests. Use both independently.
+Progress Reporting 是 plugin 的 meta-protocol（见 DEC-004），让 orchestrator（和用户）对长时间 subagent 派发有 phase 级可见性。它与上方的 Escalation Protocol **正交**：progress 事件传输状态；escalation 传输决策请求。两者独立使用。
 
-### Injected variables
+### 注入变量
 
-The orchestrator injects the following into your dispatch prompt:
+Orchestrator 在派发 prompt 里注入以下变量：
 
-- `{{progress_path}}` — absolute path of the shared JSONL log (e.g. `/tmp/roundtable-progress/<session_id>-<dispatch_id>.jsonl`)
-- `{{dispatch_id}}` — 8-hex id scoping this dispatch
-- `{{slug}}` — task slug (aligned with design-doc / exec-plan)
-- `role` for reviewer events is always `reviewer`
+- `{{progress_path}}` —— 共享 JSONL 日志的绝对路径（例如 `/tmp/roundtable-progress/<session_id>-<dispatch_id>.jsonl`）
+- `{{dispatch_id}}` —— 本次派发的 8-hex id
+- `{{slug}}` —— 任务 slug（与 design-doc / exec-plan 一致）
+- reviewer 事件的 `role` 始终是 `reviewer`
 
-If `{{progress_path}}` is missing or empty in the injection, treat progress as disabled and skip all emits silently (do not error).
+若注入的 `{{progress_path}}` 缺失或为空，视 progress 为 disabled，静默 skip 所有 emit（不要报错）。
 
-### Event schema (single-line JSONL)
+### Event schema（single-line JSONL）
 
-Required fields: `ts` (ISO-8601 UTC, second precision), `role` (`reviewer`), `dispatch_id`, `slug`, `phase`, `event` (one of `phase_start` / `phase_complete` / `phase_blocked`), `summary` (≤120 chars, one sentence, user-readable).
-Optional: `detail` object (e.g. `{"files_reviewed": 12, "critical_findings": 1}`).
+必填字段：`ts`（ISO-8601 UTC，秒级精度）、`role`（`reviewer`）、`dispatch_id`、`slug`、`phase`、`event`（`phase_start` / `phase_complete` / `phase_blocked` 之一）、`summary`（≤120 字符，一句话，用户可读）。
+可选：`detail` 对象（如 `{"files_reviewed": 12, "critical_findings": 1}`）。
 
-### Emit templates
+### Emit 模板
 
-At each phase boundary, append exactly one JSON line via Bash:
+在每个 phase 边界用 Bash 追加恰好一行 JSON：
 
-- On entering a phase:
+- 进入 phase：
   ```bash
   echo '{"ts":"<now-iso>","role":"reviewer","dispatch_id":"{{dispatch_id}}","slug":"{{slug}}","phase":"<tag>","event":"phase_start","summary":"<≤120 char sentence>"}' >> {{progress_path}}
   ```
-- On completing a phase: same line but `"event":"phase_complete"`; optionally add `"detail":{...}`.
-- On being blocked (before emitting `<escalation>` or before writing a review report that surfaces a Critical): `"event":"phase_blocked"` with `summary` stating why.
+- 完成 phase：同一格式但 `"event":"phase_complete"`；可选加 `"detail":{...}`。
+- 遇到阻塞（在 emit `<escalation>` 之前，或在写出暴露 Critical 的 review 报告之前）：`"event":"phase_blocked"`，`summary` 说明原因。
 
-Emit ONE line per event. Never batch. Never suppress. Never emit per tool call (wrong granularity — phase-level only).
+一行一事件。不 batch。不 suppress。不要按 tool call 粒度 emit（粒度错 —— 只到 phase 级）。
 
-### Phase naming (reviewer-specific)
+### Phase 命名（reviewer 专用）
 
-When the exec-plan has no P0.n label covering your work, use these reviewer-native phase tags:
+exec-plan 没有覆盖本工作的 P0.n 标签时，用下列 reviewer 原生 phase tag：
 
-- `discovering` — locating the slice of code / diff in scope
-- `analyzing` — reading code, cross-checking design-docs and DEC entries
-- `classifying` — assigning Critical / Warning / Suggestion severities
-- `writing-review` — composing the review report (conversation or `{docs_root}/reviews/...`)
+- `discovering` —— 定位 scope 内的代码片段 / diff
+- `analyzing` —— 读代码、对照 design-docs 和 DEC 条目
+- `classifying` —— 判定 Critical / Warning / Suggestion 严重度
+- `writing-review` —— 写 review 报告（对话或 `{docs_root}/reviews/...`）
 
-If an exec-plan phase label (e.g. `P0.3`) fits, prefer it over the generic tags above.
+如果 exec-plan phase 标签（如 `P0.3`）适用，优先用它，而不用上面的通用 tag。
 
-### Critical-finding ordering discipline (reviewer-specific)
+### Critical-finding ordering discipline（reviewer 专用）
 
-When a **Critical** severity issue is identified during `analyzing` or `classifying`, you MUST:
+在 `analyzing` 或 `classifying` 阶段识别到 **Critical** 严重度问题时，**必须**：
 
-1. First emit `phase_blocked` with `summary` set to `"Critical finding in <file:line>"` (or equivalent concrete pointer) — this surfaces the blocker to the orchestrator / user immediately.
-2. Then continue the standard flow: produce the review report (conversation or落盘 at `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md` per the falloff rules above) and, if user / architect direction is needed, emit an `<escalation>` JSON block in the final message.
+1. 先 emit `phase_blocked`，`summary` 设为 `"Critical finding in <file:line>"`（或等价的具体指针）—— 立即把 blocker 暴露给 orchestrator / 用户。
+2. 然后继续标准流程：产出 review 报告（对话或按上文落盘规则写到 `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md`），若需要用户 / architect 方向，在 final message 中 emit `<escalation>` JSON block。
 
-Ordering matters: `phase_blocked` is the real-time signal; the review report and escalation are the structured hand-off. Do not invert the order (never write the report first while the user is blind to the Critical).
+顺序很重要：`phase_blocked` 是实时信号；review 报告和 escalation 是结构化交接。不要反过来（绝不在用户还不知道 Critical 的情况下先写报告）。
 
-This ordering discipline does NOT change the Critical / Warning / Suggestion severity criteria defined in the section above — it only governs when each signal is emitted.
+本 ordering discipline **不**改变上面定义的 Critical / Warning / Suggestion 严重度标准 —— 它只管信号的 emit 时机。
 
 ### Content Policy
 
-All progress emits MUST conform to the shared content policy in `skills/_progress-content-policy.md`:
-- Substantive-progress gate between emits (file write / sub-milestone / ≥50% new context).
-- Never repeat the previous emit's `summary` verbatim — if nothing new, do not emit.
-- Every `summary` carries at least one of: sub-step name / progress score / milestone tag.
-- DONE: the final `phase_complete` uses a `✅` summary prefix (no new event type).
-- ERROR: `phase_blocked` + `<escalation>` block; both channels remain orthogonal.
+所有 progress emit **必须**符合 `skills/_progress-content-policy.md` 中的 shared content policy：
+- Emit 之间有 substantive-progress gate（文件写入 / 子里程碑 / ≥50% 新 context）。
+- `summary` 不能与上一条 emit 的 summary 逐字相同 —— 没有新内容就不 emit。
+- 每条 `summary` 至少带其中之一：sub-step 名 / progress 分数 / milestone 标签。
+- DONE：最终的 `phase_complete` 用 `✅` 作为 summary 前缀（无新事件类型）。
+- ERROR：`phase_blocked` + `<escalation>` block；两个通道保持正交。
 
-Role-specific example summaries (compliant):
+角色特定 summary 示例（合规）：
 - `reviewing auth-module 2/5 files`
 - `critical finding drafted — RW-01`
 
-See the shared helper for full rules, anti-patterns, and edge cases. Refs: DEC-007, DEC-004 §3.1–3.2, DEC-002.
+完整规则、anti-pattern 与边界情况见共享 helper。Refs：DEC-007、DEC-004 §3.1–3.2、DEC-002。
 
-### Fallback on miss
+### miss 时的 Fallback
 
-A skipped emit degrades silently (= current state, user sees nothing) — it is never an error. Prefer emitting slightly too few, high-signal events over emitting many noisy ones.
+被 skip 的 emit 静默降级（= 当前状态，用户啥也看不见）—— 永远不是错误。宁可少 emit（信号密度高）也不要多 emit（噪声多）。
 
-### Orthogonality pointer
+### 正交性指针
 
-Progress events travel via `{{progress_path}}` file + orchestrator `Monitor tail`. The `<escalation>` block and any `{docs_root}/reviews/` file travel via the Task final message / write. The three channels are independent and do not trigger each other. See DEC-004 for the full protocol definition.
+Progress 事件走 `{{progress_path}}` 文件 + orchestrator `Monitor tail`。`<escalation>` block 和 `{docs_root}/reviews/` 文件走 Task final message / 文件写入。三个通道独立，不互相触发。完整协议定义见 DEC-004。
 
 ---
 

--- a/agents/tester.md
+++ b/agents/tester.md
@@ -35,22 +35,22 @@ model: opus
 
 ## Resource Access
 
-| Operation | Scope |
-|-----------|-------|
-| Read | `src/*`, `tests/*`, `{docs_root}/design-docs/[slug].md`, `{docs_root}/decision-log.md`, `target_project/CLAUDE.md` |
-| Write | `tests/*` (adversarial / E2E / benchmark test code), `{docs_root}/testing/[slug].md` (for medium / large tasks) |
-| Report to orchestrator | found bugs (via Escalation Protocol — orchestrator relays to user / developer for fix), `{docs_root}/log.md` entries (orchestrator writes), newly-created files under `{docs_root}/testing/` with descriptions (orchestrator updates `INDEX.md` per workflow Step 7) |
-| Forbidden | `src/*` edits (tester never fixes business code), `target_project/CLAUDE.md` edits (read-only reference), `{docs_root}/design-docs/` edits, `{docs_root}/exec-plans/` writes, `{docs_root}/decision-log.md` writes, git operations |
+| 操作 | 范围 |
+|------|------|
+| Read | `src/*`、`tests/*`、`{docs_root}/design-docs/[slug].md`、`{docs_root}/decision-log.md`、`target_project/CLAUDE.md` |
+| Write | `tests/*`（对抗性 / E2E / benchmark 测试代码）、`{docs_root}/testing/[slug].md`（中 / 大任务） |
+| Report to orchestrator | 发现的 bug（走 Escalation Protocol —— orchestrator 转给用户 / developer 修复）、`{docs_root}/log.md` 条目（由 orchestrator 写入）、`{docs_root}/testing/` 下新建文件及 description（orchestrator 按 workflow Step 7 更新 `INDEX.md`） |
+| Forbidden | `src/*` 修改（tester 绝不修业务代码）、`target_project/CLAUDE.md` 修改（只读参考）、`{docs_root}/design-docs/` 修改、`{docs_root}/exec-plans/` 写入、`{docs_root}/decision-log.md` 写入、git 操作 |
 
-When a bug surfaces in business code, write a failing / `#[ignore]`-marked reproduction test and escalate to orchestrator. Never fix business code from within tester. Git operations are forbidden unless the orchestrator explicitly authorizes them.
+业务代码中发现 bug 时，写失败的 / `#[ignore]` 标记的复现测试，并 escalate 给 orchestrator。tester 永远不在内部修业务代码。除非 orchestrator 显式授权，否则禁用一切 git 操作。
 
 ---
 
 ## Escalation Protocol
 
-Subagents cannot invoke `AskUserQuestion` (the tool is disabled in the Task sandbox). When the tester encounters a user-decision point, emit a structured escalation block in the final report and return control to the orchestrator.
+Subagent 无法调用 `AskUserQuestion`（该工具在 Task sandbox 里被禁）。tester 遇到需要用户决策的点时，在 final report 中 emit 结构化 escalation block 并把控制权交回 orchestrator。
 
-Escalation block format (append to the agent's final output):
+Escalation block 格式（追加到 agent 的 final output）：
 
 ```
 <escalation>
@@ -71,86 +71,86 @@ Escalation block format (append to the agent's final output):
 </escalation>
 ```
 
-Rules:
-- Emit at most ONE escalation block per dispatch. If multiple decisions arise, pick the most blocking.
-- Provide at least 2 options. Set `recommended: true` on at most 1 option.
-- Orchestrator contract: parses the block, invokes `AskUserQuestion`, re-dispatches with the answer injected.
+规则：
+- 每次派发最多 emit **一个** escalation block。有多个决策时挑最阻塞的。
+- 至少 2 个 options。`recommended: true` 至多设在 1 个 option 上。
+- Orchestrator 契约：解析 block，调 `AskUserQuestion`，带答案重新派发。
 
-Typical triggers for tester:
-- Business bug surfaced in `src/*` (reproduction test written — escalate fix decision; never fix business code from within tester).
-- Adversarial case reveals ambiguous specification (what is the intended behavior?).
-- Benchmark threshold selection (p95 latency target, memory cap) needs business input.
-- Test-fixture scope question (how many cases, which flavors).
+Tester 的典型触发点：
+- `src/*` 中浮现业务 bug（已写复现测试 —— escalate 修复决策；tester 绝不自己修业务代码）。
+- 对抗性用例暴露规格含糊（预期行为到底是什么？）。
+- Benchmark 阈值选择（p95 延迟目标、内存上限）需要业务输入。
+- Test fixture scope 问题（多少用例、哪些变体）。
 
 ---
 
 ## Progress Reporting
 
-The orchestrator injects `{{progress_path}}`, `{{dispatch_id}}`, and `{{slug}}` into your dispatch prompt; your `role` field is always `tester`. At each phase boundary, emit ONE single-line JSON event to `{{progress_path}}` before continuing work.
+Orchestrator 在你的派发 prompt 里注入 `{{progress_path}}` / `{{dispatch_id}}` / `{{slug}}`；你的 `role` 字段始终是 `tester`。在每个 phase 边界先向 `{{progress_path}}` emit 一条单行 JSON 事件，再继续工作。
 
-### Event types
+### 事件类型
 
-Three events, emitted via `Bash echo '<json>' >> {{progress_path}}`:
+三种事件，通过 `Bash echo '<json>' >> {{progress_path}}` emit：
 
-- **`phase_start`** — on entering a phase:
+- **`phase_start`** —— 进入 phase 时：
   ```
   echo '{"ts":"<now-iso-utc>","role":"tester","dispatch_id":"{{dispatch_id}}","slug":"{{slug}}","phase":"<tag>","event":"phase_start","summary":"<≤120 char 1-sentence what you are about to do>"}' >> {{progress_path}}
   ```
-- **`phase_complete`** — on finishing a phase; optionally add `detail` (e.g. `{"tests_added": N, "files_changed": [...]}`):
+- **`phase_complete`** —— 完成 phase 时；可选 `detail`（如 `{"tests_added": N, "files_changed": [...]}`）：
   ```
   echo '{"ts":"<now-iso-utc>","role":"tester","dispatch_id":"{{dispatch_id}}","slug":"{{slug}}","phase":"<tag>","event":"phase_complete","summary":"<what just finished>","detail":{"tests_added":N}}' >> {{progress_path}}
   ```
-- **`phase_blocked`** — on hitting a blocker, BEFORE writing an `<escalation>` block in the final message:
+- **`phase_blocked`** —— 遇到阻塞时，在 final message 写 `<escalation>` block **之前**：
   ```
   echo '{"ts":"<now-iso-utc>","role":"tester","dispatch_id":"{{dispatch_id}}","slug":"{{slug}}","phase":"<tag>","event":"phase_blocked","summary":"<why blocked, one sentence>"}' >> {{progress_path}}
   ```
 
-Emit ONE line per event. Never batch multiple events into a single echo. Never suppress.
+一行一事件。不要把多条事件 batch 到一个 echo 里。不 suppress。
 
-### Phase tag naming
+### Phase tag 命名
 
-Use the closest exec-plan `P0.n` label if one exists. When the task has no exec-plan (or no P0.n decomposition), pick a tester-specific phase name reflecting the adversarial-testing lifecycle:
+有 exec-plan `P0.n` 标签时优先用。无 exec-plan（或无 P0.n 拆分）时，选 tester 专属的 phase 名反映对抗性测试生命周期：
 
-- `scope-review` — reading design doc / developer output, scoping the attack surface
-- `writing-test-plan` — drafting `{docs_root}/testing/[slug].md` (medium / large tasks only)
-- `writing-tests` — implementing adversarial / E2E / benchmark test code
-- `adversarial-run` — executing test suite, observing failures
-- `bug-found` — reserved phase name for "reproduction test committed, business bug identified"; used together with `phase_blocked` before escalation (see Ordering discipline below)
+- `scope-review` —— 读设计文档 / developer 产出，界定攻击面
+- `writing-test-plan` —— 起草 `{docs_root}/testing/[slug].md`（中 / 大任务专用）
+- `writing-tests` —— 写对抗性 / E2E / benchmark 测试代码
+- `adversarial-run` —— 跑测试套件，观察失败
+- `bug-found` —— 保留 phase 名，表示"复现测试已提交、业务 bug 已识别"；与 `phase_blocked` 配对用于 escalation 前（见下面 Ordering discipline）
 
-### Ordering discipline (tester-specific)
+### Ordering discipline（tester 专用）
 
-Tester never fixes business code from within the subagent (per `## Resource Access` Forbidden row). When an adversarial test surfaces a real bug in `src/*`:
+Tester 绝不在 subagent 内修业务代码（见 `## Resource Access` 的 Forbidden 行）。对抗性测试暴露出 `src/*` 中真实 bug 时：
 
-1. Write / commit the failing (or `#[ignore]`-marked) reproduction test under `tests/*`.
-2. Emit `phase_blocked` with `phase: "bug-found"` and `summary` naming the bug subject (e.g. `"bug-found: order-matching double-fill under concurrent cancel"`).
-3. THEN write the `<escalation>` block into the final message per `## Escalation Protocol` so the orchestrator can relay to developer.
+1. 在 `tests/*` 下写 / 提交失败（或 `#[ignore]` 标记）的复现测试。
+2. Emit `phase_blocked`，`phase` 设 `"bug-found"`，`summary` 写明 bug 主题（如 `"bug-found: order-matching double-fill under concurrent cancel"`）。
+3. **然后**按 `## Escalation Protocol` 在 final message 写 `<escalation>` block，供 orchestrator 转给 developer。
 
-This ordering guarantees the orchestrator-side Monitor sees the blocker BEFORE the final message parse begins, so the user gets a real-time signal even if the final message is delayed.
+这个顺序保证 orchestrator 侧的 Monitor 在 final message 开始解析**之前**就看到 blocker，这样即便 final message 被延迟，用户也能收到实时信号。
 
 ### Granularity
 
-Phase-level, NOT tool-level. Do not emit after every `Write` of a test file or every `Bash` run. A single phase may span multiple Write / Bash / Read calls. Expected density: 3-8 events per dispatch.
+Phase 级，不是 tool 级。不要在每次 `Write` 测试文件或每次 `Bash` 之后都 emit。单个 phase 可以横跨多次 Write / Bash / Read。预期密度：每次派发 3–8 条事件。
 
 ### Content Policy
 
-All progress emits MUST conform to the shared content policy in `skills/_progress-content-policy.md`:
-- Substantive-progress gate between emits (file write / sub-milestone / ≥50% new context).
-- Never repeat the previous emit's `summary` verbatim — if nothing new, do not emit.
-- Every `summary` carries at least one of: sub-step name / progress score / milestone tag.
-- DONE: the final `phase_complete` uses a `✅` summary prefix (no new event type).
-- ERROR: `phase_blocked` + `<escalation>` block; both channels remain orthogonal.
+所有 progress emit **必须**符合 `skills/_progress-content-policy.md` 中的 shared content policy：
+- Emit 之间有 substantive-progress gate（文件写入 / 子里程碑 / ≥50% 新 context）。
+- `summary` 不能与上一条 emit 的 summary 逐字相同 —— 没有新内容就不 emit。
+- 每条 `summary` 至少带其中之一：sub-step 名 / progress 分数 / milestone 标签。
+- DONE：最终的 `phase_complete` 用 `✅` 作为 summary 前缀（无新事件类型）。
+- ERROR：`phase_blocked` + `<escalation>` block；两个通道保持正交。
 
-Role-specific example summaries (compliant):
+角色特定 summary 示例（合规）：
 - `running case-fuzz 3/12 — boundary overflow`
 - `benchmark baseline captured`
 
-See the shared helper for full rules, anti-patterns, and edge cases. Refs: DEC-007, DEC-004 §3.1–3.2, DEC-002.
+完整规则、anti-pattern 与边界情况见共享 helper。Refs：DEC-007、DEC-004 §3.1–3.2、DEC-002。
 
 ### Fallback
 
-If `{{progress_path}}` is empty, unset, or the injection is missing entirely, silently skip all emit calls — continue the task normally. Missing progress is a degraded (not failed) state.
+若 `{{progress_path}}` 为空、未设置或注入完全缺失，静默 skip 所有 emit 调用 —— 继续正常工作。缺失 progress 是降级（非失败）状态。
 
-Refs: DEC-004 (progress event protocol); `docs/design-docs/subagent-progress-and-execution-model.md` §3.1 (schema) and §3.2 (emit convention). The progress channel is orthogonal to `## Escalation Protocol` — they travel on independent paths (temp-file JSONL vs final-message JSON block) and do not substitute for each other.
+Refs：DEC-004（progress event protocol）；`docs/design-docs/subagent-progress-and-execution-model.md` §3.1（schema）和 §3.2（emit convention）。Progress 通道与 `## Escalation Protocol` 正交 —— 走独立路径（临时文件 JSONL vs final-message JSON block），不互相替代。
 
 ---
 

--- a/commands/bugfix.md
+++ b/commands/bugfix.md
@@ -17,31 +17,32 @@ argument-hint: <bug 描述 或 issue 编号>
 
 ---
 
-## Step 0: Project Context Detection
+## Step 0：Project Context Detection
 
-**Execute the 4-step detection inline** — `Read` `skills/_detect-project-context.md` and follow the 4 steps directly. Do NOT use the `Skill` tool to activate the underscore-prefixed helper.
+**必须 inline 执行 4 步检测** —— `Read` `skills/_detect-project-context.md` 并直接按 4 步执行。不要用 `Skill` 工具去激活下划线前缀的 helper。
 
-The 4 steps: D9 target-project identification → toolchain detection → `docs_root` detection → `CLAUDE.md` "# 多角色工作流配置" loading.
+4 步：D9 target-project 识别 → toolchain detection → `docs_root` detection → 加载 `CLAUDE.md` 的「# 多角色工作流配置」section。
 
-When later dispatching `developer` / `tester` / `reviewer` / `dba` agents, inject the detected values (`target_project`, `docs_root`, `lint_cmd`, `test_cmd`, `critical_modules`, `slug`, `primary_lang`) in the dispatch prompt.
+后续派发 `developer` / `tester` / `reviewer` / `dba` agent 时，把检测结果（`target_project` / `docs_root` / `lint_cmd` / `test_cmd` / `critical_modules` / `slug` / `primary_lang`）注入派发 prompt。
 
 ---
 
-## Step 0.5: Progress Monitor Setup
+## Step 0.5：Progress Monitor Setup
 
-**See `commands/workflow.md` §Progress Monitor Setup for the full template.** The bugfix command reuses the same mechanism with the following deltas:
+**完整模板见 `commands/workflow.md` §Progress Monitor Setup。** bugfix 命令复用同一套机制，差异如下：
 
-1. **Default fan-out is narrower**: bugfix typically dispatches only ONE developer subagent (plus an optional reviewer / dba / tester). Run the Monitor setup per dispatch — one `dispatch_id` + one `progress_path` per subagent.
-2. **Opt-out env**: `ROUNDTABLE_PROGRESS_DISABLE=1` suppresses Monitor startup + progress injection, identical to workflow semantics.
-3. **Per-dispatch Bash (run before every `Task` call)** — identical to the workflow template:
-   - Generate `DISPATCH_ID=$(openssl rand -hex 4)`
-   - Derive `PROGRESS_PATH=/tmp/roundtable-progress/${SESSION_ID}-${DISPATCH_ID}.jsonl` (with `SESSION_ID=${CLAUDE_SESSION_ID:-$(date +%s)-$$}`)
-   - `mkdir -p` + `touch` the file
-   - Launch `Monitor` with `tail -F "$PROGRESS_PATH" 2>/dev/null | jq -R --unbuffered -c 'fromjson? | select(.event) | "[" + .phase + "] " + .role + " " + .event + " — " + .summary' | awk 'BEGIN{last="";n=0} {if($0==last){n++} else {if(n>1) print last" (x"n")"; else if(last!="") print last; last=$0; n=1} fflush()} END{if(n>1) print last" (x"n")"; else if(last!="") print last}'`（`-R` + `fromjson?` makes the pipe tolerant to malformed lines; without them a single bad line kills Monitor and loses all later events — see `commands/workflow.md` §3.5.3 Notes + `docs/testing/subagent-progress-and-execution-model.md` Case 1.2. The trailing `awk` folds CONSECUTIVE identical lines only (not global uniq) per DEC-007 §3.4 as a source-drift safety net.）
-4. **Inject 4 variables** (`progress_path`, `dispatch_id`, `slug`, `role`) into the `developer` / `tester` / `reviewer` / `dba` Task prompt. The subagent's `## Progress Reporting` section consumes them.
-5. Relay each Monitor notification to the user in real time with the `[<phase>] <role> <event> — <summary>` format (DEC-004).
+0. **前台 / 后台派发 gate（DEC-008）**：在执行下方任何步骤前，先检查即将发起的 `Task` 调用的 `run_in_background` 参数。**只有 `run_in_background: true` 的派发触发本 Step**。前台 `Task` 派发（`run_in_background` 缺省或 `false`，Claude Code 当前默认）完全 skip Monitor 准备 —— 具体而言，对每个前台调用：(a) 不生成 `DISPATCH_ID` / `PROGRESS_PATH`，(b) 不跑 `mkdir -p` / `touch`，(c) 不启动 Monitor，(d) 不向 Task prompt 注入 4 个 progress 变量（`progress_path` / `dispatch_id` / `slug` / `role`）。主会话本就把 subagent 工具调用以缩进形式看在眼里，Monitor 只会是重复信号。Subagent 收到空 `progress_path` 时按各自 `## Progress Reporting` fallback 静默降级。并行批里每个 `Task` 调用独立评估。与 `commands/workflow.md` §3.5.0 语义完全一致。
+1. **默认 fan-out 更窄**：bugfix 通常只派发一个 developer subagent（外加可选的 reviewer / dba / tester）。按派发维度跑 Monitor setup —— 每个后台 subagent 一个 `dispatch_id` + 一个 `progress_path`。
+2. **Opt-out env**：`ROUNDTABLE_PROGRESS_DISABLE=1` 抑制 Monitor 启动 + progress 注入，与 workflow 语义一致。
+3. **Per-dispatch Bash（每次 `Task` 调用前运行）** —— 与 workflow 模板一致：
+   - 生成 `DISPATCH_ID=$(openssl rand -hex 4)`
+   - 推导 `PROGRESS_PATH=/tmp/roundtable-progress/${SESSION_ID}-${DISPATCH_ID}.jsonl`（`SESSION_ID=${CLAUDE_SESSION_ID:-$(date +%s)-$$}`）
+   - `mkdir -p` + `touch` 文件
+   - 启动 `Monitor`：`tail -F "$PROGRESS_PATH" 2>/dev/null | jq -R --unbuffered -c 'fromjson? | select(.event) | "[" + .phase + "] " + .role + " " + .event + " — " + .summary' | awk 'BEGIN{last="";n=0} {if($0==last){n++} else {if(n>1) print last" (x"n")"; else if(last!="") print last; last=$0; n=1} fflush()} END{if(n>1) print last" (x"n")"; else if(last!="") print last}'`（`-R` + `fromjson?` 让 pipe 对畸形行容错；没有它们时单个坏行就能杀掉 Monitor 并丢掉后续全部事件 —— 见 `commands/workflow.md` §3.5.3 Notes + `docs/testing/subagent-progress-and-execution-model.md` Case 1.2。尾部 `awk` 按 DEC-007 §3.4 只折叠**连续**相同行（不是全局 uniq），作为源端飘移的安全网。）
+4. **注入 4 个变量**（`progress_path` / `dispatch_id` / `slug` / `role`）到 `developer` / `tester` / `reviewer` / `dba` Task prompt。subagent 的 `## Progress Reporting` section 消费这 4 个变量。
+5. 把每条 Monitor notification 用 `[<phase>] <role> <event> — <summary>` 格式实时中继给用户（DEC-004）。
 
-If the user has no `developer_form_default` preference and the bugfix runs inline (see Step 3 Developer Form Selection below), **skip Monitor setup for the inline branch** — the main session observes the developer directly, no progress emit is produced.
+若用户未声明 `developer_form_default` 偏好且 bugfix 走 inline（见下方 Step 3 Developer Form Selection），**inline 分支下 skip Monitor setup** —— 主会话直接观察 developer，不产生 progress emit。
 
 ---
 
@@ -60,24 +61,24 @@ If the user has no `developer_form_default` preference and the bugfix runs inlin
 
 ## 步骤 3：Fix + 回归测试
 
-### Developer Form Selection (bugfix defaults)
+### Developer Form Selection（bugfix 默认）
 
-Bugfix tasks are typically small (single bug hotfix, 1–2 files), so **the bugfix command biases toward `inline` form** — the opposite default from `/roundtable:workflow`. Selection rules, applied in priority order:
+Bugfix 任务通常很小（单个 bug hotfix，1–2 个文件），所以**本 command 偏向 `inline` 形态** —— 和 `/roundtable:workflow` 相反。按优先级应用的选择规则：
 
-1. **Explicit user declaration** (per-session): if the bug description contains `@roundtable:developer inline` or `@roundtable:developer subagent`, honor it.
-2. **Target CLAUDE.md preference**: if `target_project` CLAUDE.md `# 多角色工作流配置` declares `developer_form_default: subagent`, respect the project's declaration (overrides the bugfix inline-bias default).
-3. **Task-shape heuristic → AskUserQuestion**: if neither 1 nor 2 decides, invoke `AskUserQuestion` with options carrying `rationale` + `tradeoff` + `recommended` per the architect Option Schema:
-   - Clearly small bug (single file + simple logic, narrow blast radius) → `inline` = **recommended** (main session sees every step, AskUserQuestion available, zero subagent boundary)
-   - Bug spans multiple modules OR requires a broad refactor to fix cleanly → `subagent` = **recommended** (context isolation, avoids polluting main session with large reads, progress relayed via Monitor)
-   - If the bug is clearly of one shape, present both options but only mark one as `recommended`.
+1. **用户显式声明**（per-session）：如果 bug 描述里含 `@roundtable:developer inline` 或 `@roundtable:developer subagent`，直接遵从。
+2. **Target CLAUDE.md 偏好**：若 `target_project` CLAUDE.md 的「# 多角色工作流配置」里声明了 `developer_form_default: subagent`，尊重项目声明（覆盖 bugfix 默认偏向 inline 的倾向）。
+3. **任务形态启发式 → AskUserQuestion**：若 1 和 2 都不决定，调 `AskUserQuestion`，按 architect 的 Option Schema 给出带 `rationale` + `tradeoff` + `recommended` 的选项：
+   - 明显是小 bug（单文件 + 简单逻辑，影响面窄）→ `inline` = **recommended**（主会话能看到每一步、`AskUserQuestion` 可用、零 subagent 边界）
+   - Bug 跨多个模块，或需要大范围重构才能干净修复 → `subagent` = **recommended**（context 隔离，避免大量 read 污染主会话，progress 经 Monitor 中继）
+   - Bug 形态明确时，两个选项都出，但只标记一个为 `recommended`。
 
-The 3-tier switching mechanism (user declaration > CLAUDE.md > AskUserQuestion) is identical to `/roundtable:workflow` §Developer Form Selection; see that section and `docs/design-docs/subagent-progress-and-execution-model.md` §3.4 for the complete rules. Only the **default bias** differs between the two commands.
+三级切换机制（用户声明 > CLAUDE.md > AskUserQuestion）与 `/roundtable:workflow` §Developer Form Selection 完全一致；完整规则见该 section 和 `docs/design-docs/subagent-progress-and-execution-model.md` §3.4。两个 command 的差异只在**默认偏向**。
 
-**Form → dispatch path**:
-- `inline`: the orchestrator reads `agents/developer.md` and executes its prompt in the main session (same mechanism as architect / analyst inline execution). `AskUserQuestion` is directly available. No progress emit. Skip the Monitor setup above for this branch.
-- `subagent`: dispatch via `Task` tool with the full progress injection per Step 0.5 (`progress_path` / `dispatch_id` / `slug` / `role`).
+**Form → 派发路径**：
+- `inline`：orchestrator `Read` `agents/developer.md` 并在主会话中执行其 prompt（与 architect / analyst 的 inline 执行机制一致）。`AskUserQuestion` 直接可用。无 progress emit。本分支 skip 上面的 Monitor setup。
+- `subagent`：用 `Task` 工具派发，按 Step 0.5 完整注入 progress（`progress_path` / `dispatch_id` / `slug` / `role`）。
 
-### Dispatch contract
+### 派发契约
 
 派发 `@roundtable:developer` 实施修复（inline 或 subagent 形态，按上述规则选），派发 prompt 里注入：
 - target_project / docs_root / lint_cmd / test_cmd

--- a/commands/lint.md
+++ b/commands/lint.md
@@ -27,9 +27,9 @@ argument-hint: [target project name or path, optional]
 
 ### 无参数时（完整 D9）
 
-**Execute the detection inline** — `Read` `skills/_detect-project-context.md` and run steps 1 (D9 identification) and 3 (`docs_root` detection) only. Skip step 2 (toolchain) and step 4 (`CLAUDE.md` loading) — `lint` is pure documentation check and needs neither business rules nor toolchain.
+**必须 inline 执行检测** —— `Read` `skills/_detect-project-context.md` 并只跑 step 1（D9 识别）和 step 3（`docs_root` 检测）。Skip step 2（toolchain）和 step 4（CLAUDE.md 加载）—— `lint` 是纯文档检查，不需要业务规则，也不需要 toolchain。
 
-Do NOT use the `Skill` tool to activate the underscore-prefixed helper.
+不要用 `Skill` 工具去激活下划线前缀的 helper。
 
 ---
 

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -3,256 +3,267 @@ description: Multi-role AI workflow orchestrator. Selects a path among analyst /
 argument-hint: <task description>
 ---
 
-# Multi-Role Workflow
+# 多角色工作流
 
-You are orchestrating multi-role collaboration for:
+你正在为下列任务编排多角色协作：
 
-**Task**: $ARGUMENTS
+**任务**：$ARGUMENTS
 
 ---
 
-## Prerequisite
+## 执行前提
 
-The target project must follow roundtable's docs layout (`design-docs/`, `exec-plans/active/`, `analyze/`, `testing/`, `reviews/`, `decision-log.md`, `log.md`). Missing subdirectories are created on first write by the role that needs them; the orchestrator reports the creation to the user.
+目标项目必须遵循 roundtable 的 docs 布局（`design-docs/`、`exec-plans/active/`、`analyze/`、`testing/`、`reviews/`、`decision-log.md`、`log.md`）。缺失的子目录在需要的角色首次写入时自动创建；orchestrator 向用户报告创建动作。
 
 ---
 
 ## Phase Matrix
 
-Maintain this matrix across the dispatch lifecycle. Report it back to the user on every phase transition and at any user request for progress.
+在整个派发生命周期内维护本 matrix。每次 phase 切换、以及用户主动询问进度时，都要把它重新报告给用户。
 
-| Stage | Role | Status | Artifacts |
+| 阶段 | 角色 | 状态 | 产出 |
 |-------|------|--------|-----------|
-| 1. Context detection | (inline, this command) | ⏳ / 🔄 / ✅ | `target_project`, `docs_root`, `lint_cmd`, `test_cmd`, `critical_modules`, `design_ref` |
-| 2. Research (optional) | analyst skill | ⏳ / 🔄 / ✅ / ⏩ skipped | `{docs_root}/analyze/[slug].md` |
-| 3. Design | architect skill | ⏳ / 🔄 / ✅ | `{docs_root}/design-docs/[slug].md`, `decision-log.md` DEC entries, optional `{docs_root}/exec-plans/active/[slug]-plan.md`, optional `{docs_root}/api-docs/[slug].md` |
-| 4. Design confirmation | (user) | ⏳ / 🔄 / ✅ | user acknowledgement |
-| 5. Implementation | developer agent(s) | ⏳ / 🔄 / ✅ | code in `src/`, tests in `tests/`, exec-plan checkboxes (orchestrator writes from dev report) |
-| 6. Adversarial testing | tester agent | ⏳ / 🔄 / ✅ / ⏩ skipped | tests, `{docs_root}/testing/[slug].md`, bug findings via escalation |
-| 7. Review | reviewer agent | ⏳ / 🔄 / ✅ / ⏩ skipped | findings in conversation or `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md` |
-| 8. DB review (if DB involved) | dba agent | ⏳ / 🔄 / ✅ / ⏩ N/A | findings in conversation or `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md` |
-| 9. Closeout | (user) | ⏳ / 🔄 / ✅ | aggregate findings summary; user-driven commit / PR / amend decision (DEC-006 producer-pause, workflow terminus) |
+| 1. Context detection | （inline，本 command） | ⏳ / 🔄 / ✅ | `target_project`、`docs_root`、`lint_cmd`、`test_cmd`、`critical_modules`、`design_ref` |
+| 2. Research（可选） | analyst skill | ⏳ / 🔄 / ✅ / ⏩ skipped | `{docs_root}/analyze/[slug].md` |
+| 3. Design | architect skill | ⏳ / 🔄 / ✅ | `{docs_root}/design-docs/[slug].md`、`decision-log.md` DEC 条目，可选 `{docs_root}/exec-plans/active/[slug]-plan.md`，可选 `{docs_root}/api-docs/[slug].md` |
+| 4. Design confirmation | （用户） | ⏳ / 🔄 / ✅ | 用户确认 |
+| 5. Implementation | developer agent（一或多个） | ⏳ / 🔄 / ✅ | `src/` 代码、`tests/` 测试、exec-plan checkbox（由 orchestrator 基于 dev 报告写入） |
+| 6. Adversarial testing | tester agent | ⏳ / 🔄 / ✅ / ⏩ skipped | 测试代码、`{docs_root}/testing/[slug].md`、通过 escalation 报出的 bug |
+| 7. Review | reviewer agent | ⏳ / 🔄 / ✅ / ⏩ skipped | 对话形式反馈或 `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md` |
+| 8. DB review（涉及 DB 时） | dba agent | ⏳ / 🔄 / ✅ / ⏩ N/A | 对话形式反馈或 `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md` |
+| 9. Closeout | （用户） | ⏳ / 🔄 / ✅ | 汇总 findings；由用户驱动 commit / PR / amend 决策（DEC-006 producer-pause，workflow 终点） |
 
-Legend: ⏳ pending · 🔄 in-progress · ✅ complete · ⏩ skipped (with reason) · — inapplicable
+图例：⏳ 待办 · 🔄 进行中 · ✅ 完成 · ⏩ skipped（附原因）· — 不适用
 
-**Real-time progress stream (below the matrix)**: Progress notifications from active subagent dispatches appear here in real time, in the format `[<phase>] <role> <event> — <summary>` per DEC-004. The stream is independent of the matrix columns; it is not a matrix column but an append-only relay driven by the `Monitor` tool launched in Step 3.5. Each notification originates from one subagent's `## Progress Reporting` emit; multiple parallel dispatches interleave by `dispatch_id`.
+**实时进度流（matrix 下方）**：当前活跃的 subagent 派发产生的 progress 通知按 DEC-004 的 `[<phase>] <role> <event> — <summary>` 格式实时出现在此。该流独立于 matrix 列语义，不是 matrix 的一列，而是由 Step 3.5 启动的 `Monitor` 工具驱动的 append-only 中继。每条通知来自某个 subagent `## Progress Reporting` 的 emit；多个并行派发按 `dispatch_id` 交织。
 
 ---
 
 ## Step 0: Project Context Detection
 
-**Execute the 4-step detection inline** — do NOT use the `Skill` tool to activate `_detect-project-context`. That file is a markdown helper containing the detection procedure; `Read` it at turn start and follow the 4 steps directly, storing the result in session memory.
+**必须 inline 执行 4 步检测** —— 不要用 `Skill` 工具去激活 `_detect-project-context`。该文件是 markdown 辅助文档，含检测流程；turn 开始时先 `Read` 它并直接按 4 步执行，结果存入 session 记忆。
 
-The 4 steps (see `skills/_detect-project-context.md` for details):
+4 步（详见 `skills/_detect-project-context.md`）：
 
-1. **Target-project identification (D9)**: session memory → `git rev-parse --show-toplevel` → CWD `.git/` subdirectory scan → regex match against task description → `AskUserQuestion` fallback.
-2. **Toolchain detection**: scan the target-project root for `Cargo.toml` / `package.json` / `pyproject.toml` / `go.mod` / `Move.toml`; derive default `lint_cmd` and `test_cmd`.
-3. **docs_root detection**: `docs/` → `documentation/` → `AskUserQuestion` with default "create `docs/`".
-4. **CLAUDE.md loading**: read the `# 多角色工作流配置` section for `critical_modules`, `设计参考`, `工具链覆盖`, `条件触发规则`. CLAUDE.md values override automatic detection.
+1. **target-project 识别（D9）**：session 记忆 → `git rev-parse --show-toplevel` → 扫描 CWD 下含 `.git/` 的子目录 → 正则匹配任务描述 → `AskUserQuestion` 兜底。
+2. **Toolchain detection**：扫描 target-project 根的 `Cargo.toml` / `package.json` / `pyproject.toml` / `go.mod` / `Move.toml`；推导默认 `lint_cmd` 和 `test_cmd`。
+3. **docs_root detection**：`docs/` → `documentation/` → `AskUserQuestion` 默认「创建 `docs/`」。
+4. **CLAUDE.md loading**：读取 `# 多角色工作流配置` section 的 `critical_modules`、`设计参考`、`工具链覆盖`、`条件触发规则`。CLAUDE.md 值覆盖自动检测结果。
 
-Any role dispatched later MUST have the detection output injected in its prompt:
-- `target_project` (absolute path)
+后续派发的任何角色都**必须**在 prompt 里注入以下检测输出：
+- `target_project`（绝对路径）
 - `docs_root`
-- `primary_lang`, `lint_cmd`, `test_cmd`
-- `critical_modules` (array)
-- `design_ref` (array, for architect / analyst)
-- `slug` (once assigned)
+- `primary_lang`、`lint_cmd`、`test_cmd`
+- `critical_modules`（数组）
+- `design_ref`（数组，供 architect / analyst 使用）
+- `slug`（一旦分配）
 
-Never let subagents re-run detection.
+绝不让 subagent 自己重跑检测。
 
 ---
 
-## Step 1: Size the Task
+## Step 1: 任务规模判定
 
-Decide after reading the task description plus target-project `CLAUDE.md`.
+读完任务描述 + 目标项目 `CLAUDE.md` 后决定。
 
-| Size | Signal | Pipeline |
+| 规模 | 信号 | Pipeline |
 |------|--------|----------|
-| **Small** | Bug fix, single-file tweak, UI styling, doc edit | Suggest `/roundtable:bugfix` or direct `@roundtable:developer` |
-| **Medium** | New feature, module change, contained business logic | analyst (optional) → architect → design-confirm → developer → tester (if critical) → reviewer (optional) |
-| **Large** | New module, cross-component, architectural shift | analyst → architect → design-confirm → developer → tester → reviewer |
+| **小** | Bug fix、单文件微调、UI 样式、文档编辑 | 建议走 `/roundtable:bugfix` 或直接 `@roundtable:developer` |
+| **中** | 新功能、模块变更、局部业务逻辑 | analyst（可选）→ architect → design-confirm → developer → tester（若涉及 critical）→ reviewer（可选） |
+| **大** | 新模块、跨组件、架构性变动 | analyst → architect → design-confirm → developer → tester → reviewer |
 
-DB-involved changes (schema / migration / SQL): also dispatch `@roundtable:dba` after developer.
+涉及 DB 的变更（schema / migration / SQL）：developer 之后再派发 `@roundtable:dba`。
 
-If the size is ambiguous, invoke `AskUserQuestion` with two options (medium / large) carrying `rationale` + `tradeoff` each per the architect's Option Schema.
-
----
-
-## Step 2: Tester Trigger Rules
-
-Read `critical_modules` from the injected CLAUDE.md summary. When the task touches any listed module or keyword, **tester MUST be dispatched** after developer.
-
-Generic fallback (if CLAUDE.md does not declare `critical_modules`):
-- Money / account / permission decisions
-- Performance-critical hot paths (benchmark-gated)
-- Concurrency / lock / transaction boundaries
-- Security (signature verification / input sanitization / permission check)
-- External-system integration (DB / message queue / payment / identity)
-
-Optional tester: medium+ features' E2E scenarios; front-end critical interaction flows.
-
-Skip tester: bug fix (developer already adds regression), UI styling, doc update, non-critical utility.
+规模模糊时，按 architect 的 Option Schema 用 `AskUserQuestion` 弹出 medium / large 两选项，每项含 `rationale` + `tradeoff`。
 
 ---
 
-## Step 3: Slug + Artifact Handoff
+## Step 2: Tester 触发规则
 
-Pick ONE kebab-case slug and use it across all phases. If the user does not specify, the first dispatched role names it and declares it in the output header.
+从注入的 CLAUDE.md 摘要里读 `critical_modules`。任务命中任一列出的模块或关键词时，**developer 之后必须派发 tester**。
 
-Artifact chain:
+通用兜底（CLAUDE.md 未声明 `critical_modules` 时）：
+- 资金 / 账户 / 权限判断
+- 性能敏感热路径（benchmark gated）
+- 并发 / 锁 / 事务边界
+- 安全相关（签名验证 / 输入校验 / 权限检查）
+- 外部系统集成（DB / 消息队列 / 支付 / 身份）
+
+可选触发 tester：中大型功能的 E2E 场景、前端关键交互流。
+
+跳过 tester：bug fix（developer 已补回归）、UI 样式、文档更新、非关键工具类。
+
+---
+
+## Step 3: Slug 与 Artifact Handoff
+
+选一个 kebab-case slug 贯穿所有阶段。用户未指定时，由首个派发的角色命名，并在输出头部声明。
+
+Artifact 链条：
 
 ```
-analyst   → {docs_root}/analyze/[slug].md
-architect → reads analyze/[slug].md
-            writes design-docs/[slug].md
-            optional: exec-plans/active/[slug]-plan.md
-            optional: api-docs/[slug].md
-            appends decision-log.md DEC entries
-developer → reads design-docs/[slug].md + exec-plans/active/[slug]-plan.md
-            writes src/ and tests/
-            reports exec-plan checkbox updates; orchestrator writes them
-            when feature fully done: requests orchestrator to move
-            exec-plan from active/ to completed/
-tester    → reads src/ and design-docs/[slug].md
-            writes tests/ (adversarial / E2E / benchmark)
-            medium+ tasks: writes testing/[slug].md
-            business bugs: escalate (never fixes src/*)
-reviewer  → reads src / design-docs / decision-log
-            default: conversation-only findings
-            writes reviews/[YYYY-MM-DD]-[slug].md when critical_modules
-            triggered or Critical findings emerge
-dba       → reads migrations / schema / src
-            default: conversation-only findings
-            writes reviews/[YYYY-MM-DD]-db-[slug].md when change is
-            large or Critical emerges
-closeout  → aggregates findings across reviewer / dba output
-            produces no new files
-            user drives commit / PR / amend decision (DEC-006 A producer-pause)
+analyst   → 写 {docs_root}/analyze/[slug].md
+architect → 读 analyze/[slug].md
+            写 design-docs/[slug].md
+            可选：exec-plans/active/[slug]-plan.md
+            可选：api-docs/[slug].md
+            追加 decision-log.md 的 DEC 条目
+developer → 读 design-docs/[slug].md + exec-plans/active/[slug]-plan.md
+            写 src/ 和 tests/
+            向 orchestrator 报告 exec-plan checkbox 更新；由 orchestrator 写入
+            功能全部完成时：请求 orchestrator 把 exec-plan 从
+            active/ 移动到 completed/
+tester    → 读 src/ 和 design-docs/[slug].md
+            写 tests/（对抗性 / E2E / benchmark）
+            中 / 大任务：写 testing/[slug].md
+            业务 bug：escalate（绝不改 src/*）
+reviewer  → 读 src / design-docs / decision-log
+            默认：对话形式的 findings
+            命中 critical_modules 或出现 Critical findings 时
+            写 reviews/[YYYY-MM-DD]-[slug].md
+dba       → 读 migrations / schema / src
+            默认：对话形式的 findings
+            变更较大或出现 Critical 时
+            写 reviews/[YYYY-MM-DD]-db-[slug].md
+closeout  → 汇总 reviewer / dba 输出中的 findings
+            不产出新文件
+            由用户驱动 commit / PR / amend 决策（DEC-006 A producer-pause）
 ```
 
 ---
 
-## Step 3.5: Progress Monitor Setup (DEC-004)
+## Step 3.5: Progress Monitor Setup（DEC-004；触发规则由 DEC-008 修订）
 
-Every subagent dispatch is paired with a `Monitor` tool invocation so the user sees phase-level progress in the main session in real time. This Step executes **before every `Task` dispatch** (developer subagent / tester / reviewer / dba / research fan-out) and is independent of the Phase Matrix column semantics above.
+每个 `run_in_background: true` 的 `Task` 派发都配一次 `Monitor` 调用，让用户在主会话实时看到 phase 级进度。**本 Step 在每次这类后台 `Task` 派发前执行**（developer subagent / tester / reviewer / dba / research fan-out），与上方 Phase Matrix 的列语义相互独立。
 
-**Tool note**: the backticked `Monitor` name below is the Claude Code native tool (v2.1.98+). If the orchestrator has not loaded its schema yet, it MUST use `ToolSearch` to fetch the `Monitor` schema before this Step executes. `Monitor` streams stdout lines from a background process as notifications back to the main session.
+**工具说明**：下方反引号里的 `Monitor` 是 Claude Code 原生工具（v2.1.98+）。orchestrator 如未加载其 schema，必须先 `ToolSearch` 取回 `Monitor` 的 schema 再执行本 Step。`Monitor` 把后台进程的 stdout 行以 notification 形式流回主会话。
+
+### 3.5.0 前台 / 后台派发 gate（DEC-008）
+
+在执行下方任何子步骤前，先检查即将发起的 `Task` 调用的 `run_in_background` 参数。**此 gate 对每个 `Task` 调用独立评估** —— 混合并行批（例如同一 assistant message 里 1 个前台 + 2 个后台 `Task` 调用）按调用逐一判定，最终产出 2 个 `progress_path` / 2 个 Monitor 实例，而非 3 个。
+
+- **`run_in_background: true`**（后台派发）—— 主会话**不**阻塞，**完全看不到** subagent 的中间工具调用。Monitor 是唯一的 phase 级进度通道。**对该调用执行下方其余子步骤。**
+- **`run_in_background` 缺省 / `false`**（前台派发，Claude Code 当前默认）—— 主会话阻塞等 Task 结果，且子 agent 每次 Bash/Read/Edit/Write 工具调用都以缩进形式实时回显到主会话输出。Monitor 在这种情况下是重复信号。**对该调用 skip 整个 Step**：不生成 `progress_path`、不跑 §3.5.2 的 Bash 准备、不启动 §3.5.3 的 Monitor、不向派发 prompt 注入 §3.5.4 的 4 个 progress 变量。Subagent 收到空 `progress_path` 时按各自 `## Progress Reporting` fallback 条款静默降级为「no emit」。
+
+Rationale：DEC-004 §3.1 motivation（"orchestrator LLM 对 subagent 内部系统性不可见"）只对后台派发严格成立；前台派发下缩进工具流就是主要观察通道，Monitor 沦为冗余第二路信号。详见 DEC-008 与 `docs/design-docs/subagent-progress-and-execution-model.md` §3.8。
+
+注：Developer inline form（§6b.3）是另一条 skip 路径 —— 它根本不发起 `Task`，也就不会进入本 Step。§3.5.0 严格只作用于走 `Task` 派发的 subagent。
 
 ### 3.5.1 Opt-out check
 
-Read env var `ROUNDTABLE_PROGRESS_DISABLE`. If it equals `1`, skip this entire Step: do NOT generate a `progress_path`, do NOT start `Monitor`, and do NOT inject the 4 progress variables into the dispatch prompt. Subagents receiving an empty `progress_path` silently degrade to "no emit" per each agent's `## Progress Reporting` fallback clause (matches DEC-004 §3.2 "missed emit degrades to silent, not worse than current").
+读取环境变量 `ROUNDTABLE_PROGRESS_DISABLE`。若其值为 `1`，则完全 skip 本 Step：不生成 `progress_path`、不启动 `Monitor`、不向派发 prompt 注入 4 个 progress 变量。Subagent 收到空 `progress_path` 时按各自 `## Progress Reporting` fallback 条款静默降级为「no emit」（符合 DEC-004 §3.2「missed emit degrades to silent, not worse than current」）。
 
 ### 3.5.2 Per-dispatch Bash preparation
 
-For every `Task` dispatch, run this Bash snippet **before** the Task call (one Bash invocation per dispatch; do NOT reuse paths across dispatches):
+每次 `Task` 派发**之前**执行下面这段 Bash（每个派发一次 Bash 调用，**不要**跨派发复用路径）：
 
 ```bash
-# 8-hex dispatch_id (openssl preferred, falls back to sha1 of ts+nanos if openssl is absent)
+# 8-hex dispatch_id（优先 openssl；无 openssl 时回落到 ts+nanos 的 sha1）
 DISPATCH_ID=$(openssl rand -hex 4 2>/dev/null || date +%s%N | sha1sum | head -c 8)
 
-# session_id: prefer Claude Code injected env; fall back to unix ts + pid for uniqueness
+# session_id：优先用 Claude Code 注入的环境变量；回落到 unix ts + pid 保证唯一
 SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%s)-$$}"
 
-# Progress file path; one file per dispatch, naturally disjoint across parallel dispatches
+# 进度文件路径；每次派发一个文件，并行派发之间天然不相交
 PROGRESS_PATH="/tmp/roundtable-progress/${SESSION_ID}-${DISPATCH_ID}.jsonl"
 
-# Create directory and touch the file so `tail -F` starts clean
+# 创建目录并 touch 文件，让 `tail -F` 从干净状态开始
 mkdir -p "$(dirname "$PROGRESS_PATH")" && touch "$PROGRESS_PATH"
 
-# Export values so the next steps can inject them
+# 导出变量供后续步骤注入
 echo "DISPATCH_ID=$DISPATCH_ID"
 echo "PROGRESS_PATH=$PROGRESS_PATH"
 ```
 
-Capture `DISPATCH_ID` and `PROGRESS_PATH` from Bash output; both are needed for Step 3.5.3 and 3.5.4.
+从 Bash 输出里捕获 `DISPATCH_ID` 和 `PROGRESS_PATH`；Step 3.5.3 和 3.5.4 都要用。
 
-### 3.5.3 Launch the Monitor
+### 3.5.3 启动 Monitor
 
-Immediately after the Bash preparation, launch `Monitor` with:
+Bash 准备完成后立即启动 `Monitor`：
 
 ```
 Monitor script: "tail -F ${PROGRESS_PATH} 2>/dev/null | jq -R --unbuffered -c 'fromjson? | select(.event) | \"[\" + .phase + \"] \" + .role + \" \" + .event + \" — \" + .summary' | awk 'BEGIN{last=\"\";n=0} {if($0==last){n++} else {if(n>1) print last\" (x\"n\")\"; else if(last!=\"\") print last; last=$0; n=1} fflush()} END{if(n>1) print last\" (x\"n\")\"; else if(last!=\"\") print last}'"
 ```
 
-Notes:
-- `tail -F` (capital F) survives the file briefly not existing and re-opens on truncation.
-- `jq --unbuffered` defeats pipe buffering so each JSONL line is flushed as a separate notification. Without `--unbuffered`, jq may batch lines and delay the user-visible relay by several seconds.
-- **`-R` + `fromjson?` (required fault tolerance)**: `-R` reads each line as a raw string and `fromjson?` attempts to parse it — the `?` swallows parse errors per line so unparseable input (garbled debug prints, truncated writes under disk pressure, concurrent interleaving) is silently skipped instead of aborting the whole pipe. Without this, a single malformed line makes jq exit 4 and silently kills the Monitor; all subsequent events are lost. See `docs/testing/subagent-progress-and-execution-model.md` Case 1.2 / 1.2b for the failure mode this guards against.
-- `select(.event)` further filters out parsed-but-incomplete rows (valid JSON but missing `event` field).
-- **awk consecutive-collapse filter (DEC-007 §3.4 bottom-layer guard)**: the trailing `awk` folds CONSECUTIVE identical lines only (not global uniq); guards against source-side drift without suppressing valid repeated phase tags separated by other events. Emits `<line> (xN)` when a run of ≥2 identical lines ends; `fflush()` after each print preserves per-line delivery to Claude Code's Monitor (matches the `--unbuffered` intent upstream). DEC-007 source-side content policy (in each agent's `## Progress Reporting → Content Policy`) is the primary defence; the awk layer is a cheap safety net.
-- The formatted output becomes the "Real-time progress stream" line documented below the Phase Matrix.
+注意事项：
+- `tail -F`（大写 F）在文件短暂不存在时不会退出，文件被 truncate 时会重新打开。
+- `jq --unbuffered` 破解 pipe 缓冲，使每个 JSONL 行作为独立 notification 刷出。没有 `--unbuffered` 时，jq 可能批处理行、让用户可见的中继延迟数秒。
+- **`-R` + `fromjson?`（必需的容错）**：`-R` 按 raw string 读每行，`fromjson?` 尝试解析；`?` 吞掉单行解析错误，使不可解析的输入（乱码 debug 输出、磁盘压力下的截断写、并发交织）被静默跳过，而不是整个 pipe 中止。没有它，单个畸形行就会让 jq 以 exit 4 退出、静默杀掉 Monitor，后续事件全部丢失。失效模式详见 `docs/testing/subagent-progress-and-execution-model.md` Case 1.2 / 1.2b。
+- `select(.event)` 进一步过滤掉「JSON 合法但缺 `event` 字段」的残缺行。
+- **awk consecutive-collapse 过滤（DEC-007 §3.4 底层保障）**：尾部 awk 只折叠**连续**相同行（不是全局 uniq）；防范源端飘移，同时不会误伤「被其他事件分隔的重复 phase 标签」这一合法情形。当一段 ≥2 行的连续相同内容结束时，emit `<line> (xN)`；每次 print 后 `fflush()` 保留逐行交付给 Claude Code Monitor 的语义（与上游 `--unbuffered` 意图一致）。DEC-007 的源端 content policy（写在各 agent 的 `## Progress Reporting → Content Policy`）是主防线；awk 层是廉价的安全网。
+- 格式化后的输出即 Phase Matrix 下方所说的「实时进度流」行。
 
-### 3.5.4 Inject 4 variables into the Task prompt
+### 3.5.4 向 Task prompt 注入 4 个变量
 
-Every `Task` call dispatched after Step 3.5.3 MUST inject these 4 variables into the subagent prompt (in addition to the regular context variables from Step 0):
+Step 3.5.3 之后派发的每个 `Task` 调用**必须**在 subagent prompt 里注入以下 4 个变量（在 Step 0 的常规 context 变量之外）：
 
-| Variable | Source | Used by subagent |
-|----------|--------|------------------|
-| `progress_path` | `$PROGRESS_PATH` from Step 3.5.2 | `Bash echo '{...}' >> {{progress_path}}` at every phase boundary |
-| `dispatch_id` | `$DISPATCH_ID` from Step 3.5.2 | included as `dispatch_id` JSON field in every emitted event |
-| `slug` | from Step 3 (Slug + Artifact Handoff) | included as `slug` JSON field |
-| `role` | the dispatched subagent role (`developer` / `tester` / `reviewer` / `dba` / `research`) | included as `role` JSON field |
+| 变量 | 来源 | subagent 用途 |
+|------|------|----------------|
+| `progress_path` | Step 3.5.2 的 `$PROGRESS_PATH` | 在每个 phase 边界 `Bash echo '{...}' >> {{progress_path}}` |
+| `dispatch_id` | Step 3.5.2 的 `$DISPATCH_ID` | 作为 `dispatch_id` JSON 字段出现在每条 emit |
+| `slug` | Step 3（Slug + Artifact Handoff） | 作为 `slug` JSON 字段 |
+| `role` | 被派发的 subagent 角色（`developer` / `tester` / `reviewer` / `dba` / `research`） | 作为 `role` JSON 字段 |
 
-The subagent's `## Progress Reporting` section handles the emit format; the orchestrator is only responsible for the 4-variable injection.
+subagent 的 `## Progress Reporting` section 处理 emit 格式；orchestrator 只负责注入这 4 个变量。
 
-### 3.5.5 Lifecycle & cleanup
+### 3.5.5 生命周期与清理
 
-- `Monitor` runs in the background for the duration of the dispatch. When the `Task` call returns, `tail -F` idles (no new writes); the Monitor instance can be left to expire naturally, or explicitly torn down with `MonitorStop` if the orchestrator is about to dispatch another subagent and wants a clean channel. Default: let it expire.
-- Progress files accumulate under `/tmp/roundtable-progress/`; rely on OS tmpfiles.d cleanup (DEC-004 §3.5). Plugin does not gc.
+- `Monitor` 在派发期间后台运行。`Task` 调用返回后 `tail -F` 空闲（无新写入）；Monitor 实例可让其自然过期，或者在 orchestrator 即将派发下一个 subagent 希望保持干净通道时用 `MonitorStop` 显式停掉。默认策略：任其自然过期。
+- Progress 文件累积在 `/tmp/roundtable-progress/`；依赖 OS tmpfiles.d 清理（DEC-004 §3.5）。Plugin 本身不做 gc。
 
-### 3.5.6 Parallel-dispatch safety
+### 3.5.6 并行派发安全性
 
-Per DEC-004 §3.7 and DEC-002 §4 parallel dispatch rules, each parallel `Task` gets its own `DISPATCH_ID` → its own `PROGRESS_PATH` → its own `Monitor`. The 4 conditions of the parallel decision tree hold:
+按 DEC-004 §3.7 和 DEC-002 §4 并行派发规则，每个并行 `Task` 都有自己的 `DISPATCH_ID` → 自己的 `PROGRESS_PATH` → 自己的 `Monitor`。并行判定树的 4 个条件全部成立：
 
-1. **PREREQ MET** — progress files only append, no pre-existing state required.
-2. **PATH DISJOINT** — per-dispatch filename (`${SESSION_ID}-${DISPATCH_ID}.jsonl`) guarantees disjoint file sets.
-3. **SUCCESS-SIGNAL INDEPENDENT** — each `Monitor` watches a distinct file; its notifications are scoped to one `dispatch_id`.
-4. **RESOURCE SAFE** — no shared lock on `/tmp/roundtable-progress/`; concurrent `tail -F` on distinct files is OS-level safe.
+1. **PREREQ MET** —— progress 文件只 append，无需任何预先状态。
+2. **PATH DISJOINT** —— 按派发的文件名（`${SESSION_ID}-${DISPATCH_ID}.jsonl`）保证不相交。
+3. **SUCCESS-SIGNAL INDEPENDENT** —— 每个 `Monitor` 监视独立文件；其 notification 归属唯一 `dispatch_id`。
+4. **RESOURCE SAFE** —— `/tmp/roundtable-progress/` 无共享锁；并发 `tail -F` 不同文件在 OS 层面安全。
 
-Parallel dispatches therefore produce interleaved notifications in the user's stream, each prefixed with `role` and tagged by `phase` — the `dispatch_id` is preserved in the underlying JSONL for debug / audit but not rendered in the default format.
-
----
-
-## Step 4: Parallel Dispatch Decision Tree
-
-The orchestrator MAY dispatch multiple subagents in parallel when ALL of the following hold. When any fails, dispatch sequentially.
-
-1. **PREREQ MET** — Both candidates have their `前置` from the exec-plan already satisfied (prior phases complete or artifacts in place).
-2. **PATH DISJOINT** — The candidates write to disjoint file sets (e.g., one phase writes `moduleA/`, another writes `moduleB/` — no path overlap).
-3. **SUCCESS-SIGNAL INDEPENDENT** — Each candidate has its own success signals (lint / test checkpoint) that do not depend on the other candidate's output.
-4. **RESOURCE SAFE** — Combined parallel work does not trip rate limits, lockfiles, or shared tool single-writer constraints (e.g., only one process may hold the test DB).
-
-Default: sequential. Escalate to parallel only when all four rules hold AND the speedup is material (> 30% expected time reduction).
-
-When dispatching in parallel: issue the Task calls in ONE assistant message so they run concurrently.
-
-**Exec-plan checkbox writes are serialized.** Even in parallel dispatches, the orchestrator writes checkboxes back to the plan file. Developers report completed items in their final message; the orchestrator updates the file. This prevents races on the shared exec-plan markdown.
+因此，并行派发在用户的进度流里产生交织 notification，每条都带 `role` 前缀和 `phase` 标签 —— `dispatch_id` 在底层 JSONL 里保留用于 debug / audit，但默认格式不渲染。
 
 ---
 
-## Step 5: Subagent Escalation Handling
+## Step 4: 并行派发判定树
 
-Agents cannot invoke `AskUserQuestion` inside the Task sandbox. When an `<escalation>` block appears in the agent's final report, the orchestrator MUST:
+当下列条件**全部**成立时，orchestrator **可以**并行派发多个 subagent；任一条件失败则串行派发。
 
-1. **Parse** the JSON block (`type` / `question` / `context` / `options` / `remaining_work`).
-2. **Invoke `AskUserQuestion`** with the options. Each option's description carries `rationale` + `tradeoff`. Flag the `recommended: true` option with a `★` marker and its `why_recommended` reason.
-3. **On user answer**: re-dispatch the SAME agent with the decision fact injected into the prompt, scoped to the `remaining_work` listed in the escalation.
-4. **Never decide on behalf of the user.** If the agent did not recommend an option, pick nothing — pass the decision through.
+1. **PREREQ MET** —— 两个候选的 exec-plan `前置` 均已就绪（前置阶段完成或产物已在位）。
+2. **PATH DISJOINT** —— 候选写入的文件集合不相交（例如一个阶段写 `moduleA/`、另一个写 `moduleB/`，路径无重叠）。
+3. **SUCCESS-SIGNAL INDEPENDENT** —— 每个候选有各自独立的成功信号（lint / test checkpoint），不依赖对方产出。
+4. **RESOURCE SAFE** —— 合并的并行工作不会触发 rate limit、lockfile 或共享工具的 single-writer 约束（例如测试 DB 同一时刻只能一个进程持有）。
 
-Parsing rules:
-- One `<escalation>` block per dispatch. Multiple suggests the dispatch was poorly scoped; split the task.
-- If the block is malformed (missing required fields), echo the error back to the agent and ask for a corrected block; do not forward to the user yet.
-- Distinguish **escalation** (expected user input; continue unblocked work) from **abort** (missing prerequisite; stop and fix the dispatch).
+默认策略：串行。仅当 4 条规则全部满足**且**加速效果显著（预期时间节省 > 30%）时升级为并行。
 
-See each agent's `## Escalation Protocol` section for the block format.
+并行派发时：在同一 assistant message 里发出所有 Task 调用，让它们并发运行。
+
+**Exec-plan checkbox 写入保持串行。**即便并行派发，orchestrator 依然负责把 checkbox 写回 plan 文件。Developer 在 final message 报告已完成项，orchestrator 来更新文件。这避免了对共享 exec-plan markdown 的 race。
 
 ---
 
-## Step 6: Execution Rules
+## Step 5: Subagent Escalation 处理
 
-1. **Phase gating taxonomy (DEC-006)**: every phase transition falls into one of three categories; gating behavior is determined by category.
+Subagent 在 Task sandbox 内无法调用 `AskUserQuestion`。当 agent 的 final report 出现 `<escalation>` block 时，orchestrator **必须**：
 
-   - **A. producer-pause** — phase ends with user-consumable artifacts. Stages: Research (analyst) / Design (architect Draft) / Closeout (Stage 9). Orchestrator emits a 3-line summary and **stops, invoking no tools**, waiting for the user's next message:
+1. **Parse** JSON block（`type` / `question` / `context` / `options` / `remaining_work`）。
+2. **调用 `AskUserQuestion`** 带上这些 options。每个选项 description 携带 `rationale` + `tradeoff`。`recommended: true` 的选项用 `★` 标记并附 `why_recommended` 原因。
+3. **用户回答后**：用决策事实注入 prompt 重新派发**同一个** agent，scope 限定为 escalation 里列出的 `remaining_work`。
+4. **绝不替用户决策。** 如果 agent 未给出 recommended option，不要擅自选 —— 把决策直接转给用户。
+
+Parsing 规则：
+- 每个派发最多一个 `<escalation>` block。出现多个说明派发 scope 粗糙；拆任务。
+- 若 block 格式不对（缺必填字段），把错误回传给 agent 要求重新给出修正后的 block；**先不要**转给用户。
+- 区分 **escalation**（预期用户输入；同时继续未阻塞的工作）与 **abort**（缺前置条件；停下并修派发）。
+
+block 格式见各 agent 的 `## Escalation Protocol` section。
+
+---
+
+## Step 6: 执行规则
+
+1. **Phase gating 分类（DEC-006）**：每个 phase transition 归入三类之一；gating 行为由类别决定。
+
+   - **A. producer-pause** —— phase 以用户可消费产物作为结尾。阶段：Research（analyst）/ Design（architect Draft）/ Closeout（Stage 9）。Orchestrator 给出 3 行 summary 并**停下，不再调用任何工具**，等待用户下一条消息：
      ```
      ✅ <role> 完成。
      产出：
@@ -260,15 +271,15 @@ See each agent's `## Escalation Protocol` section for the block format.
      - <path2> — <desc>
      请阅读后告诉我：`go` / `调范围: ...` / 问题
      ```
-     User drives advancement via free-text: `go` / `继续` advances; `问: …` stays in FAQ (orchestrator answers directly or appends to the artifact's FAQ section per that role's convention); `调: …` re-dispatches the same role with expanded scope under the same slug; `停` aborts the workflow, leaving the Phase Matrix at the current stage.
+     用户通过自由文本驱动推进：`go` / `继续` 推进；`问: …` 留在 FAQ（orchestrator 直接回答，或按该角色惯例追加到 artifact 的 FAQ section）；`调: …` 在同一 slug 下以扩展的 scope 重新派发同一角色；`停` 中止 workflow，Phase Matrix 停留在当前阶段。
 
-   - **B. approval-gate** — hard directional lock. The ONLY B-class transition is Design confirmation (Stage 4). Orchestrator MUST invoke `AskUserQuestion` with options following the Option Schema (`feedback_askuserquestion_options`): Accept / Modify <specific part> / Reject / etc. Each option carries `rationale` + `tradeoff` + optional `recommended`. User's choice determines whether to advance to Implementation, re-dispatch architect, or abort.
+   - **B. approval-gate** —— 强方向性锁。**唯一**的 B 类 transition 是 Design confirmation（Stage 4）。Orchestrator **必须**按 Option Schema（`feedback_askuserquestion_options`）调用 `AskUserQuestion` 给出选项：Accept / Modify <具体部分> / Reject / 等等。每个选项带 `rationale` + `tradeoff` + 可选的 `recommended`。用户选择决定是推进到 Implementation、重新派发 architect，还是 abort。
 
-   - **C. verification-chain** — internal machine/AI handoff with no user decision point. Stages: context-detect → analyst, design-confirm accepted → developer, developer → tester, tester → reviewer, reviewer → closeout, dba → closeout. Orchestrator **auto-advances**, emitting a single-line handoff notice (e.g., `🔄 developer 完成 → dispatching tester (critical_modules hit: [...])`). `critical_modules`-driven mandatory tester/reviewer dispatches remain in C (mechanical, CLAUDE.md pre-authorizes it; the handoff notice annotates `(critical_modules hit: ...)` for transparency). Critical findings / `<escalation>` blocks / lint+test failures still interrupt immediately per Step 5 and Step 6 rules 5–6. Before emitting the C-class handoff notice, the orchestrator MUST scan the subagent's final message for `<escalation>` tags; if present, suspend auto-advance and route through Step 5.
+   - **C. verification-chain** —— 内部机器 / AI 交接，无用户决策点。阶段：context-detect → analyst、design-confirm accepted → developer、developer → tester、tester → reviewer、reviewer → closeout、dba → closeout。Orchestrator **自动推进**，emit 一行交接提示（如 `🔄 developer 完成 → dispatching tester (critical_modules hit: [...])`）。`critical_modules` 驱动的强制 tester / reviewer 派发仍属 C 类（机械性动作，CLAUDE.md 已预先授权；交接提示中加注 `(critical_modules hit: ...)` 以保持透明）。Critical findings / `<escalation>` block / lint+test 失败依然按 Step 5 和 Step 6 第 5–6 条立即打断。在发出 C 类交接提示前，orchestrator **必须**扫描 subagent final message 中的 `<escalation>` 标签；若存在则暂停自动推进，走 Step 5。
 
-   **Phase Matrix → category mapping**:
+   **Phase Matrix → category 映射**：
 
-   | Stage | Role | Category |
+   | 阶段 | 角色 | 类别 |
    |---|---|---|
    | 1. Context detection | inline | C |
    | 2. Research | analyst | A |
@@ -280,124 +291,124 @@ See each agent's `## Escalation Protocol` section for the block format.
    | 8. DB review | dba | C |
    | 9. Closeout | user | A |
 
-   See `{docs_root}/design-docs/phase-transition-rhythm.md` and DEC-006 for full rationale.
+   完整 rationale 见 `{docs_root}/design-docs/phase-transition-rhythm.md` 和 DEC-006。
 
-2. **In-phase decisions**: when an active skill encounters a user-decision point, invoke `AskUserQuestion` IMMEDIATELY following the skill's `## AskUserQuestion Option Schema`. Do not accumulate decisions for a batch ask.
+2. **In-phase 决策**：正在运行的 skill 遇到用户决策点时，**立即**按该 skill 的 `## AskUserQuestion Option Schema` 调用 `AskUserQuestion`。不要把决策攒起来批量问。
 
-3. **plan-then-execute**:
-   - **architect**: three-phase flow (explore → land design-docs → optional exec-plan). See `skills/architect.md`.
-   - **developer**: medium / large tasks output an implementation plan for user confirmation BEFORE coding (small tasks may skip).
-   - **tester**: medium / large tasks output a test plan for user confirmation BEFORE coding (small tasks may skip).
+3. **plan-then-execute**：
+   - **architect**：三阶段流（explore → land design-docs → 可选 exec-plan）。见 `skills/architect.md`。
+   - **developer**：中 / 大任务在编码前输出实现计划让用户确认（小任务可跳过）。
+   - **tester**：中 / 大任务在编码前输出测试计划让用户确认（小任务可跳过）。
 
-4. **Role forms**:
-   - `architect` / `analyst` are **skills** (main session; `AskUserQuestion` available) — activate via the `Skill` tool.
-   - `developer` / `tester` / `reviewer` / `dba` are **agents** (subagent isolation; `AskUserQuestion` disabled) — dispatch via the `Task` tool; inject `target_project` / `docs_root` / `lint_cmd` / `test_cmd` / `critical_modules` / `slug` / `primary_lang` into every dispatch prompt.
+4. **角色形态**：
+   - `architect` / `analyst` 是 **skill**（主会话；可用 `AskUserQuestion`）—— 通过 `Skill` 工具激活。
+   - `developer` / `tester` / `reviewer` / `dba` 是 **agent**（subagent 隔离；`AskUserQuestion` 不可用）—— 通过 `Task` 工具派发；每次派发 prompt 都注入 `target_project` / `docs_root` / `lint_cmd` / `test_cmd` / `critical_modules` / `slug` / `primary_lang`。
 
-5. **After developer**: run `lint_cmd` and `test_cmd` against target-project. Failures are reported to the user; the orchestrator does not silently re-dispatch to fix.
+5. **developer 完成后**：对目标项目跑 `lint_cmd` 和 `test_cmd`。失败时向用户报告；orchestrator **不**静默重派修复。
 
-6. **Tester finds business bugs**: tester writes a reproduction test, reports via `<escalation>`, and does NOT fix business code. Orchestrator surfaces the bug to the user, who decides whether to dispatch a bug-fix sub-dispatch (typically via `/roundtable:bugfix`).
+6. **Tester 发现业务 bug**：tester 写复现测试、通过 `<escalation>` 上报，**不**修业务代码。Orchestrator 把 bug 报告给用户，由用户决定是否派发 bug-fix 子派发（典型通过 `/roundtable:bugfix`）。
 
-7. **Handling escalations**: see Step 5.
+7. **处理 escalation**：见 Step 5。
 
-8. **No autonomous git operations**: `git commit` / `push` / `branch` / `tag` / `reset` / `stash` only when the user explicitly asks. Default: leave everything in the working tree. Staging (`git add`) for committing is likewise user-triggered.
+8. **不自动执行 git 操作**：`git commit` / `push` / `branch` / `tag` / `reset` / `stash` 只在用户显式要求时执行。默认：所有改动留在 working tree。Staging（`git add`）同样由用户触发。
 
 ---
 
-## Step 6b: Developer Form Selection (DEC-005)
+## Step 6b: Developer Form Selection（DEC-005）
 
-The `developer` role supports two execution forms per DEC-005: `subagent` (DEC-001 D8 default) and `inline` (main-session execution of `agents/developer.md`). `tester` / `reviewer` / `dba` / `research` remain subagent-only (DEC-005 explicitly does not extend the dual-form pattern to them). This Step runs **immediately before** every developer dispatch.
+按 DEC-005，`developer` 角色支持两种执行形态：`subagent`（DEC-001 D8 默认）和 `inline`（在主会话 inline 执行 `agents/developer.md`）。`tester` / `reviewer` / `dba` / `research` 保持 subagent-only（DEC-005 明确不把 dual-form 推广给它们）。本 Step 在每次 developer 派发**之前**执行。
 
-### 6b.1 Default form
+### 6b.1 默认形态
 
-**Default = `subagent`** (preserves DEC-001 D8 role→form mapping). Switching to `inline` requires one of the three triggers in §6b.2 to fire.
+**默认 = `subagent`**（保留 DEC-001 D8 的 role→form 映射）。切到 `inline` 需要 §6b.2 三个触发条件之一命中。
 
-### 6b.2 Three-level switch triggers (DEC-005 §3.4.2)
+### 6b.2 三级切换触发器（DEC-005 §3.4.2）
 
-Evaluate in order; the first matching trigger wins.
+按顺序评估；第一个匹配的触发器胜出。
 
-1. **Per-session (user prompt)** — the user's current task description, or an earlier message in the same session, explicitly asks for inline:
-   - Marker phrases: `@roundtable:developer inline`, `developer 用 inline`, `this developer task inline`, or natural-language equivalents the orchestrator recognizes.
-   - Effect: force `form = inline` for this dispatch. No AskUserQuestion.
+1. **Per-session（用户 prompt）** —— 用户当前任务描述、或本 session 内早期消息明确要求 inline：
+   - 关键短语：`@roundtable:developer inline`、`developer 用 inline`、`this developer task inline`，或 orchestrator 能识别的等价自然语言。
+   - 效果：本派发强制 `form = inline`。不走 AskUserQuestion。
 
-2. **Per-project (target CLAUDE.md)** — read the `# 多角色工作流配置` section (already parsed in Step 0) for the optional key:
+2. **Per-project（target CLAUDE.md）** —— 读取 `# 多角色工作流配置` section（Step 0 已解析）里的可选 key：
    ```markdown
-   developer_form_default: inline    # or: subagent
+   developer_form_default: inline    # 或：subagent
    ```
-   If present, use its value as the baseline. If absent, baseline stays `subagent`. Per-session (level 1) still overrides per-project (level 2).
+   若存在，用其值作为 baseline。若缺失，baseline 保持 `subagent`。Per-session（level 1）仍然覆盖 per-project（level 2）。
 
-3. **Per-dispatch (AskUserQuestion)** — when neither of the above applies, invoke `AskUserQuestion` before dispatch. Build options following the architect's Option Schema (`rationale` + `tradeoff` + `recommended`). Choose the recommendation by the "small task signal" heuristic:
-   - **Small task markers** (any one): single-file change, bug hotfix, estimated < 2 min wall time, estimated < 20k total tokens, strictly inside one module.
-   - If small-task markers present → set `recommended: true` on the `inline` option.
-   - Otherwise → set `recommended: true` on the `subagent` option.
+3. **Per-dispatch（AskUserQuestion）** —— 前两条都不适用时，派发前调用 `AskUserQuestion`。按 architect 的 Option Schema 构造选项（`rationale` + `tradeoff` + `recommended`）。用「小任务信号」启发式选 recommended：
+   - **小任务标志**（满足任一即可）：单文件改动、bug hotfix、预估 wall time < 2 min、预估总 token < 20k、严格限于一个模块内。
+   - 命中小任务标志 → `inline` 选项设 `recommended: true`。
+   - 否则 → `subagent` 选项设 `recommended: true`。
 
-   Example options payload:
+   选项示例 payload：
    ```
    Option A: inline
      rationale: "Small task (1 file, bug hotfix) — inline keeps decisions visible and AskUserQuestion available."
      tradeoff:  "Pollutes main-session context with developer's reads/edits."
-     recommended: true   # when small-task markers present
+     recommended: true   # 命中小任务标志时
    Option B: subagent
      rationale: "Isolates developer's context and enables parallel dispatch."
      tradeoff:  "Progress only via phase-level events (DEC-004); interactive decisions gated through <escalation>."
-     recommended: true   # when task is not small
+     recommended: true   # 任务不小时
    ```
-   The user's answer is final; the orchestrator never overrides the user choice.
+   用户回答是最终决定；orchestrator 绝不覆盖用户选择。
 
-### 6b.3 Execution paths
+### 6b.3 执行路径
 
-Once `form` is decided:
+`form` 决定后：
 
-**Form = `inline`** (small / single-file / hotfix path):
-- Orchestrator `Read`s `agents/developer.md` and executes its instructions **in the main session** (same mechanism as the `architect` and `analyst` skills).
-- `AskUserQuestion` is directly available to the developer flow — no `<escalation>` indirection.
-- **Do NOT run Step 3.5** for this dispatch (no `progress_path`, no `Monitor`, no 4-variable injection). The main session observes the developer flow directly; progress relay is redundant.
-- Resource Access constraints match the subagent form (`agents/developer.md` Resource Access matrix applies identically; see DEC-005 decision #7).
-- `<escalation>` blocks are not needed; decisions go through `AskUserQuestion` inline.
+**Form = `inline`**（小 / 单文件 / hotfix 路径）：
+- Orchestrator `Read` `agents/developer.md` 并**在主会话中**执行其指令（与 `architect` 和 `analyst` skill 相同机制）。
+- `AskUserQuestion` 对 developer 流直接可用 —— 无需 `<escalation>` 间接路径。
+- 本派发**不**执行 Step 3.5（无 `progress_path`、无 `Monitor`、不注入 4 变量）。主会话直接观察 developer 流；progress 中继是冗余。
+- Resource Access 约束与 subagent 形态一致（`agents/developer.md` Resource Access matrix 原样适用；见 DEC-005 decision #7）。
+- 不需要 `<escalation>` block；决策通过 inline 的 `AskUserQuestion` 完成。
 
-**Form = `subagent`** (default path):
-- Run Step 3.5 (Progress Monitor Setup) first.
-- Dispatch via `Task` with the subagent prompt carrying the 4 progress injection variables plus the regular Step 0 context.
-- Developer's `## Progress Reporting` section handles phase-boundary emits; `<escalation>` handles user-decision points per Step 5.
+**Form = `subagent`**（默认路径）：
+- 先执行 Step 3.5（Progress Monitor Setup）。
+- 用 `Task` 派发，subagent prompt 中带上 4 个 progress 注入变量以及 Step 0 的常规 context。
+- Developer 的 `## Progress Reporting` section 处理 phase 边界 emit；`<escalation>` 按 Step 5 处理用户决策点。
 
-### 6b.4 tester / reviewer / dba / research remain subagent-only
+### 6b.4 tester / reviewer / dba / research 保持 subagent-only
 
-Per DEC-005, do NOT offer an inline form for `tester`, `reviewer`, `dba`, or `research`:
-- Their contexts are large (adversarial test suites / full-repo review / cross-schema DB analysis / fan-out research) and inline execution would pollute or exhaust main-session context.
-- These four roles always go through `Task` dispatch and always receive the 4 progress variables from Step 3.5.
-- The per-project `developer_form_default` key in CLAUDE.md applies ONLY to developer. Ignore any user attempt to set analogous keys for the other three roles — this is a DEC-005 boundary.
+按 DEC-005，**不要**给 `tester`、`reviewer`、`dba`、`research` 提供 inline 形态：
+- 它们的 context 体量大（对抗性测试套件 / 全仓审查 / 跨 schema DB 分析 / fan-out 调研），inline 执行会污染或耗尽主会话 context。
+- 这 4 个角色永远走 `Task` 派发，永远从 Step 3.5 接收 4 个 progress 变量。
+- CLAUDE.md 里的 `developer_form_default` 键**只**对 developer 生效。用户尝试给其他三个角色设同类 key 要忽略 —— 这是 DEC-005 边界。
 
-### 6b.5 Form selection audit trail
+### 6b.5 Form 选择的 audit trail
 
-When form resolves to `inline`, include one-line note in the phase-gate summary: `Developer dispatched inline (trigger: <per-session | per-project | per-dispatch user choice>)`. This keeps the user informed that the usual subagent-boundary isolation was relaxed for this task.
+当 form 解析为 `inline` 时，在 phase-gate summary 里加一行：`Developer dispatched inline (trigger: <per-session | per-project | per-dispatch user choice>)`。这让用户知道本任务放宽了通常的 subagent 边界隔离。
 
 ---
 
-## Step 7: Index Maintenance (batched)
+## Step 7: Index Maintenance（批量）
 
-When a role creates new artifacts under `{docs_root}/` (`analyze/` / `design-docs/` / `exec-plans/` / `api-docs/` / `testing/` / `reviews/`), the orchestrator owns the `{docs_root}/INDEX.md` update. Roles do NOT edit `INDEX.md` directly — same serialization pattern as exec-plan checkboxes (DEC-002 shared-resource protocol).
+当角色在 `{docs_root}/` 下（`analyze/` / `design-docs/` / `exec-plans/` / `api-docs/` / `testing/` / `reviews/`）创建新 artifact 时，`{docs_root}/INDEX.md` 的维护归 orchestrator。角色**不**直接编辑 `INDEX.md` —— 和 exec-plan checkbox 是同一类串行化模式（DEC-002 shared-resource protocol）。
 
-**Batching rule**: Do NOT update `INDEX.md` after every subagent return. Accumulate new-file reports across the phase and update the index **once per phase gate** (before reporting phase summary to the user), or at workflow completion. This keeps token overhead to a single Read + Edit cycle per phase, not per subagent.
+**Batching 规则**：**不要**在每次 subagent 返回后都更新 `INDEX.md`。在 phase 内累积新文件报告，**每个 phase gate 更新一次** index（在给用户发 phase summary 之前），或者在 workflow 结束时更新。这样 token 开销被控制在"每 phase 一次 Read + Edit"，而非每 subagent 一次。
 
-**DEC-006 C-verification-chain bridging clause**: C-class transitions auto-advance with a 1-line handoff (no user-facing phase-gate summary). To keep `INDEX.md` fresh, the orchestrator MUST run Step 7 (single Read + Edit) **before emitting each C→C handoff notice**. At the next A-class producer-pause (including Stage 9 Closeout) the final flush covers any still-pending entries. This preserves the "single Edit per boundary" cost ceiling while preventing stale-index windows during long C chains.
+**DEC-006 C-verification-chain 过桥条款**：C 类 transition 自动推进，只有一行交接（无面向用户的 phase-gate summary）。为保持 `INDEX.md` 新鲜，orchestrator **必须**在每次 C→C 交接提示发出**之前**执行 Step 7（单次 Read + Edit）。下一个 A 类 producer-pause（包括 Stage 9 Closeout）时的最终 flush 覆盖所有仍待处理的条目。这在保持「每个边界单次 Edit」成本上限的同时，避免了长 C 链中出现 stale-index 窗口。
 
-**Steps**:
+**步骤**：
 
-1. **Collect**: Every role's final report MUST list newly-created files under a `created:` section (not merely in prose). Orchestrator parses this from each `Task` result and from each skill's in-session output.
-2. **Aggregate**: Accumulate `created[]` paths across parallel / sequential subagents within the current phase.
-3. **Sync**: Before the phase-gate summary to the user, `Read` `{docs_root}/INDEX.md` once (or `Grep` for the category-section anchors if large).
-4. **Update**: For each new path, identify its category (`analyze` / `design-docs` / `exec-plans/active` / `exec-plans/completed` / `testing` / `reviews` / `api-docs`) and append one line under the matching `### <category>` subsection. If no such subsection exists yet, create it.
-5. **Single Edit**: One `Edit` call on `INDEX.md` covers all appends for the phase.
-6. **Report**: Include "`INDEX.md` updated with N new entries" in the phase-gate summary.
+1. **Collect**：每个角色的 final report **必须**在 `created:` section 下列出新建文件（不能只出现在散文里）。orchestrator 从每个 `Task` 结果和每个 skill 的 in-session 输出里解析。
+2. **Aggregate**：在当前 phase 内累积所有并行 / 串行 subagent 的 `created[]` 路径。
+3. **Sync**：向用户发 phase-gate summary 之前，`Read` 一次 `{docs_root}/INDEX.md`（文件大时用 `Grep` 找分类 section 锚点）。
+4. **Update**：对每个新路径识别其类别（`analyze` / `design-docs` / `exec-plans/active` / `exec-plans/completed` / `testing` / `reviews` / `api-docs`），在对应 `### <category>` subsection 下 append 一行。若该 subsection 不存在则创建。
+5. **Single Edit**：用一次 `Edit` 覆盖 phase 内所有 append。
+6. **Report**：在 phase-gate summary 里加一句「`INDEX.md` updated with N new entries」。
 
-**Entry format**:
+**条目格式**：
 
 ```
 - [<file>](<relative-path-from-INDEX.md>) — <one-line description>
 ```
 
-Description source priority: artifact frontmatter `description:` → role's report `description:` line → first sentence of the artifact's introduction.
+description 来源优先级：artifact frontmatter 的 `description:` → 角色 report 的 `description:` 行 → artifact 引言首句。
 
-**Role report contract** (for `created:` section):
+**角色 report 契约**（`created:` section）：
 
 ```
 created:
@@ -407,20 +418,20 @@ created:
     description: Adversarial / benchmark plan for feature-x (18 cases)
 ```
 
-**Fallback**: `/roundtable:lint` detects INDEX orphans / broken links as a safety net for missed Step 7 updates (periodic audit, not creation-time enforcement).
+**Fallback**：`/roundtable:lint` 检测 INDEX 孤儿 / 断链，作为 Step 7 遗漏的兜底（周期性审计，不是创建时强约束）。
 
-**Forbidden**: roles never edit `INDEX.md` themselves — writes always routed through orchestrator per DEC-002.
+**Forbidden**：角色从不自行编辑 `INDEX.md` —— 写入始终由 orchestrator 按 DEC-002 转发。
 
 ---
 
-## Starting Point
+## 起点
 
-1. Run Step 0 inline (context detection).
-2. Run Step 1 (task sizing). If ambiguous, `AskUserQuestion`.
-3. Initialize the Phase Matrix (all ⏳).
-4. Activate / dispatch the first role per the size pipeline.
-5. Update the matrix at every phase transition and report it.
-6. Accumulate `created:` paths from each role's report; update `INDEX.md` at phase gates per Step 7.
-7. Obey the rules in Step 6.
+1. 执行 Step 0（inline，context detection）。
+2. 执行 Step 1（任务规模判定）。模糊时 `AskUserQuestion`。
+3. 初始化 Phase Matrix（全部 ⏳）。
+4. 按规模 pipeline 激活 / 派发第一个角色。
+5. 每次 phase transition 更新 matrix 并报告。
+6. 从每个角色的 report 中累积 `created:` 路径；按 Step 7 在 phase gate 更新 `INDEX.md`。
+7. 遵守 Step 6 的规则。
 
-**This command orchestrates only — it does not design, code, or review itself. Delegate all substantive work to the appropriate role.**
+**本 command 只做编排 —— 它自己不做设计 / 编码 / 审查。所有实质性工作都派发给合适的角色。**

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -69,9 +69,11 @@
 - [subagent-progress-and-execution-model.md](testing/subagent-progress-and-execution-model.md) — issue #7 P0.1-P0.10 对抗性测试（30+ case / 34 PASS + 4 FAIL + 18 WARN / 1 Critical escalation：Monitor jq pipe 被单行非 JSON 击穿）
 - [phase-transition-rhythm.md](testing/phase-transition-rhythm.md) — issue #10 DEC-006 三段式对抗测试（2 Critical / 9 Warning / 5 Suggestion；C-01 悬空指针 + C-02 Step 7 与 C 自动前进语义冲突）
 - [progress-content-policy.md](testing/progress-content-policy.md) — issue #14 DEC-007 对抗测试（25 cases：0 Critical / 3 Warning / 4 Suggestion；D1 原 dogfood 刷屏回归修复确认 `(x5)`）
+- [step35-foreground-skip-monitor.md](testing/step35-foreground-skip-monitor.md) — issue #15 DEC-008（workflow §3.5.0 前台派发免 Monitor gate）对抗测试（18 cases：2 Critical / 3 Warning / 1 Suggestion → post-fix 全绿）
 
 ### reviews
 
+- [2026-04-19-step35-foreground-skip-monitor.md](reviews/2026-04-19-step35-foreground-skip-monitor.md) — issue #15 DEC-008 终审 Approve（0 Critical / 0 Warning / 0 new Suggestion / 4 Positive；tester 前轮 2 Critical + 3 Warning + 1 Suggestion 全修复复验通过）
 - [2026-04-19-subagent-progress-and-execution-model.md](reviews/2026-04-19-subagent-progress-and-execution-model.md) — issue #7 终审（Approved with caveats：0 Critical / 3 Warning / 4 Suggestion，5 DEC 对齐 + user north-star 满足度 85%）
 - [2026-04-19-phase-transition-rhythm.md](reviews/2026-04-19-phase-transition-rhythm.md) — issue #10 DEC-006 终审（Approved-with-caveats：0 Critical / 3 Warning / 5 Suggestion；DEC-001~DEC-005 全对齐；2C+W-08 已根因修复）
 - [2026-04-19-progress-content-policy.md](reviews/2026-04-19-progress-content-policy.md) — issue #14 DEC-007 终审（Approve-with-caveats：0 Critical / 2 Warning / 3 Suggestion / 5 Positive；4 agent 逐字对称；推荐 back-feed fflush 到 design-doc §3.4）

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -35,6 +35,30 @@
 
 ---
 
+### DEC-008 workflow Step 3.5 前台派发免 Monitor（修正 DEC-004 触发规则 assumption）
+- **日期**: 2026-04-19
+- **状态**: Accepted
+- **上下文**: issue #15 —— DEC-007 (#14) 会话中发现 DEC-004 §3.6 触发规则 "所有 subagent dispatch 默认开启" 隐含未言明 assumption：所有 Task 派发都是后台派发。dogfood 实录证明：前台 Task（默认 `run_in_background` 缺省 / `false`）主会话阻塞等结果且**子 agent 的 Bash/Read/Edit/Write 工具调用以缩进形式实时显示**在主会话输出里，主会话已天然观察到内部进度；只有后台 Task（`run_in_background: true`）主会话不阻塞且完全看不到 subagent 内部，Monitor 才是唯一进度通道。Step 3.5 当前无差别要求所有派发启 Monitor，对前台派发等于主会话同时收两份信号（Monitor 通知 + 缩进工具流），纯开销且潜在分散注意力
+- **决定**:
+  1. **触发条件收紧**：Step 3.5（progress monitor 启动 + 4 变量注入）从"所有 Task 派发"收紧为"`run_in_background: true` 的 Task 派发"；前台派发完全 skip 整段
+  2. **gate 位置**：`commands/workflow.md` Step 3.5 顶部新增 §3.5.0 "Foreground vs background gate"，先于现有 §3.5.1 env opt-out（gate 失败即 skip 后续所有子步骤；与 env opt-out 同语义层）
+  3. **bugfix 同步**：`commands/bugfix.md` §Step 0.5 加一句 gate 说明（template 引用 workflow.md，无需复制完整模板）
+  4. **不改 5 份 agent prompt 本体**：5 个 subagent 的 §Progress Reporting Fallback 条款（"空 progress_path 静默 skip"）由 DEC-004 落地时已就位，天然兼容本变更
+  5. **DEC-004 标 Superseded by DEC-008**（仅 §3.6 触发规则维度；其余条款仍 Accepted）；保留原文不删，对齐 decision-log 铁律
+  6. **与 DEC-007 正交**：DEC-007 修源端 summary 内容质量（agent prompt §Content Policy）+ orchestrator awk 折叠；DEC-008 修触发条件（commands 层）。两个补丁不重叠、不互依、可分别合并；从两个层次（content vs gate）补 DEC-004 的不同 assumption 漏洞
+  7. **与 DEC-005 同源**：DEC-005 §6b.3 已声明 inline developer 不跑 Step 3.5（"主会话直接观察"），DEC-008 把这条 inline-only 逻辑推广到所有"主会话可观察"的派发 — inline developer 是真子集，前台 Task 是另一子集
+- **备选**:
+  - **保留无差别开启 Monitor**：DEC-004 原状；前台派发的双份信号开销持续，违背"用户掌控感"north-star 的"信号不冗余"细则
+  - **新增 env var `ROUNDTABLE_PROGRESS_FOREGROUND_DISABLE`**：与现有 `ROUNDTABLE_PROGRESS_DISABLE` 语义重复且解释成本翻倍；前台/后台是 dispatch 形态属性而非用户偏好，不该走 env
+  - **改 5 份 agent prompt 加形态自检**：agent 不知派发形态（subagent prompt 不感知 parent 调用参数），无法在源端 gate；orchestrator 层 gate 是唯一可执行点
+  - **Patch DEC-004 §3.6 in place（不开新 DEC）**：违反 decision-log 铁律 "不删除旧条目 / 编号递增"；触发规则变更属于实质性 supersede 范畴
+  - **新增 done event type 区分形态**：与本 DEC 目标无关；DEC-007 已确立 "不扩 DEC-004 event 枚举" 纪律
+- **理由**: (1) gate 在 orchestrator 层是唯一可执行点（agent 不感知 parent 派发参数）；(2) skip 前台派发完全消除双份信号开销且不损失任何观测能力（缩进工具流已经透传）；(3) 不改 agent prompt 本体减少 critical_modules（5 份 agent prompt）改动面，复用 DEC-004 已就位的 fallback 条款；(4) 与 DEC-005 inline developer 的 skip 逻辑同源，心智一致；(5) 与 DEC-007 正交可分别合并，降低集成风险；(6) 走 Superseded 流程而非 in-place patch 保持 decision-log append-only 纪律
+- **相关文档**: docs/design-docs/subagent-progress-and-execution-model.md §3.8（patch 章节）+ §6 变更记录条目、DEC-004（被本 DEC 部分 supersede 的上游协议）、DEC-007（同期 DEC-004 follow-up，正交合并）、DEC-005（inline developer 同源 skip 逻辑）
+- **影响范围**: `commands/workflow.md` §Step 3.5 新增 §3.5.0 gate；`commands/bugfix.md` §Step 0.5 加 gate 说明；`docs/design-docs/subagent-progress-and-execution-model.md` 新增 §3.8 + frontmatter `decisions` 加 DEC-008 + 变更记录条目；`docs/decision-log.md` 本条 + DEC-004 状态行追加 "（§3.6 触发规则 Superseded by DEC-008）"；`docs/log.md` 新增合并条目。**不改** 5 份 agent prompt 本体；**不改** DEC-004 event schema；**不改** Monitor 工具；**不改** target CLAUDE.md
+
+---
+
 ### DEC-007 subagent progress content policy（#7 dogfood 刷屏 follow-up）
 - **日期**: 2026-04-19
 - **状态**: Accepted
@@ -111,7 +135,7 @@
 
 ### DEC-004 subagent progress event protocol（P1 push 模型）
 - **日期**: 2026-04-19
-- **状态**: Accepted
+- **状态**: Accepted（决定第 6 项「触发规则」Superseded by DEC-008 — 改为 `run_in_background: true` 派发才开启；其余条款仍 Accepted）
 - **上下文**: issue #7 问题 A —— P4 dogfood 实录证实 subagent 长任务（3-10+ 分钟）期间主会话无反馈，用户失去对流程的掌控感。Claude Code 原生 `/agents` Running tab、transcript JSONL、Ctrl+B 提供**用户侧**观察通道，但 orchestrator LLM 对 subagent 内部**系统性**不可见（官方 "intermediate tool calls … only its final message returns to the parent"）
 - **决定**:
   1. **push 模型**（非 pull）：subagent 在 phase 边界主动 append JSON event 到共享文件；orchestrator `Monitor` tail。对比 pull 模型（周期 Read transcript）的关键收益：事件驱动（无空 poll）、官方架构对齐（Claude Code Agent 工具 description 明确建议"do NOT poll"）、与 DEC-002 Escalation JSON 同一范式

--- a/docs/design-docs/subagent-progress-and-execution-model.md
+++ b/docs/design-docs/subagent-progress-and-execution-model.md
@@ -4,7 +4,7 @@ source: analyze/subagent-progress-and-execution-model.md
 created: 2026-04-19
 updated: 2026-04-19
 status: Accepted
-decisions: [DEC-004, DEC-005]
+decisions: [DEC-004, DEC-005, DEC-008]
 supersedes: []
 orthogonal_to: [DEC-001 D8, DEC-002, DEC-003]
 issue: https://github.com/duktig666/roundtable/issues/7
@@ -261,6 +261,29 @@ progress 机制**不破坏**并行派发四条件：
 3. SUCCESS-SIGNAL INDEPENDENT — Monitor notification 按 dispatch_id 路由
 4. RESOURCE SAFE — `/tmp/roundtable-progress/` 无锁文件；多 Monitor 并发 tail 不同文件 OS 级支持
 
+### 3.8 Foreground vs background dispatch gate（DEC-008 patch）
+
+DEC-004 决定第 6 项「触发规则」原文 "所有 subagent dispatch 默认开启" 隐含一个未言明的 assumption：所有 `Task` 派发都是后台派发（`run_in_background: true`），主会话对 subagent 内部不可见。issue #15 dogfood 实录证明该 assumption 不成立：
+
+| 派发形态 | 主会话观测能力 | Monitor 必要性 |
+|---------|---------------|---------------|
+| **前台 Task**（currently the Claude Code default；`run_in_background` 缺省 / `false`） | 主会话阻塞等结果；子 agent 的 Bash/Read/Edit/Write 工具调用以**缩进形式实时显示**在主会话输出里 | ❌ 冗余 — Monitor 通知 + 缩进工具流，主会话收两份信号 |
+| **后台 Task**（`run_in_background: true`） | 主会话不阻塞，**完全看不到** subagent 内部工具调用 | ✅ 必须 — 唯一的 phase 级进度通道 |
+
+DEC-004 §3.1 motivation —— "orchestrator LLM 对 subagent 内部**系统性**不可见" —— 仅对后台派发严格成立；前台派发的不可见是 LLM 注意力问题（缩进流过长易失焦），不是 systemic blindness。
+
+**DEC-008 决定**：Step 3.5（progress monitor 启动 + 4 变量注入）的触发条件从"所有 Task 派发"收紧为"`run_in_background: true` 的 Task 派发"。前台派发完全 skip 该 Step（无 `progress_path`、无 Monitor、无 4 变量注入）。subagent 收到空 `progress_path` 时按 §3.2 末句 "漏 echo 时降级为静默" 条款（结构化骨架 + FAQ Q2）静默 — 该 fallback 在 DEC-004 落地时已就位，本 DEC 不需要改 5 份 agent prompt 本体。
+
+**并行派发语义**：`run_in_background` 是 per-`Task`-call 参数。orchestrator 在同一 assistant message 中 issue 多个 `Task` 调用时（DEC-002 §4 并行派发），**逐个 Task 调用独立评估 §3.5.0 gate**。混合批（如 1 前台 + 2 后台）产生 2 个 Monitor / 2 个 `progress_path`，不是 3 个。
+
+**实现位置**：
+- `commands/workflow.md` Step 3.5 顶部新增 §3.5.0 "Foreground vs background gate"，先于 §3.5.1 env opt-out 检查（gate 失败直接 skip 整段；§3.5.1 仅在 gate 通过后运行）
+- `commands/bugfix.md` Step 0.5 同步加 delta 0（显式枚举 skip 的 4 件事：不生成 progress_path / 不启动 Monitor / 不注入 4 变量 / subagent Fallback 静默）
+
+**与 DEC-007 的正交性**：DEC-007 修源端 summary 内容质量（agent prompt §Content Policy）+ orchestrator awk 折叠；DEC-008 修触发条件（commands 层）。两个补丁不重叠、不互依、可分别合并；它们是从两个层次（content vs gate）补 DEC-004 的不同 assumption 漏洞。
+
+**与 DEC-005 的关系**：DEC-005 §6b.3 已声明 inline developer 不跑 Step 3.5（"主会话直接观察 developer 流程；progress 中继冗余"）。DEC-008 把这条 inline-only 的逻辑推广到所有"主会话可观察"的派发 — inline developer（不走 `Task`）和前台 `Task` 是两条独立 skip 路径，互不重叠：inline 完全不派发 Task，§3.5.0 甚至不会被评估到。两条 skip 的理由同源："主会话已能观察 → Monitor 冗余"。
+
 ---
 
 ## 4. 关键决策与权衡
@@ -333,6 +356,7 @@ plugin 元协议（Accepted）与 CLAUDE.md 声明的关键差别：
 ## 6. 变更记录
 
 - 2026-04-19 创建 — 解 issue #7；落 DEC-004（progress event protocol）+ DEC-005（developer 双形态正交补强 D8）
+- 2026-04-19 新增 §3.8 Foreground vs background gate — 解 issue #15；落 DEC-008（Supersedes DEC-004 决定第 6 项「触发规则」）。前台派发（`run_in_background` 缺省 / `false`）skip Step 3.5 整段，避免主会话同时收 Monitor 通知 + 子 agent 缩进工具流的双份信号。同步补丁 commands/workflow.md §3.5 + commands/bugfix.md §Step 0.5；不改 5 份 agent prompt 本体（§3.2 末句漏发降级条款已兼容）
 - 2026-04-19 §3.3 Monitor 模板鲁棒性修正 — tester 发现单行非 JSON 击穿 jq pipe 导致后续 event 全丢（docs/testing/subagent-progress-and-execution-model.md Case 1.2/1.2b Critical）。把 `jq --unbuffered -c 'select(.event) | ...'` 改为 `jq -R --unbuffered -c 'fromjson? | select(.event) | ...'`：`-R` 读 raw string，`fromjson?` 带问号的 try-parse 在遇到坏行时 silently no-op。同步更新 commands/workflow.md §3.5.3 + commands/bugfix.md §Step 0.5。Smoke 复验：3 合规 + 2 坏行输入 → 3 合规全过，exit 0
 
 ## 7. 待确认项

--- a/docs/log.md
+++ b/docs/log.md
@@ -38,6 +38,21 @@
 
 ---
 
+## review | step35-foreground-skip-monitor | 2026-04-19
+- 操作者: reviewer subagent (critical_modules hit → 必落盘)
+- 影响文件: docs/reviews/2026-04-19-step35-foreground-skip-monitor.md（新建）
+- 说明: issue #15 DEC-008 终审 Approve；tester 2 Critical + 3 Warning + 1 Suggestion 全修复复验通过；0 new finding；5 agent prompt Fallback 未动兼容 / lint 0 命中 / DEC-004 append-only + DEC-007 正交性双向自证
+
+## test-plan | step35-foreground-skip-monitor | 2026-04-19
+- 操作者: tester subagent (critical_modules hit → 必落盘)
+- 影响文件: docs/testing/step35-foreground-skip-monitor.md（新建）
+- 说明: issue #15 DEC-008 对抗测试 18 cases；2 Critical + 3 Warning + 1 Suggestion；T12 §3.2 vs §3.6 引用错位 + T13 §3.7 heading 丢失悬空指针 — 全部 post-fix 落地
+
+## decide | DEC-008 + design patch §3.8 | 2026-04-19
+- 操作者: architect skill (inline)
+- 影响文件: docs/decision-log.md（DEC-008 新增 + DEC-004 状态行追加 §3.6 Superseded 注记）, docs/design-docs/subagent-progress-and-execution-model.md（frontmatter decisions 增列 DEC-008 + 新增 §3.8 Foreground vs background gate + §6 变更记录条目）
+- 说明: 解 issue #15；Step 3.5 触发条件从"所有 Task 派发"收紧为"`run_in_background: true` 派发"；与 DEC-007 正交可分别合并；不改 5 份 agent prompt 本体；待 design-confirm 后派 developer 改 commands/workflow.md + commands/bugfix.md
+
 ## review | progress-content-policy | 2026-04-19
 - 操作者: reviewer subagent (critical_modules hit → 必落盘)
 - 影响文件: docs/reviews/2026-04-19-progress-content-policy.md（新建）

--- a/docs/reviews/2026-04-19-step35-foreground-skip-monitor.md
+++ b/docs/reviews/2026-04-19-step35-foreground-skip-monitor.md
@@ -1,0 +1,116 @@
+---
+slug: step35-foreground-skip-monitor
+reviewer: roundtable:reviewer (final review, issue #15 DEC-008 landing)
+date: 2026-04-19
+verdict: Approve
+critical_modules_hit:
+  - workflow command Phase Matrix + 并行判定树 + phase gating taxonomy (DEC-006)
+  - Progress event JSON schema (DEC-004)
+  - Escalation Protocol / decision-log append-only 铁律
+scope:
+  - commands/workflow.md §3.5.0
+  - commands/bugfix.md §Step 0.5 delta 0
+  - docs/decision-log.md (DEC-008 + DEC-004 status line)
+  - docs/design-docs/subagent-progress-and-execution-model.md (frontmatter + §3.8 + §6)
+  - docs/log.md combined entry
+  - docs/INDEX.md testing entry
+  - docs/testing/step35-foreground-skip-monitor.md
+---
+
+# DEC-008 落地终审：Step 3.5 前台派发免 Monitor
+
+## 0. 审查结论
+
+**Approve**。tester 前轮标记的 2 Critical + 3 Warning + 1 Suggestion 均已根因修复并在本轮复验通过；5 份 agent prompt Fallback 条款未被触碰且语义兼容；lint_cmd 0 命中；decision-log append-only 铁律遵守；与 DEC-004 / DEC-005 / DEC-007 的正交/supersede 关系在 DEC-008 条目与 design-doc §3.8 双向自洽。
+
+## 1. tester 修复复验
+
+| Ref | 原严重度 | 修复点 | 复验结果 |
+|-----|---------|--------|---------|
+| T12 | Critical | design-doc §3.8 引用从"§3.6 漏发降级"改为"§3.2 末句 漏 echo 时降级为静默" | design-docs/subagent-progress-and-execution-model.md:275 "按 §3.2 末句 ... 静默"；§3.2（line 136-158）末段确含 "subagent 遗漏 echo 时降级为'静默'" 条款，引用落点正确 |
+| T13 | Critical | §3.7 标题丢失 → 恢复 `### 3.7 对并行派发判定树（DEC-002 §4）的影响`，§3.8 置于其后 | Grep 显示 `### 3.7` 在 line 255，`### 3.8` 在 line 264，顺序正确；`commands/workflow.md` §3.5.6 / `exec-plans/active/subagent-progress-and-execution-model-plan.md` 对 DEC-004 §3.7 的外部引用不再悬空 |
+| T04 | Warning | §3.5.0 加 "evaluate this gate independently for each `Task` call" | workflow.md:143 "Evaluate this gate independently for each `Task` call — in a mixed parallel batch ... 1 foreground + 2 background ... produces exactly 2 progress_paths / 2 Monitor instances, not 3"，并给出混合批实例，措辞精准 |
+| T09 | Warning | DEC-004 状态行从 "§3.6 触发规则" 改为 "决定第 6 项「触发规则」" | decision-log.md:138 已落地；歧义解除 |
+| T14 | Warning | bugfix delta 0 显式枚举 skip 4 件事 | bugfix.md:34 "(a) do NOT generate DISPATCH_ID / PROGRESS_PATH, (b) do NOT run mkdir -p / touch, (c) do NOT launch Monitor, (d) do NOT inject the 4 progress variables"，与 workflow.md §3.5.0 的显式列举对称 |
+| T15 | Suggestion | "(the default)" → "(currently the Claude Code default)" | workflow.md:146、bugfix.md:34 两处均已更新；与未来 Claude Code 默认行为可能翻转解耦 |
+
+## 2. 本轮独立审查
+
+### 2.1 DEC-008 条目质量
+- 格式：日期/状态/上下文/决定(7)/备选(5)/理由(6)/相关文档/影响范围 齐全，匹配 DEC-007 先例。
+- "决定" 7 条与 "备选" 5 条对 1:1 拒绝理由；"理由" 6 条覆盖 gate 位置 / skip 正确性 / 不改 agent / 与 DEC-005 同源 / 与 DEC-007 正交 / append-only 纪律，逻辑闭环。
+- "影响范围" 明列 "不改 5 份 agent prompt 本体 / 不改 DEC-004 event schema / 不改 Monitor 工具 / 不改 target CLAUDE.md"，边界清晰且与实际 diff 完全对齐。
+
+### 2.2 append-only 铁律
+- DEC-004 原文保留（decision-log.md:136-160 仍为原 9 条决定），仅状态行在括号内追加 Superseded 注记。
+- DEC-008 编号递增（DEC-007 → DEC-008），与 DEC-008 "备选" 段对 in-place patch 方案的否决理由一致。
+- 铁律 1 / 2 / 3 全部遵守。
+
+### 2.3 design-doc §3.8 完整性
+- frontmatter `decisions: [DEC-004, DEC-005, DEC-008]` 新增 DEC-008。
+- §3.8 4 段结构（motivation 表 / 决定 / 并行派发 / 实现位置 + 与 DEC-007/DEC-005 正交关系）与 DEC-008 条目一一映射。
+- §6 变更记录第 2 条覆盖 DEC-008 落地动因 + 4 处 diff 范围。
+- §3.7 标题存在（line 255），孤儿段问题已消除。
+
+### 2.4 workflow.md Step 3.5 级联语义
+- §3.5.0 → §3.5.1（env opt-out）→ §3.5.2 Bash → §3.5.3 Monitor → §3.5.4 注入 → §3.5.5 生命周期 → §3.5.6 并行安全。gate 先于 env 判定，级联顺序正确。
+- 并行混合批实例（1 前台 + 2 后台 = 2 Monitor）与 DEC-002 §4 并行派发四条件兼容：PATH DISJOINT / SUCCESS-SIGNAL INDEPENDENT 对 skip 的前台 Task 天然不适用（无 progress_path 可冲突），对 2 个后台 Task 仍按 §3.5.6 逻辑保 disjoint。
+
+### 2.5 bugfix.md delta 0 对齐
+- 与 workflow.md §3.5.0 语义等价；四件 skip 枚举对称；"Evaluate independently for each Task call in a parallel batch" 亦显式出现；"Identical semantics to `commands/workflow.md` §3.5.0" 末句保留权威引用。
+
+### 2.6 5 agent prompt Fallback 条款未动且兼容
+Grep 验证：
+- `agents/developer.md:186` — "empty, unset, or the file is not writable, silently skip all emits"
+- `agents/tester.md:151` — "empty, unset, or the injection is missing entirely, silently skip all emit calls"
+- `agents/reviewer.md:99` + `:156` — "missing or empty ... skip all emits silently"（含独立 `### Fallback on miss` 子节）
+- `agents/dba.md:129` — "absent or empty ... silently skip emission"
+- `agents/research.md:176` — "empty, unset, or the injection is missing entirely, silently skip all emit calls"
+
+5 份 agent prompt 在 DEC-004 落地时已就位 Fallback，DEC-008 "空 progress_path 静默" 降级路径无须任何改动即生效。DEC-008 影响范围声明 "不改 5 份 agent prompt 本体" 与实际完全一致。
+
+### 2.7 lint_cmd 扫描
+`grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` → 0 命中（exit 1）。满足 CLAUDE.md 条件触发规则 "prompt 本体修改 → lint 0 命中才可合并"。
+
+### 2.8 DEC-007 / DEC-008 正交性验证
+- DEC-007 修**源端内容质量**（5 份 agent prompt §Content Policy 子节 + orchestrator awk 折叠）—— 层次：content。
+- DEC-008 修**触发条件**（commands 层 gate）—— 层次：trigger。
+- 两者路径无交集：DEC-007 的 Content Policy 条款被 DEC-008 skip 掉整个 Step 3.5 的场景里根本不会被执行到（前台派发无 emit）；DEC-008 放行的后台派发场景里 DEC-007 的 dedup + 代理节拍条款正常生效。两条补丁可独立合并，先后顺序不影响最终语义。
+- design-doc §3.8 末段 "与 DEC-007 的正交性" + DEC-008 决定 6 的描述自洽。
+
+### 2.9 INDEX.md 维护
+- `### testing` 新增 step35-foreground-skip-monitor.md 条目（INDEX.md:72），描述"18 cases：2 Critical / 3 Warning / 1 Suggestion → post-fix 全绿"准确概括测试文档内容。
+- 未在 `### reviews` 提前占位（符合 Step 7 批处理，本审查完成后由 orchestrator 统一补入）。
+
+## 3. 发现
+
+### Critical
+无。
+
+### Warning
+无。
+
+### Suggestion
+无新增。tester T15 的"(the default)"措辞漂移已修复；本轮未发现其他 Suggestion 级问题。
+
+### Positive
+- **append-only 纪律教科书级落地**：DEC-004 部分 Superseded 采用"状态行括号注记 + 原文逐字保留 + 新 DEC 显式引用"三件套，是未来类似 partial-supersede 场景的参考范式。
+- **正交性双向自证**：DEC-008 条目 "理由" 5 与 design-doc §3.8 末段从 DEC-008 侧和 design-doc 侧各自独立陈述正交性，形成 cross-check，降低单侧漂移风险。
+- **skip 语义 fail-safe 设计**：§3.5.0 显式列举 skip 4 件事（§3.5.2 Bash / §3.5.3 Monitor / §3.5.4 注入 / 不生成 path），消除 "skip Monitor 但仍生成 progress_path 致 silent buildup" 的隐形 bug（T18 关注点）。
+- **inline developer ↔ 前台 Task 两条 skip 路径边界清晰**：§3.5.0 末段 Note "inline developer never enters this Step ... §3.5.0 applies strictly to Task-dispatched subagents" 精准划清"源头分流"与"内部 gate"两层语义。
+
+## 4. 决策一致性检查
+
+| DEC | 关系 | 核对结论 |
+|-----|------|---------|
+| DEC-001 D2 | 零 userConfig 边界 | ✅ DEC-008 不引入 CLAUDE.md 新 key，纯 plugin 元协议改动 |
+| DEC-002 | Escalation Protocol | ✅ 未触碰；前台派发下 subagent 仍可在 final message 产出 `<escalation>` |
+| DEC-003 | research fan-out | ✅ research agent §Progress Reporting Fallback 兼容 DEC-008 skip |
+| DEC-004 | progress event protocol | ✅ 仅决定第 6 项「触发规则」Superseded；event schema / §3.1 motivation（后台场景下仍成立）/ §3.7 并行安全 全部继承 |
+| DEC-005 | developer 双形态 | ✅ DEC-008 把 §6b.3 inline skip 逻辑同源推广到前台 Task，两条 skip 路径不重叠 |
+| DEC-006 | phase gating | ✅ C-class verification-chain 下子 agent 派发不受 DEC-008 影响（DEC-008 仅调整 Monitor 触发条件，不改 phase 转场语义） |
+| DEC-007 | progress content policy | ✅ 正交（content vs trigger 两层），互不触发，可独立合并 |
+
+## 5. 总结
+- **可合并**：是。
+- **主要关注点**：tester 在 #15 落地过程中抓出的 T12 / T13 两枚 Critical 是 design-doc 编辑回归；修复已根因闭环，未在 DEC 条目或 commands 层留下任何遗漏副作用。本轮审查建议 orchestrator 在 issue #15 closeout 时把"§3.8 类 'patch 段' 插入需附带 §N.old heading 保留检查清单"作为 onboarding/contributing 的 soft guideline 备忘（非本 DEC 范畴，future issue）。

--- a/docs/testing/step35-foreground-skip-monitor.md
+++ b/docs/testing/step35-foreground-skip-monitor.md
@@ -1,0 +1,257 @@
+---
+slug: step35-foreground-skip-monitor
+source: design-docs/subagent-progress-and-execution-model.md §3.8, decision-log.md DEC-008
+created: 2026-04-19
+tester: roundtable:tester (adversarial)
+scope: commands/workflow.md §3.5.0, commands/bugfix.md §Step 0.5 delta 0, design-doc §3.8, DEC-008 + DEC-004 status line
+critical_modules_hit:
+  - workflow command Phase Matrix + 并行判定树 + phase gating taxonomy (DEC-006)
+  - Progress event JSON schema (DEC-004)
+---
+
+# Step 3.5 前台派发免 Monitor（DEC-008）对抗性测试
+
+> 本测试文档针对 DEC-008 落地的 4 处 diff：
+> 1. `commands/workflow.md` §3.5.0 新增 gate
+> 2. `commands/bugfix.md` §Step 0.5 新增 delta 0
+> 3. `docs/decision-log.md` DEC-008 条目 + DEC-004 状态行补注
+> 4. `docs/design-docs/subagent-progress-and-execution-model.md` §3.8 + frontmatter + §6 changelog
+>
+> 测试策略：静态审读为主（本变更无运行态）+ 场景矩阵推演。
+
+---
+
+## 0. 测试计划（plan-first，critical_modules 命中）
+
+### 攻击面分类
+
+| # | 场景 | 关注维度 |
+|---|------|---------|
+| T01 | 纯后台单派发 | gate 正确放行 → Monitor 正常 |
+| T02 | 纯前台单派发 | gate 正确 skip；4 变量不注入；agent Fallback 生效 |
+| T03 | `run_in_background: false` 显式 | 与缺省等价 gate-skip |
+| T04 | 混合并行（1 前台 + 2 后台） | gate 逐派发独立判定，不整批 skip |
+| T05 | gate + env opt-out 级联 | §3.5.0 先行 → §3.5.1；双激活不重复 skip |
+| T06 | inline developer + 同会话后台 tester | 两条 skip 路径不冲突 |
+| T07 | `run_in_background: true` 但 `ROUNDTABLE_PROGRESS_DISABLE=1` | §3.5.0 放行 → §3.5.1 拦截 |
+| T08 | 5 个 agent prompt Fallback 兼容性 | 空 progress_path 不崩 |
+| T09 | DEC-004 部分 Supersede 语义 | 仅 §3.6 触发规则 scope；其余条款仍 Accepted |
+| T10 | 决策日志铁律 | DEC-008 未删 DEC-004 原文；编号递增 |
+| T11 | DEC-008 内部一致性 | 上下文/决定/理由/影响范围 不互相矛盾 |
+| T12 | design-doc §3.8 引用准确性 | 对 DEC-004 §3.1 / §3.6 / DEC-005 §6b.3 / DEC-007 的交叉引用 |
+| T13 | 节号破碎 | §3.8 插入是否破坏原 §3.7 及其后引用 |
+| T14 | bugfix.md delta 0 与 workflow.md §3.5.0 语义对齐 | "Identical to commands/workflow.md §3.5.0" 的真值 |
+| T15 | Claude Code Task 默认行为漂移 | 未来若 Task 默认变更，gate 是否仍稳定 |
+| T16 | lint_cmd 硬编码扫描 | 0 命中 |
+| T17 | §3.5.0 Note：inline vs Task-foreground 边界 | 两条 skip 路径不重叠不矛盾 |
+| T18 | Monitor 预备 Bash snippet 未跑 | 前台派发 `DISPATCH_ID` / `PROGRESS_PATH` 完全不产生 |
+
+---
+
+## 1. 执行与发现
+
+### T01 — 后台单派发放行（Positive）
+
+输入：orchestrator 以 `Task {..., run_in_background: true}` 派发 reviewer。
+期望：§3.5.0 放行 → §3.5.1 放行（env 未设）→ §3.5.2 生成 ID/path → §3.5.3 Monitor 启 → §3.5.4 4 变量注入。
+结果：**Positive** — §3.5.0 明确 "Run the rest of this Step" 对 `run_in_background: true` 分支。
+
+---
+
+### T02 — 前台单派发 skip（Positive）
+
+输入：`Task {..., run_in_background: false}` 或 run_in_background 缺省派发 tester。
+期望：§3.5.0 skip；不产生 progress_path；agent 侧 Fallback 静默。
+结果：**Positive**。
+
+验证点：
+- `agents/tester.md:151` Fallback 明文 "If `{{progress_path}}` is empty, unset, or the injection is missing entirely, silently skip all emit calls"
+- `agents/developer.md:186`、`agents/reviewer.md:156`、`agents/dba.md:129`、`agents/research.md:176` 均有等价条款。
+
+---
+
+### T03 — 显式 `run_in_background: false`（Positive）
+
+§3.5.0 条款文本："`run_in_background` omitted / `false`（foreground dispatch, the default）— ... Skip this entire Step"。**显式 false 与缺省并列处理**，gate 语义正确。
+
+---
+
+### T04 — 混合并行派发（Warning）
+
+输入：orchestrator 在一条 assistant message 里发 3 个 Task：A 前台、B 后台、C 后台。
+期望：§3.5.0 逐派发判定 → 仅 B、C 走 Monitor setup；A skip。
+
+**发现 (Warning)**：§3.5.0 文本用 "the upcoming `Task` call's `run_in_background` parameter"（单数），未显式说明并行场景下 orchestrator 必须**逐个 Task call 独立执行 §3.5**。当前措辞在严格读字面时也能推导（"before running any sub-step"）但 LLM 容易在并行场景里把 3 个 Task 的判定合并评估（"至少一个后台 → 跑 Step"）导致给前台 A 也生成 progress_path。
+
+建议：§3.5.0 末尾加一句 "In a parallel dispatch batch, evaluate this gate **independently for each `Task` call**; mixed-mode batches are expected."
+
+---
+
+### T05 — gate + env opt-out 级联（Positive）
+
+顺序：§3.5.0（foreground → skip）→ 若非 foreground 再 §3.5.1（env → skip）。
+两条 skip 同语义层、都终结 Step；不重复 skip，不互相取消。
+`commands/workflow.md` §3.5.0 Rationale 段与 §3.5.1 头句明确 "先于 §3.5.1" / "If it equals `1`, skip this entire Step"，文本无歧义。
+
+---
+
+### T06 — inline developer + 同会话后台 tester（Positive）
+
+DEC-005 §6b.3: "Do NOT run Step 3.5" for inline developer（无 Task 派发）。
+DEC-008 §3.5.0 Note: "applies strictly to `Task`-dispatched subagents"。
+
+两条 skip 路径**正交**：inline developer 在 orchestrator 内联执行，根本不触发 Step 3.5 流程入口；§3.5.0 处理的是已经进入 Step 3.5 但派发形态是前台 Task 的情形。同会话可共存，互不冲突。
+
+---
+
+### T07 — `run_in_background: true` + ROUNDTABLE_PROGRESS_DISABLE=1（Positive）
+
+链条：§3.5.0 放行（is background）→ §3.5.1 拦截（env=1）→ skip。用户侧 env 仍是顶层一刀切 opt-out；gate 叠加正确。
+
+---
+
+### T08 — 5 agent prompt 空 progress_path Fallback（Positive）
+
+grep 证据见 T02。`agents/reviewer.md:156` 用 "Fallback on miss" 表述略有差异但语义等价。**无需修改 5 个 agent prompt**，DEC-008 影响范围声明与实际一致。
+
+---
+
+### T09 — DEC-004 部分 Supersede（Warning）
+
+decision-log.md line 138:
+`**状态**: Accepted（§3.6 触发规则 Superseded by DEC-008 — 改为 run_in_background: true 派发才开启；其余条款仍 Accepted）`
+
+**发现 (Warning)**：`§3.6 触发规则` 的 scope 标注含糊。DEC-004 条目本体**未使用 section 号**，是以 "决定" 后的数字列表 1-9 组织的（其中第 6 项 "触发规则"）。用 "§3.6" 既可能误读为引用 design-doc §3.6（实际是"与 DEC-002/DEC-003 的接口"，完全无关），也可能误读为 DEC-004 决定列表的第 6 项。
+
+建议：改为更无歧义的表述之一：
+- `**状态**: Accepted（决定第 6 项「触发规则」Superseded by DEC-008；其余条款仍 Accepted）`
+- 或直接：`**状态**: Accepted（触发规则 Superseded by DEC-008；其余条款仍 Accepted）`
+
+铁律 "不删除旧条目" 已遵守。
+
+---
+
+### T10 — decision-log 铁律（Positive）
+
+- DEC-008 条目采用规定格式（日期/状态/上下文/决定/备选/理由/相关文档/影响范围）。
+- DEC-004 原文保留，仅追加状态注解。
+- 编号递增（DEC-007 → DEC-008）。
+- 冲突已在 DEC-008 "备选" 段显式引用 DEC-004 并给出 Supersede 理由。
+- 铁律 1 / 2 / 3 全部遵守。
+
+---
+
+### T11 — DEC-008 内部一致性（Positive）
+
+交叉比对：
+- 上下文 → 问题是"前台派发 Monitor 冗余"（一致）
+- 决定 1/2/3 → gate 位置（一致）、bugfix 同步（一致）、不改 agent prompt（一致）
+- 决定 5 → DEC-004 标 Superseded by DEC-008（与 decision-log line 138 实际落地一致）
+- 决定 6/7 → 与 DEC-007 正交、与 DEC-005 同源（design-doc §3.8 末尾两段呼应一致）
+- 理由 6 条与"决定"7 条在"走 Superseded 流程"上一致
+
+---
+
+### T12 — design-doc §3.8 引用准确性（Critical）
+
+**发现 (Critical)**：§3.8 line 266:
+> subagent 收到空 `progress_path` 时按 §3.6 漏发降级条款静默
+
+但 design-doc §3.6 实际标题是 "与 DEC-002 / DEC-003 的接口"，**内容完全不涉及"漏发降级"**。真正的 "漏发降级 / 遗漏 echo 时降级为静默" 条款在 **§3.2** 末段（`subagent-progress-and-execution-model.md:157`）"subagent 遗漏 echo 时降级为'静默'"。
+
+类似问题：§6 changelog line 357:
+> 落 DEC-008（Supersedes DEC-004 §3.6 触发规则）
+
+此处 "DEC-004 §3.6" 指什么同样含糊（参见 T09）。且把 design-doc §3.6 和 DEC-004 条目混用 "§3.6" 会让后续读者 / agent 解读时错位。
+
+修复建议：
+- §3.8 line 266 改为 "按 §3.2 末段漏发降级条款" 或 "按各 agent `## Progress Reporting` Fallback 条款"。
+- §6 changelog line 357 改为 "Supersedes DEC-004 触发规则（决定列表第 6 项）"。
+
+---
+
+### T13 — 节号破碎（Critical）
+
+设计文档**原 §3.7 "parallel-dispatch safety" 块在 DEC-008 编辑后丢失了标题**。
+
+证据：
+- `subagent-progress-and-execution-model.md:278-283` 存在一段 "progress 机制**不破坏**并行派发四条件" 的内容（4 条 PREREQ MET / PATH DISJOINT / SUCCESS-SIGNAL INDEPENDENT / RESOURCE SAFE），**但无任何 `### 3.7` 标题**，位于 §3.8 之后完全裸奔。
+- 外部多处仍在引用 "DEC-004 §3.7"：
+  - `commands/workflow.md:216` `Per DEC-004 §3.7 and DEC-002 §4 parallel dispatch rules, ...`
+  - `docs/exec-plans/active/subagent-progress-and-execution-model-plan.md:158` `progress_path 按 dispatch_id 命名，天然隔离（DEC-004 §3.7）`
+
+编辑似乎原本想在 §3.6 后插入 §3.8（以区分"新增"），但未保留 §3.7 的 heading。结果：
+1. 原 §3.7 内容变成**孤儿段**（无标题、无锚、无 anchor-like 引用点）。
+2. 节号从 §3.6 → §3.8 跳跃，违反 design-doc 节号连续性。
+3. `commands/workflow.md` §3.5.6 和 `exec-plans/active/...-plan.md` 对 "§3.7" 的引用**实际悬空**（读者翻到 design-doc 发现没有 §3.7）。
+
+**修复建议**：把孤儿段恢复为 `### 3.7 并行派发安全性`（或等价标题），或交换 §3.8 和 §3.7 顺序使 §3.7 仍在 §3.8 之前。后者与外部引用的位置期待更一致。
+
+---
+
+### T14 — bugfix.md delta 0 与 workflow.md §3.5.0 对齐（Warning）
+
+`commands/bugfix.md:34`:
+> **Foreground vs background gate (DEC-008)**: ... Identical to `commands/workflow.md` §3.5.0.
+
+**发现 (Warning)**：bugfix delta 0 文本**缺少** workflow.md §3.5.0 的两个关键细节：
+1. 没有 "gate 失败后不注入 4 变量" 的显式列举（workflow.md §3.5.0 明写 "do NOT generate progress_path, do NOT run the Bash preparation, do NOT launch Monitor, do NOT inject the 4 progress variables"）。bugfix 版本仅笼统说 "Foreground ... skip Monitor setup entirely"。
+2. 没有 "§3.5.0 vs inline developer §6b.3 是两条 skip 路径" 的 Note（workflow.md §3.5.0 结尾那段）。
+
+由于 bugfix 的 "Identical to ... §3.5.0" 宣示权威，读者可能跳回 workflow.md 查细节，功能上不破。但对纯执行 bugfix 命令的 LLM，缺失的细节可能导致它只 skip Monitor 却仍生成 progress_path 并注入进 Task prompt —— subagent 然后会尝试 emit 但文件不被 tail（silent data loss，非 fail-loud）。
+
+建议：bugfix delta 0 显式列出"skip Monitor + skip progress_path 生成 + skip 4 变量注入"三件一起，或加一句 "All four sub-steps of §3.5 are skipped, including the 4-variable injection"。
+
+---
+
+### T15 — Claude Code Task 默认行为漂移（Suggestion）
+
+当前：`run_in_background` 默认 false / 缺省 = 前台。
+假设未来 Claude Code 升级改为默认后台：gate 仍以 "true → 后台派发 Monitor" 为单源真值，**不会因默认行为翻转而误导**。但 §3.5.0 文字 "(foreground dispatch, the default)" 会变成过期陈述。
+
+建议：`(foreground dispatch, currently the Claude Code default)` 或直接删 "the default" 补注，使条款与默认值解耦。
+
+---
+
+### T16 — lint_cmd 硬编码扫描（Positive）
+
+执行 `grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/`：**0 命中**。
+
+---
+
+### T17 — §3.5.0 Note：inline vs Task-foreground 边界（Positive）
+
+§3.5.0 结尾：
+> Note: the Developer inline form (§6b.3) is a separate skip path — it never enters this Step because no `Task` call is issued. §3.5.0 applies strictly to `Task`-dispatched subagents.
+
+措辞精准。inline developer 是"根本不跑 Step 3.5"（源头分流），§3.5.0 是"跑 Step 3.5 但判定后 skip"（内部 gate）。两条路径不重叠，联合覆盖"主会话能观察到"的所有情形。
+
+---
+
+### T18 — 前台派发下 Monitor 预备 Bash 未跑（Positive）
+
+§3.5.0 明确 "do NOT run the Bash preparation in §3.5.2"。此细节关键：若 gate 仅 skip Monitor 启动但仍跑 §3.5.2 生成 `PROGRESS_PATH`，subagent 后续 emit 会写入文件但无 Monitor 读取（silent buildup 占 /tmp 空间，长期跑会累计垃圾文件）。明文列举 §3.5.2 在 skip 范围内，避免此隐患。
+
+---
+
+## 2. 发现汇总
+
+| 严重度 | 测试 | 描述 | 建议 |
+|-------|------|------|------|
+| Critical | T12 | design-doc §3.8 line 266 引用 "§3.6 漏发降级条款" 但 §3.6 内容不含降级；实际在 §3.2 | 改引 §3.2 或各 agent §Progress Reporting Fallback |
+| Critical | T13 | §3.7 "parallel-dispatch safety" 段在 DEC-008 编辑后失去标题，沦为孤儿段；外部 2 处 `§3.7` 引用悬空 | 恢复 `### 3.7` 标题，或调换 §3.7 / §3.8 顺序 |
+| Warning | T04 | 并行派发场景下 §3.5.0 未显式说明逐 Task 独立评估 | §3.5.0 末尾加一句并行判定说明 |
+| Warning | T09 | DEC-004 状态行 `§3.6 触发规则` 的 scope 标注含糊（DEC-004 本体无 §） | 改为 "决定第 6 项" 或 "触发规则" |
+| Warning | T14 | bugfix.md delta 0 缺少 workflow.md §3.5.0 的 "4 变量不注入" 显式条款 | 显式列 skip 三件：Monitor + progress_path 生成 + 4 变量注入 |
+| Suggestion | T15 | §3.5.0 含 "the default" 陈述，依赖 Claude Code 当前默认行为 | 改为 "currently the Claude Code default" 以解耦未来变更 |
+| Positive | T01/02/03/05/06/07/08/10/11/16/17/18 | 核心 gate 语义正确、铁律遵守、lint 0 命中、Fallback 兼容 | — |
+
+---
+
+## 3. 潜在业务 bug（反馈给调度方）
+
+无（本变更纯文档/编排层，无业务代码修改）。Critical 级发现为**设计文档自洽性 bug**（非业务 bug），不走 developer bugfix 流程；建议 architect/作者直接修文档。
+
+## 4. 变更记录
+
+- 2026-04-19 创建 —— DEC-008 落地对抗性审查；发现 2 Critical / 3 Warning / 1 Suggestion。

--- a/skills/_detect-project-context.md
+++ b/skills/_detect-project-context.md
@@ -9,20 +9,20 @@ description: Internal helper skill. Detects target_project (via D9 algorithm), t
 
 不要在响应用户普通任务时直接激活本 skill。
 
-> **Activation note**: Callers (commands `workflow` / `bugfix` / `lint`, and skills `architect` / `analyst`) should **`Read` this file and execute the 4 steps inline** in the main session, not activate via the `Skill` tool. The underscore prefix signals "internal helper, not an end-user skill" — during P4 dogfooding, `Skill` activation of underscore-prefixed skills was observed to fail in some Claude Code releases. Inline execution is safe, deterministic, and keeps the detected context in the active session memory where subsequent dispatches can reuse it.
+> **Activation note**：调用方（commands `workflow` / `bugfix` / `lint`，skills `architect` / `analyst`）应在主会话中 **`Read` 本文件并 inline 执行 4 步**，不要通过 `Skill` 工具激活。下划线前缀表示"内部 helper，不是终端用户 skill" —— P4 dogfooding 期间观察到，某些 Claude Code 版本对下划线前缀 skill 的 `Skill` 激活会失败。Inline 执行安全、确定性强，且把检测结果保留在活跃 session 记忆中供后续派发复用。
 
 ---
 
 ## Resource Access
 
-| Operation | Scope |
-|-----------|-------|
-| Read | `target_project/CLAUDE.md`, project-root identifier files (`Cargo.toml` / `package.json` / `pyproject.toml` / `go.mod` / `Move.toml`), `{docs_root}/` candidate directories |
+| 操作 | 范围 |
+|------|------|
+| Read | `target_project/CLAUDE.md`、项目根标识文件（`Cargo.toml` / `package.json` / `pyproject.toml` / `go.mod` / `Move.toml`）、候选 `{docs_root}/` 目录 |
 | Write | — |
-| Report to caller | structured context summary (`target_project`, `primary_lang`, `lint_cmd`, `test_cmd`, `docs_root`, `claude_md` metadata including `critical_modules` / `design_ref` / `toolchain_override`) |
-| Forbidden | all writes, git operations, design / code modifications |
+| Report to caller | 结构化 context 摘要（`target_project`、`primary_lang`、`lint_cmd`、`test_cmd`、`docs_root`、`claude_md` 元数据包含 `critical_modules` / `design_ref` / `toolchain_override`） |
+| Forbidden | 一切写入、git 操作、设计 / 代码修改 |
 
-Pure detection helper. Never modifies files.
+纯检测 helper。从不修改文件。
 
 ---
 

--- a/skills/_progress-content-policy.md
+++ b/skills/_progress-content-policy.md
@@ -5,64 +5,64 @@ description: Internal helper. Shared progress-emission content policy included b
 
 # Progress Content Policy
 
-Referenced by `agents/{developer,tester,reviewer,dba}.md` Progress Reporting. Layered on DEC-004 §3.1–3.2 (schema — not repeated here), orthogonal to DEC-002 (escalation).
+被 `agents/{developer,tester,reviewer,dba}.md` 的 Progress Reporting 引用。叠加在 DEC-004 §3.1–3.2（schema —— 这里不重复）之上，与 DEC-002（escalation）正交。
 
 ## 1. Substantive-progress gate
 
-Before every emit, ONE of the following must hold since the previous emit:
+每次 emit 之前，自上次 emit 起必须满足下列之一：
 
-- a **file write / edit** landed on disk, OR
-- a **sub-milestone** completed (test passed, exec-plan checkbox ticked), OR
-- **≥50% new context** consumed (meaningful new reads, not re-reads).
+- 有**文件写入 / edit** 落盘，或
+- 有**子里程碑**完成（测试通过、exec-plan checkbox 勾选），或
+- 消耗了**≥50% 新 context**（有意义的新 read，不是 re-read）。
 
-No trigger → do NOT emit. Replaces clock heartbeats (LLM has no timer). Aligns with DEC-004 "3–10 events per dispatch, phase-checkpoint level".
+无触发器 → **不要** emit。替代时钟心跳（LLM 没有 timer）。与 DEC-004「每次派发 3–10 条事件、phase-checkpoint 级别」对齐。
 
-`phase_blocked` + `<escalation>` is **gate-exempt** — blockers always emit immediately.
+`phase_blocked` + `<escalation>` **gate-exempt** —— blocker 总是立即 emit。
 
 ## 2. No-repeat summary
 
-New `summary` MUST NOT equal the previous emit's `summary` verbatim. If indistinguishable, **prefer not emitting**. Consecutive-identical is forbidden; non-consecutive repeats (separated by other events) are valid phase cycles.
+新的 `summary` **不得**与上一条 emit 的 `summary` 逐字相同。若无法区分，**宁可不 emit**。连续相同禁用；非连续重复（被其他事件分隔）是合法的 phase 循环。
 
 ## 3. Differentiated content
 
-Every `summary` (≤120 chars) MUST carry at least ONE of:
+每条 `summary`（≤120 字符）**必须**带其中**至少一个**：
 
-- **sub-step name** — concrete target, e.g. `editing agents/developer.md Content Policy subsection`
-- **progress score** — fraction / count, e.g. `2/5 files done`, `test 3/12`
-- **milestone tag** — checkpoint name, e.g. `milestone: P0.2 4-agents synced`
+- **sub-step 名** —— 具体目标，如 `editing agents/developer.md Content Policy subsection`
+- **progress 分数** —— 分数 / 计数，如 `2/5 files done`、`test 3/12`
+- **milestone 标签** —— checkpoint 名，如 `milestone: P0.2 4-agents synced`
 
-Lacking all three = noise; rewrite or skip.
+三者都缺 = 噪声；重写或跳过。
 
-## 4. DONE / ERROR signals
+## 4. DONE / ERROR 信号
 
-- **DONE**: the final `phase_complete` doubles as DONE. Convention (non-mandatory): prefix summary with `✅`. No new event type; orchestrator uses `Task` return as authoritative DONE.
-- **ERROR**: emit `phase_blocked` first (gate-exempt), then include `<escalation>` JSON block in the final message per DEC-002. Channels stay orthogonal.
+- **DONE**：最终的 `phase_complete` 兼作 DONE。约定（非强制）：summary 前缀 `✅`。无新事件类型；orchestrator 以 `Task` 返回作为权威 DONE。
+- **ERROR**：先 emit `phase_blocked`（gate-exempt），再按 DEC-002 在 final message 中放 `<escalation>` JSON block。通道保持正交。
 
-## 5. Anti-pattern vs good-pattern
+## 5. 反例 vs 正例
 
-**A — no-repeat (§2)**
-- ❌ `"dev round2 progress"` × 3 consecutive emits.
-- ✅ `"P0.2 editing tester.md"` → `"P0.2 2/4 agents synced"` → `"P0.2 milestone: 4 agents synced"`.
+**A —— no-repeat（§2）**
+- ❌ `"dev round2 progress"` 连续 3 条 emit。
+- ✅ `"P0.2 editing tester.md"` → `"P0.2 2/4 agents synced"` → `"P0.2 milestone: 4 agents synced"`。
 
-**B — differentiated content (§3)**
-- ❌ `"working on tests"` — no sub-step / score / milestone.
-- ✅ `"running case-fuzz 3/12 — boundary overflow"` — sub-step + score.
+**B —— differentiated content（§3）**
+- ❌ `"working on tests"` —— 无 sub-step / score / milestone。
+- ✅ `"running case-fuzz 3/12 — boundary overflow"` —— sub-step + score。
 
-**C — gate (§1)**
-- ❌ `phase_start` immediately followed by another emit with no file write / sub-milestone / read between.
-- ✅ `phase_start` → (Edit lands) → `phase_complete` with outcome — file-write trigger.
+**C —— gate（§1）**
+- ❌ `phase_start` 紧接另一条 emit，中间无文件写入 / 子里程碑 / read。
+- ✅ `phase_start` →（Edit 落盘）→ 带结果的 `phase_complete` —— 文件写入触发器。
 
-**D — DONE marker (§4)**
-- ❌ Terminal `phase_complete` summary `"done"`.
-- ✅ `"✅ P0.4 lint 0-hit + awk smoke folded x2"` — ✅ prefix + concrete outcome.
+**D —— DONE marker（§4）**
+- ❌ 终结 `phase_complete` summary `"done"`。
+- ✅ `"✅ P0.4 lint 0-hit + awk smoke folded x2"` —— ✅ 前缀 + 具体结果。
 
-## 6. Edge cases
+## 6. 边界情况
 
-| Case | Handling |
-|------|----------|
-| Adjacent phases share a sub-step name | Differentiate via score or milestone; else skip second emit (§2). |
-| `ROUNDTABLE_PROGRESS_DISABLE=1` / empty `{{progress_path}}` | Policy inert; silent-skip per agent Fallback. |
-| No exec-plan P0.n (tester / reviewer free-form) | Use agent-native phase tags; §3 still applies. |
-| Emit IO failure | Silent degrade per DEC-004 §3.2; no new fallback. |
+| 情形 | 处理 |
+|------|------|
+| 相邻 phase 共享 sub-step 名 | 用 score 或 milestone 区分；否则跳过第二条 emit（§2）。 |
+| `ROUNDTABLE_PROGRESS_DISABLE=1` / 空 `{{progress_path}}` | Policy 失效；按各 agent Fallback 静默 skip。 |
+| 无 exec-plan P0.n（tester / reviewer 自由格式） | 用 agent 原生 phase tag；§3 依然适用。 |
+| Emit IO 失败 | 按 DEC-004 §3.2 静默降级；无新 fallback。 |
 
-Refs: DEC-007, DEC-004 §3.1–3.2, DEC-002.
+Refs：DEC-007、DEC-004 §3.1–3.2、DEC-002。

--- a/skills/analyst.md
+++ b/skills/analyst.md
@@ -9,7 +9,7 @@ description: Analyst role for research, competitive analysis, feasibility assess
 
 ## 开工第一步：项目上下文识别
 
-**Execute the detection inline** — `Read` `skills/_detect-project-context.md` and run steps 1 (D9 identification), 3 (`docs_root` detection), and 4 (`CLAUDE.md` loading). Skip step 2 (toolchain) — analyst does not run `lint` / `test`. Do NOT use the `Skill` tool. Store the result in session memory; subsequent research references `target_project` / `docs_root` / CLAUDE.md rules from memory.
+**必须 inline 执行检测** —— `Read` `skills/_detect-project-context.md` 并跑 step 1（D9 识别）、step 3（`docs_root` 检测）、step 4（`CLAUDE.md` 加载）。Skip step 2（toolchain）—— analyst 不跑 `lint` / `test`。不要用 `Skill` 工具。结果存入 session 记忆；后续调研从记忆引用 `target_project` / `docs_root` / CLAUDE.md 规则。
 
 ---
 
@@ -25,14 +25,14 @@ description: Analyst role for research, competitive analysis, feasibility assess
 
 ## Resource Access
 
-| Operation | Scope |
-|-----------|-------|
-| Read | `target_project/CLAUDE.md`, `{docs_root}/analyze/`, source code (read-only), WebFetch / WebSearch |
-| Write | `{docs_root}/analyze/[slug].md`, `{docs_root}/log.md` |
-| Report to orchestrator | — (skill runs in the main session; writes directly) |
-| Forbidden | `{docs_root}/design-docs/`, `{docs_root}/decision-log.md`, `{docs_root}/exec-plans/`, `src/*`, `tests/*`, git operations |
+| 操作 | 范围 |
+|------|------|
+| Read | `target_project/CLAUDE.md`、`{docs_root}/analyze/`、源码（只读）、WebFetch / WebSearch |
+| Write | `{docs_root}/analyze/[slug].md`、`{docs_root}/log.md` |
+| Report to orchestrator | —（skill 在主会话运行；直接写入） |
+| Forbidden | `{docs_root}/design-docs/`、`{docs_root}/decision-log.md`、`{docs_root}/exec-plans/`、`src/*`、`tests/*`、git 操作 |
 
-Analyst stays at the factual layer; architecture-layer docs are architect's domain. Git operations are forbidden unless the user explicitly authorizes them.
+Analyst 停留在事实层；架构层文档归 architect。除非用户显式授权，否则禁用一切 git 操作。
 
 ---
 
@@ -65,18 +65,18 @@ Analyst stays at the factual layer; architecture-layer docs are architect's doma
 
 ## AskUserQuestion Option Schema
 
-Every `AskUserQuestion` invocation MUST follow this structural schema. Bare option labels are forbidden — each option carries factual information so the user can decide.
+每次 `AskUserQuestion` 调用**必须**遵循本结构 schema。裸 option label 禁用 —— 每个 option 自带事实信息，让用户能做决定。
 
-Required fields per option:
+每个 option 的必填字段：
 
-| Field | Required | Notes |
-|-------|----------|-------|
-| `label` | yes | Short option name |
-| `fact` | yes | Factual statement with source (URL / `file:line` / figure) |
-| `tradeoff` | yes | Objective cost / exclusion |
-| `recommended` | **forbidden** | Analyst stays at the factual layer; recommendations are architect's job |
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `label` | yes | 简短 option 名 |
+| `fact` | yes | 带 source（URL / `file:line` / 图表）的事实陈述 |
+| `tradeoff` | yes | 客观 cost / 排除项 |
+| `recommended` | **禁用** | Analyst 停留在事实层；推荐是 architect 的职责 |
 
-Example (analyst scoping research):
+示例（analyst 界定调研 scope）：
 
 ```
 AskUserQuestion(
@@ -101,10 +101,10 @@ AskUserQuestion(
 )
 ```
 
-Rules:
-- Each `AskUserQuestion` call asks exactly ONE research decision.
-- Options are factually distinct choices, not "which is better".
-- **NO `recommended` field** — that is architect-layer reasoning.
+规则：
+- 每次 `AskUserQuestion` 调用恰好问一个调研决策。
+- Options 是事实上不同的选择，不是"哪个更好"。
+- **不要 `recommended` 字段** —— 那是 architect 层的推理。
 
 ---
 

--- a/skills/architect.md
+++ b/skills/architect.md
@@ -9,7 +9,7 @@ description: Architect role for system design, interface definition, technology 
 
 ## 开工第一步：项目上下文识别
 
-**Execute the 4-step detection inline** — `Read` `skills/_detect-project-context.md` and run all 4 steps directly (D9 identification + toolchain detection + `docs_root` detection + `CLAUDE.md` loading). Do NOT use the `Skill` tool. Store the result in session memory; subsequent design steps reference `target_project` / `docs_root` / `critical_modules` / `design_ref` from memory instead of re-detecting.
+**必须 inline 执行 4 步检测** —— `Read` `skills/_detect-project-context.md` 并直接跑全部 4 步（D9 识别 + toolchain detection + `docs_root` detection + `CLAUDE.md` 加载）。不要用 `Skill` 工具。把结果存入 session 记忆；后续设计步骤从记忆中引用 `target_project` / `docs_root` / `critical_modules` / `design_ref`，不重新检测。
 
 **额外一步：扫描 decision-log**
 
@@ -19,14 +19,14 @@ description: Architect role for system design, interface definition, technology 
 
 ## Resource Access
 
-| Operation | Scope |
-|-----------|-------|
-| Read | `target_project/CLAUDE.md`, `{docs_root}/analyze/`, `{docs_root}/design-docs/`, `{docs_root}/decision-log.md`, existing `{docs_root}/exec-plans/` |
-| Write | `{docs_root}/design-docs/[slug].md`, `{docs_root}/exec-plans/{active,completed}/[slug]-plan.md`, `{docs_root}/api-docs/[slug].md`, `{docs_root}/decision-log.md`, `{docs_root}/log.md` |
-| Report to orchestrator | — (skill runs in the main session; writes directly) |
-| Forbidden | `src/*`, `tests/*`, `{docs_root}/reviews/`, `{docs_root}/testing/`, git operations (commit / push / branch / tag / reset / stash) |
+| 操作 | 范围 |
+|------|------|
+| Read | `target_project/CLAUDE.md`、`{docs_root}/analyze/`、`{docs_root}/design-docs/`、`{docs_root}/decision-log.md`、已有 `{docs_root}/exec-plans/` |
+| Write | `{docs_root}/design-docs/[slug].md`、`{docs_root}/exec-plans/{active,completed}/[slug]-plan.md`、`{docs_root}/api-docs/[slug].md`、`{docs_root}/decision-log.md`、`{docs_root}/log.md` |
+| Report to orchestrator | —（skill 在主会话中运行；直接写入） |
+| Forbidden | `src/*`、`tests/*`、`{docs_root}/reviews/`、`{docs_root}/testing/`、git 操作（commit / push / branch / tag / reset / stash） |
 
-Git operations are forbidden unless the user explicitly authorizes them in the current turn. Default: operate only on the working tree.
+除非用户在当前 turn 显式授权，否则禁用一切 git 操作。默认：只在 working tree 中操作。
 
 ---
 
@@ -59,34 +59,34 @@ Git operations are forbidden unless the user explicitly authorizes them in the c
 2. 读取 analyst 报告、现有 design-docs、decision-log
 3. 识别所有**关键决策点**（存储方案、API 协议、模块边界、并发模型、一致性取向等）
 
-   **3.5 Research Fan-out**（optional, trigger when needed）：
+   **3.5 Research Fan-out**（可选，按需触发）：
 
-   When any identified decision point has **2-4 candidate options** AND each candidate requires non-trivial external research (≥ 1 `WebFetch` / `WebSearch` per option), **dispatch parallel `research` subagents** instead of serially fetching from the main session. See `agents/research.md` and DEC-003.
+   当任一识别到的决策点有 **2–4 个候选 option**，且每个候选需要非 trivial 的外部调研（每个 option ≥ 1 次 `WebFetch` / `WebSearch`）时，**并行派发 `research` subagent**，而不是在主会话里串行 fetch。见 `agents/research.md` 和 DEC-003。
 
-   Trigger rules:
-   - Candidate count: `2 ≤ N ≤ 4` (hard cap 4; if 5+ candidates surface, first ask the user via `AskUserQuestion` to pre-filter the 4 most promising)
-   - Per-candidate research depth: ≥ 1 WebFetch / WebSearch / non-trivial Read
-   - Total research work estimated > single-turn main-session budget
+   触发规则：
+   - 候选数：`2 ≤ N ≤ 4`（硬上限 4；出现 5+ 候选时先用 `AskUserQuestion` 让用户预筛最有希望的 4 个）
+   - 单候选调研深度：≥ 1 次 WebFetch / WebSearch / 非 trivial 的 Read
+   - 预估总调研工作量 > 单轮主会话预算
 
-   Dispatch procedure:
-   1. For each candidate `opt_i`, prepare a `Task` call dispatching the `research` agent with **required injection**: `target_project`, `docs_root`, `option_label`, `scope` (the specific fact-level question), `related_facts` (known facts to avoid duplicate research), `critical_modules`, `design_ref` (both from target CLAUDE.md session memory).
-   2. Issue all `N` Task calls **in a single assistant message** so they run in parallel.
-   3. Wait for all `N` returns (each a `<research-result>` JSON block, or a `<research-abort>` feedback).
+   派发流程：
+   1. 为每个候选 `opt_i` 准备一次 `Task` 调用派发 `research` agent，**必填注入**：`target_project`、`docs_root`、`option_label`、`scope`（具体的事实层问题）、`related_facts`（已知事实，避免重复调研）、`critical_modules`、`design_ref`（后两者来自 target CLAUDE.md session 记忆）。
+   2. 在**同一条 assistant message** 中发出所有 `N` 个 Task 调用，让它们并行运行。
+   3. 等待 `N` 个全部返回（每个是一个 `<research-result>` JSON block，或一个 `<research-abort>` feedback）。
 
-   Synthesis procedure:
-   4. Parse each `<research-result>` JSON. Extract `key_facts` (→ becomes `rationale` in AskUserQuestion option) and `tradeoffs` (→ becomes `tradeoff` field).
-   5. Architect **independently** decides which option (if any) carries `recommended: true` — research workers are barred from recommending (`recommend_for` is hard-wired `null`).
-   6. Construct the `AskUserQuestion` call per the `## AskUserQuestion Option Schema` section, one option per candidate.
+   合成流程：
+   4. 解析每个 `<research-result>` JSON。抽取 `key_facts`（→ 成为 AskUserQuestion option 的 `rationale`）和 `tradeoffs`（→ 成为 `tradeoff` 字段）。
+   5. Architect **自行**决定哪个 option（若有）带 `recommended: true` —— research worker 禁止推荐（`recommend_for` 硬导 `null`）。
+   6. 按 `## AskUserQuestion Option Schema` 构造 `AskUserQuestion` 调用，每个候选一个 option。
 
-   Failure handling:
-   - **Abort** (scope too vague / sources unreachable): re-dispatch ONCE with a narrower `scope`. If second attempt also aborts, mark that option with `☠️ research failed: <reason>` in its AskUserQuestion description and drop `recommended` consideration for it.
-   - **Timeout / exception**: partial success is acceptable. Proceed to `AskUserQuestion` with `N-1` fully-researched options and one `☠️` option; let the user decide whether to vote it out or accept incomplete information.
+   失败处理：
+   - **Abort**（scope 过模糊 / sources 不可达）：以更窄 `scope` 重新派发**一次**。第二次还 abort 就在该 option 的 AskUserQuestion description 里标 `☠️ research failed: <reason>`，放弃给它 `recommended`。
+   - **Timeout / exception**：允许部分成功。带 `N-1` 个完整调研的 option 和一个 `☠️` option 继续调 `AskUserQuestion`；让用户决定把它 vote out 还是接受不完整信息。
 
-   Parallel safety (maps to `commands/workflow.md` §4 four-condition tree):
-   - PREREQ MET ✅ (decision point identified)
-   - PATH DISJOINT ✅ (research writes no files)
-   - SUCCESS-SIGNAL INDEPENDENT ✅ (each `<research-result>` stands alone)
-   - RESOURCE SAFE ✅ (≤ 4 fan-out cap + short lifetime)
+   并行安全（对应 `commands/workflow.md` §4 的 4 条件判定树）：
+   - PREREQ MET ✅（决策点已识别）
+   - PATH DISJOINT ✅（research 不写任何文件）
+   - SUCCESS-SIGNAL INDEPENDENT ✅（每个 `<research-result>` 独立成立）
+   - RESOURCE SAFE ✅（≤ 4 fan-out 上限 + 短生命周期）
 
 4. 对每个决策点**立即用 `AskUserQuestion` 弹出**：
    - question：简明决策描述
@@ -134,18 +134,18 @@ Git operations are forbidden unless the user explicitly authorizes them in the c
 
 ## AskUserQuestion Option Schema
 
-Every `AskUserQuestion` invocation MUST follow this structural schema. Bare option labels (e.g. just "A" / "B" / "SQLite") are forbidden — each option carries its own rationale and tradeoff so the user can decide without re-researching.
+每次 `AskUserQuestion` 调用**必须**遵循本结构 schema。裸 option label（如仅有 "A" / "B" / "SQLite"）禁用 —— 每个 option 自带 rationale 和 tradeoff，让用户无需重新调研即可决定。
 
-Required fields per option:
+每个 option 的必填字段：
 
-| Field | Required | Notes |
-|-------|----------|-------|
-| `label` | yes | Short option name (≤ 30 chars) |
-| `rationale` | yes | 1-2 sentences on why this option might be chosen |
-| `tradeoff` | yes | Key cost / risk |
-| `recommended` | yes | Exactly 0 or 1 option sets `recommended: true`; if set, include a one-line `why_recommended` |
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `label` | yes | 简短 option 名（≤ 30 字符） |
+| `rationale` | yes | 1–2 句说明为什么可能选这个 option |
+| `tradeoff` | yes | 关键 cost / risk |
+| `recommended` | yes | 恰好 0 或 1 个 option 设 `recommended: true`；若设，附一行 `why_recommended` |
 
-Example (architect selecting persistence layer):
+示例（architect 选存储层）：
 
 ```
 AskUserQuestion(
@@ -174,11 +174,11 @@ AskUserQuestion(
 )
 ```
 
-Rules:
-- Each `AskUserQuestion` call asks exactly ONE decision (never combine several).
-- Options MUST be mutually exclusive within scope.
-- If the architect genuinely has no preference, all options set `recommended: false` and the `question` field should state "no preference, seeking input".
-- User's choice may disagree with the recommendation — accept and proceed.
+规则：
+- 每次 `AskUserQuestion` 调用恰好问一个决策（绝不合并多个）。
+- Options 在 scope 内**必须**互斥。
+- Architect 确实没有偏好时，所有 option 设 `recommended: false`，`question` 字段写明"no preference, seeking input"。
+- 用户的选择可能与推荐不一致 —— 接受并推进。
 
 ---
 


### PR DESCRIPTION
## Summary

- **DEC-008**：Step 3.5 触发条件从"所有 Task 派发"收紧为 `run_in_background: true` 的派发；前台派发完全 skip Monitor，避免主会话同时收缩进工具流 + Monitor 通知的双份信号。修 DEC-004 一个未言明的 assumption。
- **DEC-004 §3 决定第 6 项「触发规则」标 Superseded by DEC-008**；原文保留，append-only 纪律保持。
- **与 DEC-007 (#14) 正交**：DEC-007 修 content layer（agent summary 质量 + awk 折叠）；DEC-008 修 trigger layer（commands 派发 gate）。两个补丁不重叠、不互依。
- **Plugin prompt 语言约定迁移**（翻转 2026-04-18 "全英文"约定）：12 个 prompt 文件（commands/*.md + agents/*.md + skills/*.md, 2708 行）批量翻译为中文为主，关键专有名词（`Task` / `Monitor` / `AskUserQuestion` / `run_in_background` / DEC-xxx / Resource Access / Escalation Protocol 等）保留英文；frontmatter + 代码块不动。

## 变更清单

| 文件 | 说明 |
|------|------|
| `commands/workflow.md` | §3.5.0 新增前台/后台 gate；全文中文化 |
| `commands/bugfix.md` | §Step 0.5 delta 0 同步；全文中文化 |
| `commands/lint.md` / `agents/*.md` / `skills/*.md` | 语言约定迁移 |
| `docs/decision-log.md` | DEC-008 新增；DEC-004 状态行标注 |
| `docs/design-docs/subagent-progress-and-execution-model.md` | §3.8 + frontmatter + 变更记录 |
| `docs/testing/step35-foreground-skip-monitor.md` | 对抗测试 18 cases（2C + 3W + 1S → post-fix 全绿） |
| `docs/reviews/2026-04-19-step35-foreground-skip-monitor.md` | reviewer Approve（0 Critical / 0 Warning） |
| `docs/log.md` / `docs/INDEX.md` | 同步 |
| `CLAUDE.md` | §通用规则语言约定更新 |

## Test plan

- [x] lint_cmd：`grep -rnE "gleanforge\|dex-sui\|dex-ui\|\bvault/\|\bllm/" skills/ agents/ commands/` → 0 命中
- [x] 对抗测试：docs/testing/step35-foreground-skip-monitor.md 18 cases，post-fix 全绿
- [x] 终审：docs/reviews/2026-04-19-step35-foreground-skip-monitor.md Approve
- [x] 所有文件行数结构保持（翻译无语义改动）
- [x] DEC-004 原文未删（append-only 纪律）
- [ ] Dogfood：下一轮 `/roundtable:workflow` 命中前台派发路径验证 Monitor 未启

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)