### PR TITLE
fix(architect): propagate decision-log entry order to target projects (DEC-011, fixes #18)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -55,6 +55,7 @@
 - [phase-transition-rhythm.md](design-docs/phase-transition-rhythm.md) — issue #10 workflow phase gating 三段式分类设计（producer-pause / approval-gate / verification-chain + Stage 9 Closeout），DEC-006 落定
 - [progress-content-policy.md](design-docs/progress-content-policy.md) — issue #14 subagent progress 内容策略（代理节拍 / 去重 / 差异化 / 终止-失败分离），DEC-007 落定；补丁 DEC-004
 - [lightweight-review.md](design-docs/lightweight-review.md) — issue #9 轻量化重构（DEC-009 Proposed；4 shared helper 抽取 + log.md closeout batching + README/CLAUDE.md 结构重塑；预估省 22-25%）
+- [decision-log-entry-order.md](design-docs/decision-log-entry-order.md) — issue #18 DEC 条目顺序约定传导到目标项目（SKILL.md 补插入规则 + Minimal header 初始化 + template 补一行），DEC-011 Accepted
 
 **Plugin 内部 include-only helper**（下划线前缀约定；非独立可激活 skill；不在用户向 skill 清单露出）：
 

--- a/docs/claude-md-template.md
+++ b/docs/claude-md-template.md
@@ -43,7 +43,7 @@
 
 ## 文档约定（可选，缺省走 roundtable 通用约定）
 
-- 决策日志 `docs/decision-log.md`（追加 DEC-xxx，不删旧条目）
+- 决策日志 `docs/decision-log.md`（新条目置顶，最新在前；追加 DEC-xxx，不删旧条目）
 - 操作日志 `docs/log.md`（append-only，顶部最新）
 - 变更记录写在各 doc 底部"变更记录"章节，不入 log.md
 - 主题 slug 用 kebab-case 英文，贯穿 analyze → design-docs → exec-plans → testing

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -77,6 +77,30 @@
 
 ---
 
+### DEC-011 decision-log 条目顺序约定传导到目标项目（SKILL.md 补插入位置规则 + Minimal header 初始化）
+- **日期**: 2026-04-20
+- **状态**: Accepted
+- **上下文**: issue #18 —— roundtable 自家 `docs/decision-log.md` L4 声明"新条目追加在顶部（最新在前）"，但该约定未传导到 architect 写入的目标项目 `decision-log.md`。某目标项目（memo CLI demo）走 `/roundtable:workflow` 后呈现 DEC-001 在上、DEC-002 在下（升序），与约定相反。根因三条：(a) `skills/architect/SKILL.md` L19 Resource Access Write 行 + L59 §阶段 2 第 8 步 + L165 §完成后 只说"追加 `decision-log.md`（DEC-xxx 编号递增）"，未规定追加**位置**；(b) `docs/claude-md-template.md:46` 只说"追加 DEC-xxx，不删旧条目"，与 L47 `log.md（append-only，顶部最新）` 的"顶部最新"不对称；(c) 目标项目新建的 `decision-log.md` 无 header 声明约定，architect 默认 Edit/Write 到文件末尾
+- **决定**:
+  1. **`skills/architect/SKILL.md` 补插入位置规则**：L19 Resource Access `Write` 行、L59 §阶段 2 第 8 步、L165 §完成后 各自后面补"（置顶 / 最新在前；无文件则先写 Minimal header）"；在 §完成后 新增 ### decision-log 条目顺序约定 小节，详述锚点规则（"第一个 `### DEC-` 行"通用锚点）+ Minimal header 模板
+  2. **Minimal header 模板**（3 行引言，~5 行含 `---` 分隔）：`# <项目名> 决策日志\n\n> 新条目追加在顶部（最新在前）。\n> 本文件是项目知识的权威来源。\n\n---` —— 不复制 roundtable 自家的条目格式表 / 状态说明表 / 铁律表（~36 行开销），只固化最关键的"顺序约定"声明
+  3. **`docs/claude-md-template.md` L46 文档约定补一行**：把 `决策日志 docs/decision-log.md（追加 DEC-xxx，不删旧条目）` 改为 `决策日志 docs/decision-log.md（新条目置顶，最新在前；追加 DEC-xxx，不删旧条目）`，与 L47 `log.md（append-only，顶部最新）` 对称
+  4. **插入锚点 = "第一个 `### DEC-` 行"**：通用锚点，空文件 / 仅 header / 已有 N 个 DEC 三种状态均能单一规则定位；拒绝固定行偏移（脆弱）和显式 sentinel 注释（引入新约定成本）
+  5. **不回溯**：已有用户项目既有 DEC 顺序保持不动；本约定仅影响新写入
+  6. **本 DEC dogfood**：DEC-011 写入 roundtable 自家 `docs/decision-log.md` 置于 DEC-010 之前（最新在前）
+  7. **边界纪律**：本约定属 architect 内部规则，不抬到 target CLAUDE.md §critical_modules / §条件触发规则层；不改 5 个 agent prompt；不改 `commands/workflow.md` / `commands/bugfix.md`（它们不直写 decision-log）
+- **备选**:
+  - **Full header (~36 行 meta section)**：评分 44 vs Minimal 51；每个目标项目重复 ~36 行开销，meta 过厚；拒绝
+  - **No header，仅 SKILL.md 规则约束**：评分 38；目标项目用户打开 decision-log 看不到约定声明，未来非 architect 路径手改易违约；拒绝
+  - **固定行偏移锚点**：header 行数变动即破；拒绝
+  - **显式 sentinel 注释锚点**（`<!-- new DEC goes below this line -->`）：引入新约定成本，本项目 dogfood 也要改；拒绝
+  - **改 5 agent prompt 统一 decision-log 写约定**：agent 在 Resource Access 里对 decision-log.md 无 Write 权限（DEC 是 architect 权威源 —— DEC-002 / L165 确立），改 agent 越权；拒绝
+- **理由**: (1) Minimal header 成本最低，直接解决 issue #18 根因 3（目标项目 decision-log 无约定 header）；(2) "第一个 `### DEC-` 行"通用锚点对所有状态单一规则定位，无边界情况；(3) 约定通过文件自身 header 固化，比纯靠 SKILL.md 规则约束更 robust（非 architect 路径手改也能看到约定）；(4) architect 是 decision-log 唯一 Writer，规则落点单一 —— 改 SKILL.md 即完全覆盖；(5) 与 log.md 的"顶部最新"表述对称，用户心智一致
+- **相关文档**: docs/design-docs/decision-log-entry-order.md（设计主文档 + 决策量化评分）、issue #18、DEC-002（Resource Access 权限声明上游 —— architect 是 decision-log 唯一 Writer）
+- **影响范围**: `skills/architect/SKILL.md` 补 +12 行（L19 / L59 / L165 各补一句，§完成后 新增 ### decision-log 条目顺序约定 小节）；`docs/claude-md-template.md` L46 改 1 行；`docs/decision-log.md` 新增本条目（置顶）；`docs/design-docs/decision-log-entry-order.md` 新建。不改 DEC-001 ~ DEC-010；不改 5 个 agent prompt；不改 `commands/workflow.md` / `commands/bugfix.md`；不改 target CLAUDE.md 业务规则边界。运行时：下次 `/roundtable:workflow` 在目标项目写新 DEC 时置顶（最新在前），首次创建则先写 Minimal header
+
+---
+
 ### DEC-010 矫正 DEC-009 决定 1：revert helper 抽取 + 激进 inline 精简（运行期 token 真减）
 - **日期**: 2026-04-19
 - **状态**: Accepted

--- a/docs/design-docs/decision-log-entry-order.md
+++ b/docs/design-docs/decision-log-entry-order.md
@@ -1,0 +1,139 @@
+---
+slug: decision-log-entry-order
+source: 原创（issue #18）
+created: 2026-04-20
+status: Accepted
+decisions: [DEC-011]
+---
+
+# decision-log 条目顺序约定传导 设计文档
+
+## 1. 背景与目标
+
+### 背景
+
+roundtable 自家 `docs/decision-log.md` L4 声明：
+
+> 新条目追加在顶部（最新在前）。
+
+但该约定**未传导到被 architect 写入的目标项目** `decision-log.md`。某目标项目（memo CLI demo）走 `/roundtable:workflow` 后呈现为 DEC-001 在上、DEC-002 在下的**升序**（与约定相反）。
+
+### 根因
+
+1. `skills/architect/SKILL.md` 的 Resource Access（L19）与 §阶段 2 第 8 步（L59）、§完成后（L165）只说"追加 `decision-log.md`（DEC-xxx 编号递增）"，未规定**追加位置**
+2. `docs/claude-md-template.md:46` 只说"追加 DEC-xxx，不删旧条目"，与 L47 `log.md（append-only，顶部最新）` 的"顶部最新"**不对称**
+3. 目标项目首次由 architect 创建的 `decision-log.md` 无 header 声明约定，architect 默认走 Edit/Write 追加到文件末尾
+
+### 目标
+
+1. 在 `skills/architect/SKILL.md` 明确 DEC 追加**置于文件顶部**（紧跟 H1 + meta 引言之后、第一个 `### DEC-` 条目之前）
+2. `docs/claude-md-template.md` §文档约定 补一句"新条目置顶，最新在前"，与 `log.md` 行对称
+3. architect 首次创建目标项目 `decision-log.md` 时写入 **Minimal header**（3 行：title + "新条目追加在顶部（最新在前）" + "本文件是项目知识的权威来源。"），把约定固化到文件自身
+
+### 非目标
+
+- 不改已有用户项目既有 DEC 条目顺序（用户可自行 reorder 或保持现状）
+- 不改 roundtable 自身 `docs/decision-log.md`（它本就合规）
+- 不引入"完整 meta section"（条目格式表 / 状态说明 / 铁律表）—— 避免每个目标项目都重复 ~36 行模板
+
+## 2. 业务逻辑
+
+### 写入流程（architect 角度）
+
+```
+architect 决定写新 DEC-xxx
+  ├─ target decision-log.md 存在？
+  │   ├─ 是 → 定位第一个 `### DEC-` 行 → 在其之前插入新 DEC（含 `\n---\n\n` 分隔符）
+  │   └─ 否 → 先写 Minimal header（3 行）+ `\n---\n\n` → 再写第一个 DEC
+  └─ 已 Accepted DEC 原文不改
+```
+
+### Minimal header 模板
+
+```markdown
+# <项目名> 决策日志
+
+> 新条目追加在顶部（最新在前）。
+> 本文件是项目知识的权威来源。
+
+---
+```
+
+### 插入锚点规则（Anchor）
+
+通用锚点：**第一个 `### DEC-` 行**。这个锚点在 3 种状态下都能定位：
+
+| 文件状态 | 锚点行为 |
+|---------|---------|
+| 空文件 / 不存在 | 无 `### DEC-`，按 "否" 分支走 header 初始化 |
+| 仅 Minimal header（DEC-001 还没写） | 无 `### DEC-`，先写第一个 DEC（header 下面）|
+| 已有 N 个 DEC | 第一个 `### DEC-` 即最新的，在其之前插入新 DEC |
+
+## 3. 技术实现
+
+### 改动清单
+
+| 文件 | 改动 | 行数 |
+|------|------|------|
+| `skills/architect/SKILL.md` | L19 Resource Access Write 行 + L59 §阶段 2 第 8 步 + L165 §完成后 —— 各自后面补"（置顶 / 最新在前；无文件则先写 Minimal header）"；在 §完成后 新增一小节 "decision-log 条目顺序约定" 详述 Minimal header 模板与锚点规则 | +12 行 |
+| `docs/claude-md-template.md` | L46 补"新条目置顶，最新在前" | +1 字段 |
+| `docs/decision-log.md`（本项目 dogfood）| 追加 DEC-011 **置顶**（DEC-010 之前） | +1 条目 |
+
+**不改**：
+
+- 5 个 agent prompt（不触碰 decision-log）
+- `commands/workflow.md` / `commands/bugfix.md`（不直写 decision-log）
+- 其他 skill（analyst / 等）
+- `CLAUDE.md` §critical_modules / §条件触发规则（本约定属 architect 内部规则，不抬到业务规则层）
+
+### SKILL.md §完成后 新增小节草稿
+
+```markdown
+### decision-log 条目顺序约定
+
+- **位置**：新 DEC 置于**顶部**（最新在前）。锚点 = 目标文件第一个 `### DEC-` 行；在其之前插入新条目（含 `\n---\n\n` 分隔符）
+- **初始化**：若目标 `{docs_root}/decision-log.md` 不存在，先写 Minimal header 再写第一个 DEC：
+
+  ```markdown
+  # <项目名> 决策日志
+
+  > 新条目追加在顶部（最新在前）。
+  > 本文件是项目知识的权威来源。
+
+  ---
+  ```
+
+- **不回溯**：已有用户项目既有 DEC 顺序保持不动；本约定仅影响新写入
+```
+
+## 4. 关键决策与权衡
+
+### 决策 1：Header 策略 = Minimal（3 行引言）
+
+| 维度 (0-10) | Minimal ★ | Full (~36 行) | No header |
+|------------|-----------|---------------|-----------|
+| 用户一眼可见约定 | **9** | 9 | 2 |
+| 目标项目 meta 开销 | **9** | 4 | 10 |
+| 与 roundtable 自家一致性 | 7 | **10** | 5 |
+| 未来手改违约风险 | **8** | 8 | 3 |
+| 实施复杂度 | **9** | 7 | 10 |
+| 维护成本（规则漂移） | **9** | 6 | 8 |
+| **合计** | **51** | 44 | 38 |
+
+- **选择**：Minimal
+- **理由**：成本最低、直接解决 issue #18 根因 3（目标项目 decision-log 无约定 header），不把 roundtable 自家 meta 抬到每个目标项目
+- **备选拒绝**：
+  - **Full**：每个目标项目都复制 ~36 行模板开销；目标项目维护者可能认为 meta 过厚
+  - **No header**：目标项目用户打开 decision-log 看不到约定声明；未来手改（非 architect 路径）容易违约
+
+### 决策 2：插入锚点 = "第一个 `### DEC-` 行"
+
+- **选择**：用"第一个 `### DEC-` 行"作通用锚点，在其之前插入
+- **备选**：
+  - 固定偏移（如"第 6 行之后"）：脆弱，header 行数变动即破
+  - 显式 sentinel 注释（`<!-- new DEC goes below this line -->`）：引入新约定成本；本项目 dogfood 文件也要改
+- **理由**："第一个 `### DEC-` 行"对所有状态（空/仅 header/已有 N 条）都能定位，规则单一无边界情况
+
+## 5. 变更记录
+
+- 2026-04-20：初稿（issue #18）

--- a/docs/log.md
+++ b/docs/log.md
@@ -14,6 +14,21 @@
 
 **合并原则**：agent / skill **不直接写本文件**。每轮 workflow 由 orchestrator 按 `commands/workflow.md` §Step 8 log.md Batching 协议（bugfix 流程按 `commands/bugfix.md` §log.md Batching 简化版）收集各 agent final report 中的 `log_entries:` YAML block 聚合写入；同一 agent 在同一轮产出多份文档（如 architect 同时输出 design-doc + DEC + exec-plan）**合并为一条**，`影响文件` 列全部路径（union）；不拆多条。DEC-009 决定 2 落地。
 
+## design | decision-log-entry-order | 2026-04-20
+- 操作者: architect
+- 影响文件: docs/design-docs/decision-log-entry-order.md, docs/decision-log.md
+- 说明: issue #18 —— DEC-011 Accepted：SKILL.md 补插入位置规则 + Minimal header（3 行）初始化 + 锚点 = "第一个 `### DEC-` 行"；template L46 同步；DEC-011 自身置顶 dogfood
+
+## fix | decision-log-entry-order | 2026-04-20
+- 操作者: developer (inline)
+- 影响文件: skills/architect/SKILL.md (+~13 行), docs/claude-md-template.md (L46 改 1 行), docs/INDEX.md (+1 条)
+- 说明: DEC-011 落地 SKILL.md L19 / L59 / L165 + §完成后 新增 "### decision-log 条目顺序约定" 小节；lint 0 命中；reviewer W-01（"仅 header 无 DEC" fallback）+ Suggestion 1/2 + 用户精简诉求一并 post-fix 合并
+
+## review | decision-log-entry-order | 2026-04-20
+- 操作者: reviewer subagent (critical_modules "Skill prompt 本体" 命中 → 必落盘)
+- 影响文件: docs/reviews/2026-04-20-decision-log-entry-order.md (new)
+- 说明: DEC-011 终审 Approve with 1 Warning（0 Critical / 1 Warning / 3 Suggestion）；DEC-002 / DEC-006 / DEC-009 决定 10 / DEC-010 全对齐；影响范围 7 行 ≤ 10 合规；W-01 + Suggestion 1/2 已 post-fix
+
 ## analyze | lightweight-review | 2026-04-19
 - 操作者: analyst
 - 影响文件: docs/analyze/lightweight-review.md

--- a/docs/reviews/2026-04-20-decision-log-entry-order.md
+++ b/docs/reviews/2026-04-20-decision-log-entry-order.md
@@ -1,0 +1,69 @@
+# 审查：DEC-011 decision-log 条目顺序约定传导
+
+- **日期**: 2026-04-20
+- **审查者**: reviewer（roundtable plugin, subagent）
+- **范围**: issue #18 / DEC-011 实施（5 文件：`skills/architect/SKILL.md` + `docs/claude-md-template.md` + `docs/decision-log.md` + `docs/design-docs/decision-log-entry-order.md` + `docs/INDEX.md`）
+- **结果**: **Approve with 1 Warning**（0 Critical / 1 Warning / 3 Suggestion）
+- **触发归档**: 命中 `critical_modules` 首条（`skills/architect/SKILL.md` prompt 本体）
+
+## Critical
+
+（无）
+
+## Warning
+
+### W-01 锚点规则对"仅 Minimal header 无 DEC"状态缺 fallback 条款
+
+- **位置**: `skills/architect/SKILL.md:171`
+- **现状**: 新增小节仅声明 "锚点 = 第一个 `### DEC-` 行；在其之前插入新条目"
+- **问题**: "仅 header 无 DEC" 状态下无锚点可定位；architect 严格按 SKILL.md 执行时首次写入 DEC-001 会卡
+- **对照**: design-doc `docs/design-docs/decision-log-entry-order.md:§2` 表有完整 3 状态分支，但 SKILL.md（architect 运行时规则的权威源）只有一条硬规则
+- **建议**: 在 L171 同 bullet 内加一句："若文件仅含 Minimal header 无 DEC 条目，新 DEC 追加于 `---` 分隔符之后"
+
+## Suggestion
+
+### S-01 初始化触发条件表述不完全对齐
+
+- **位置**: `skills/architect/SKILL.md:19` 与 `:59`
+- **现状**: 两处均表述为"文件不存在时先写 Minimal header"
+- **对照**: 同文件 L172（§新增小节）与 `docs/design-docs/decision-log-entry-order.md:§2` 均用"不存在或为空"
+- **建议**: L19 / L59 括号内改为"文件不存在或为空时先写 Minimal header"
+
+### S-02 §完成后 首个 bullet 可独立可读性
+
+- **位置**: `skills/architect/SKILL.md:165`
+- **现状**: 使用间接引用 "遵循下面 'decision-log 条目顺序约定'"
+- **对照**: L19 / L59 均直接内嵌 "置顶 / 最新在前" 关键短语
+- **建议**: L165 括号内首位加 "置顶 / 最新在前；" 前缀，让该 bullet 独立可读不强依赖下文
+
+### S-03 DEC-011 条目内引用的 SKILL.md 行号是 PR 前快照
+
+- **位置**: `docs/decision-log.md:85`
+- **现状**: "L19 Resource Access / L59 §阶段 2 第 8 步 / L165 §完成后" 引用的是 PR 落地前的行号
+- **说明**: PR merge 后行号会略变（+12 行）；DEC 条目是历史快照属于正常，无需改
+- **建议**: 无 action；仅备注
+
+## 决策一致性
+
+- **DEC-002**（Resource Access 权限声明 / architect 是 decision-log 唯一 Writer）：一致。DEC-011 决定 7 显式 honor
+- **DEC-006**（phase gating taxonomy）：一致。不涉及
+- **DEC-009 决定 10**（新 DEC 影响范围 ≤ 10 行）：一致。DEC-011 影响范围段 7 行
+- **DEC-010**（revert helper 抽取 / inline 精简）：一致。无新 helper 引入
+- **roundtable 自家 decision-log L4 约定**（新条目追加顶部）：已传导到目标项目规则层
+- **DEC-011 自身 dogfood**：一致。L80 置顶（DEC-010 L104 之前），`---` 分隔符正确
+
+## Positive
+
+- ✅ Minimal header 模板结构合法（H1 + 2 行 blockquote + `---`），与 roundtable 自家 L1-L4 的核心"顺序约定"声明对齐（roundtable 自家多一行"记录 X 项目所有关键设计和技术决策"是项目专有描述，Minimal 合理裁剪）
+- ✅ DEC-011 六段齐全、备选 5 条拒绝理由充分
+- ✅ template L46 与 L47 语义对称（"新条目置顶，最新在前" vs "append-only，顶部最新"）
+- ✅ lint 0 命中（`grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` 全部 no matches）
+- ✅ DEC-011 dogfood 闭环（自身置顶，自我践约）
+- ✅ 4 处 SKILL.md 修订点（L19 / L59 / L165 / §新增小节）语义一致，共同承载同一条约束
+
+## 总结
+
+**可合并**。核心语义正确、改动面小、dogfood 自闭环、与既有 DEC 无冲突。
+
+合并前**建议**处理 W-01（1 行补丁，消除 architect 首次写 DEC-001 的 runbook 歧义）。S-01 / S-02 属可读性优化，可随 W-01 一起 ship，也可后续 lightweight follow-up。
+

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -16,7 +16,7 @@ description: Architect role for system design, interface definition, technology 
 | 操作 | 范围 |
 |------|------|
 | Read | `target_project/CLAUDE.md`、`{docs_root}/analyze/`、`{docs_root}/design-docs/`、`{docs_root}/decision-log.md`、`{docs_root}/exec-plans/` |
-| Write | `{docs_root}/design-docs/[slug].md`、`{docs_root}/exec-plans/{active,completed}/[slug]-plan.md`、`{docs_root}/api-docs/[slug].md`、`{docs_root}/decision-log.md`（追加 DEC，不改已 Accepted 条目） |
+| Write | `{docs_root}/design-docs/[slug].md`、`{docs_root}/exec-plans/{active,completed}/[slug]-plan.md`、`{docs_root}/api-docs/[slug].md`、`{docs_root}/decision-log.md`（DEC 置顶 / 最新在前，不改已 Accepted 条目；不存在或为空时先写 Minimal header —— 详见 §完成后） |
 | Report to orchestrator | `log_entries:` YAML block（skill 在主会话直写其他文档；log.md 由 orchestrator 按 Step 8 flush） |
 | Forbidden | `src/*`、`tests/*`、`{docs_root}/reviews/`、`{docs_root}/testing/`、`{docs_root}/log.md` 直写、git 写操作 |
 
@@ -56,7 +56,7 @@ description: Architect role for system design, interface definition, technology 
 
 6. 写 `{docs_root}/design-docs/[slug].md`
 7. 如涉及公开 API 同时写 `{docs_root}/api-docs/[slug].md`
-8. 新决策 → 追加 `{docs_root}/decision-log.md`（DEC-xxx 编号递增）
+8. 新决策 → 追加 `{docs_root}/decision-log.md`（DEC-xxx 编号递增；**置顶 / 最新在前**；不存在或为空时先写 Minimal header —— 详见 §完成后）
 9. in-session output 末尾以 `log_entries:` YAML block 上报本轮产出（同轮多文档合并为一条 entry）
 10. 停下来请用户审阅 design-docs，按反馈微调
 
@@ -162,6 +162,22 @@ status: Active
 
 ## 完成后
 
-- 新决策 → 追加 `{docs_root}/decision-log.md`（直写；DEC 是 architect 权威源）
+- 新决策 → 追加 `{docs_root}/decision-log.md`（直写；置顶 / 最新在前；DEC 是 architect 权威源；详见下面 "decision-log 条目顺序约定"）
 - 不直接写 log.md —— `log_entries:` YAML（`prefix: analyze | design | decide | exec-plan`）上报；同轮多文档合并为一条 entry；orchestrator 按 Step 8 flush
 - 冲突时列 diff 等用户裁决，绝不默默覆盖
+
+### decision-log 条目顺序约定（DEC-011）
+
+- **位置**：新 DEC 置顶（最新在前）。锚点 = 第一个 `### DEC-` 行前（含 `\n---\n\n` 分隔）；若仅 Minimal header 无 DEC，插入到 `---` 之后
+- **初始化**：文件不存在或为空时先写 Minimal header：
+
+  ```markdown
+  # <项目名> 决策日志
+
+  > 新条目追加在顶部（最新在前）。
+  > 本文件是项目知识的权威来源。
+
+  ---
+  ```
+
+- **不回溯**：已有 DEC 顺序不动


### PR DESCRIPTION
## Summary

Fixes #18 — roundtable 自家 `docs/decision-log.md` L4 声明 "新条目追加在顶部（最新在前）"，但该约定未传导到 **architect 写入目标项目** 的 `decision-log.md`。某目标项目（memo CLI demo）走 `/roundtable:workflow` 后呈升序（DEC-001 在上 / DEC-002 在下），与约定相反。

### 根因三条

1. `skills/architect/SKILL.md` L19 Resource Access Write 行 + L59 §阶段 2 第 8 步 + L165 §完成后 只说"追加 decision-log.md（DEC-xxx 编号递增）"，未规定追加**位置**
2. `docs/claude-md-template.md:46` 只说"追加 DEC-xxx，不删旧条目"，与 L47 `log.md（append-only，顶部最新）`不对称
3. 目标项目新建的 `decision-log.md` 无 header 声明约定

### 决定（DEC-011 Accepted）

- **插入位置**：新 DEC 置顶。锚点 = **第一个 `### DEC-` 行**（单一规则覆盖"空 / 仅 header / 已有 N 条" 三状态；若仅 header 无 DEC，插入到 `---` 之后）
- **初始化**：文件不存在或为空时，architect 先写 **Minimal header**（3 行：title + "新条目追加在顶部（最新在前）" + "本文件是项目知识的权威来源"），再写第一个 DEC
- **template L46**：改为"新条目置顶，最新在前；追加 DEC-xxx，不删旧条目"，与 L47 log.md 对称
- **不回溯**：已有用户项目既有 DEC 顺序保持不动
- **Dogfood**：DEC-011 置于 DEC-010 之前（最新在前）

### 决策取舍（量化评分）

| 维度 | Minimal header ★ | Full header (~36 行) | No header |
|------|------|------|------|
| 合计 | **51** | 44 | 38 |

详见 `docs/design-docs/decision-log-entry-order.md` §4。

### 改动清单

- `skills/architect/SKILL.md` (+~13 行) —— 4 处规则补齐
- `docs/claude-md-template.md` (L46 改 1 行)
- `docs/decision-log.md` (+DEC-011 置顶)
- `docs/design-docs/decision-log-entry-order.md` (new)
- `docs/reviews/2026-04-20-decision-log-entry-order.md` (new; reviewer Approve with 1 Warning, post-fix 已处理)
- `docs/INDEX.md` / `docs/log.md` 同步

### 与已有 Accepted DEC 关系

- **DEC-002 RA matrix**：architect 仍是 decision-log 唯一 Writer，无越权
- **DEC-006 phase gating**：走 A → B → C 正常流程，Stage 9 Closeout 汇总
- **DEC-009 决定 10**（影响范围 ≤10 行纪律）：DEC-011 影响范围 7 行合规
- 不改 5 agent prompt / 不改 commands / 不改 target CLAUDE.md 业务规则边界

## Test plan

- [x] `lint_cmd`（硬编码扫描）0 命中
- [x] reviewer 终审 Approve with 1 Warning（W-01 fallback + Suggestion 1/2 已 post-fix）
- [x] 本 PR dogfood：DEC-011 自身置于 `docs/decision-log.md` 顶部（DEC-010 之前）
- [ ] 下一次 `/roundtable:workflow` 在新目标项目首次写 DEC 时验证 Minimal header 初始化

## 相关

- Fixes #18
- DEC-011 (new) / DEC-010 / DEC-009 / DEC-006 / DEC-002

🤖 Generated with [Claude Code](https://claude.com/claude-code)