### PR TITLE
feat(workflow): add dispatch mode selection (DEC-012, fixes #19)

### DIFF
--- a/commands/bugfix.md
+++ b/commands/bugfix.md
@@ -21,6 +21,8 @@ argument-hint: <bug 描述 或 issue 编号>
 
 复用 `/roundtable:workflow` §3.5 机制。
 
+**Dispatch mode selection（DEC-012）**：派发前按 `commands/workflow.md` §Step 3.4 评估 `run_in_background`。Bugfix 通常单派发 → D2 命中 fg；reviewer / dba / tester 兜底派发同规则。
+
 **Gate（DEC-008）+ env opt-out**：仅 `run_in_background: true` 且 `ROUNDTABLE_PROGRESS_DISABLE` 未设为 `1` 的派发触发本 Step。前台派发 / env opt-out / developer inline（见 Step 3）均 skip Monitor setup 并不注入 4 progress 变量；subagent 按其 `## Progress Reporting` fallback 静默降级。并行批每个 `Task` 独立评估。
 
 **执行**：Gate 通过且未 opt-out → 按 `commands/workflow.md` §3.5.1–3.5.4 执行 Bash 准备 / Monitor 启动 / 4 变量注入 / Lifecycle。

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -87,6 +87,20 @@ closeout  → 汇总 reviewer / dba findings
 
 ---
 
+## Step 3.4: Dispatch Mode Selection
+
+每次 `Task` 派发前按序评估 `run_in_background`（第一匹配胜出）：
+
+1. **用户声明**：prompt 含 `@roundtable:<role> bg|fg` / "后台派 <role>" / "前台派 <role>" 等中英文等价 → 按声明
+2. **并行度**：本 assistant message 内 Task 调用数
+   - 单发 → `false`（对齐 Claude Code 默认）
+   - 并行批 ≥2 → 全部 `true`
+3. **模糊兜底** → `AskUserQuestion` fg / bg 两选
+
+前置：Step 4 并行判定必须先行，其结论是步骤 2 的输入。选完进入 §3.5.0 gate。
+
+---
+
 ## Step 3.5: Progress Monitor Setup（DEC-004；触发 DEC-008）
 
 每个 `run_in_background: true` 的 `Task` 派发配一次 `Monitor` 调用，让用户实时看 phase 级进度。

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,6 +46,7 @@
 - [subagent-progress-and-execution-model.md](analyze/subagent-progress-and-execution-model.md) — subagent 进度可见性 + 执行模型选择 5 路径对比（Claude Code/SDK/Monitor + CrewAI/AutoGen/LangGraph；8 事实层开放问题交 architect，解 issue #7）
 - [phase-transition-rhythm.md](analyze/phase-transition-rhythm.md) — issue #10 workflow phase transition 节奏对标研究（git/terraform/apt/kubectl/Make/CrewAI/AutoGen/LangGraph/Claude Code 9 种 CLI/orchestrator UX；6 事实层开放问题交 architect）
 - [lightweight-review.md](analyze/lightweight-review.md) — issue #9 轻量化审计（archive 826 vs 现状 2708 行 = 3.16× / 8 个 DEC 增量分类 / 3 大抽取热区 DEC-002/004/007 / 7 事实层开放问题）
+- [dispatch-mode-strategy.md](analyze/dispatch-mode-strategy.md) — issue #19 前台/后台派发选择策略调研（F1-F6 事实 + 3 选项对比 + 5 场景评估 + 判据 D1-D4 + 8 事实层开放问题 P1-P8 交 architect）
 
 ### design-docs
 
@@ -56,6 +57,7 @@
 - [progress-content-policy.md](design-docs/progress-content-policy.md) — issue #14 subagent progress 内容策略（代理节拍 / 去重 / 差异化 / 终止-失败分离），DEC-007 落定；补丁 DEC-004
 - [lightweight-review.md](design-docs/lightweight-review.md) — issue #9 轻量化重构（DEC-009 Proposed；4 shared helper 抽取 + log.md closeout batching + README/CLAUDE.md 结构重塑；预估省 22-25%）
 - [decision-log-entry-order.md](design-docs/decision-log-entry-order.md) — issue #18 DEC 条目顺序约定传导到目标项目（SKILL.md 补插入规则 + Minimal header 初始化 + template 补一行），DEC-011 Accepted
+- [dispatch-mode-strategy.md](design-docs/dispatch-mode-strategy.md) — issue #19 subagent 派发 run_in_background 选择策略（方向 1 规则补齐 + D2 并行度判据 + D4 两级逃生门；DEC-008 正交补齐），DEC-012 Accepted
 
 **Plugin 内部 include-only helper**（下划线前缀约定；非独立可激活 skill；不在用户向 skill 清单露出）：
 
@@ -87,6 +89,8 @@
 - [2026-04-19-phase-transition-rhythm.md](reviews/2026-04-19-phase-transition-rhythm.md) — issue #10 DEC-006 终审（Approved-with-caveats：0 Critical / 3 Warning / 5 Suggestion；DEC-001~DEC-005 全对齐；2C+W-08 已根因修复）
 - [2026-04-19-progress-content-policy.md](reviews/2026-04-19-progress-content-policy.md) — issue #14 DEC-007 终审（Approve-with-caveats：0 Critical / 2 Warning / 3 Suggestion / 5 Positive；4 agent 逐字对称；推荐 back-feed fflush 到 design-doc §3.4）
 - [2026-04-19-lightweight-review.md](reviews/2026-04-19-lightweight-review.md) — issue #9 DEC-009 终审（Approve-with-caveats：0 Critical / 3 Warning / 4 Suggestion / 5 Positive；DEC-001 D1-D9 + DEC-002~008 全保；decision-log 3 铁律遵守；DEC-004 schema 零改；lint 0 命中；W-01 已 post-fix）
+- [2026-04-20-decision-log-entry-order.md](reviews/2026-04-20-decision-log-entry-order.md) — issue #18 DEC-011 终审（Approve with 1 Warning；0 Critical / 1 Warning / 3 Suggestion；W-01 Minimal header 无 DEC fallback + S1/S2 措辞 post-fix）
+- [2026-04-20-dispatch-mode-strategy.md](reviews/2026-04-20-dispatch-mode-strategy.md) — issue #19 DEC-012 终审（Approve-with-caveats；0 Critical / 3 Warning / 2 Suggestion；W-01 section-number §3.4.5→§3.4 + W-03 Step 4 前置顺序 + S-01/S-02 全 post-fix）
 
 ## 主题 slug 约定
 

--- a/docs/analyze/dispatch-mode-strategy.md
+++ b/docs/analyze/dispatch-mode-strategy.md
@@ -1,0 +1,226 @@
+---
+slug: dispatch-mode-strategy
+source: 原创（issue #19）
+created: 2026-04-20
+---
+
+# 前台/后台派发选择策略 调研报告
+
+## 背景与目标
+
+**背景**：DEC-008（issue #15）引入 Step 3.5.0 gate —— `run_in_background: true` 才启 Monitor，前台派发 skip。但**上游决策缺失**：orchestrator 如何选择 `run_in_background` 的值？
+
+当前 `commands/workflow.md` / `commands/bugfix.md` 所有 Task 派发点**不声明**该参数、**不提供**选择规则。dogfood 观察到 developer subagent 派发同时可见 Monitor 通知 + 主会话缩进工具流 —— 说明 gate 判据与实际可见性在某些派发形态下不一致（或 orchestrator 将字段设为 `true` 但实际行为却像前台）。
+
+**目标**：给 architect 提供事实层交接，覆盖当前实现分布、Claude Code Task 工具语义、3 个方向（规则补齐 / 删 Monitor 全前台 / 强制全后台）的各场景代价。
+
+## 追问框架
+
+### 失败模式
+
+方案最可能失败的点：
+- **选项 1（规则补齐）**：LLM 按决策树选 dispatch mode 的一致性在真实会话里漂移（同类任务一次选 fg、一次选 bg）。一旦 orchestrator 误判，即重现 issue #19 的"Monitor + 缩进流双份信号"或"后台派发失可见性"
+- **选项 2（删 Monitor / 全前台）**：reviewer + tester + dba 并行场景被阉割成串行，wall time 翻 3×；长任务（80k token reviewer）缩进流刷屏淹没主会话
+- **选项 3（全后台强制）**：前台已就绪的缩进可见性被主动丢弃；所有小任务都多付一次 Bash + jq + Monitor 启动开销；违反 Claude Code Task 工具"foreground is default"的心智
+
+### 6 个月后评价
+
+- **选项 1** 风险：决策树过度工程，被"什么任务该 bg"的解释性争论消耗后续 DEC
+- **选项 2** 风险：回滚复杂（DEC-004/007/008 的代码和文档投入已落地，revert 需 Superseded 3 个 DEC + 改 5 个 agent prompt + 改 2 commands + 改 design-doc）
+- **选项 3** 风险：与 DEC-008 的"前台免 Monitor"心智反向，6 个月后 maintainer 可能再发一个 issue 回到现状
+
+### 按需 4 问：不适用
+
+本调研是**内部 workflow orchestrator 派发策略重构**，非新功能 / 非面向用户产品。痛点 / journey / 最简方案 / 竞品对比已在 DEC-004（P1-P6 对比 6 路径）+ DEC-008（前台 gate 动机）+ issue #19 正文覆盖。
+
+## 调研发现
+
+### F1. workflow.md / bugfix.md 的 `run_in_background` 声明分布
+
+扫 `commands/workflow.md` + `commands/bugfix.md`（共 414 + 108 行），`run_in_background` 关键词**仅出现在 DEC-008 gate 条件描述里**，**无任何派发点显式声明**：
+
+| 文件 | 行 | 上下文 |
+|------|---|--------|
+| `commands/workflow.md` | 92 / 98 / 99 | Step 3.5 gate 说明（"`true` → 进入 §3.5.1`；缺省 / `false` → skip"） |
+| `commands/bugfix.md` | 24 | Step 0.5 gate 说明（"仅 `run_in_background: true` 且 env 未 opt-out 触发"） |
+
+**派发点状态**：
+- workflow.md 中 Task 派发通过 Step 3 artifact chain 描述（L67-86）与 Step 6b developer form（L207-224）间接触发，**无显式 `Task(run_in_background: ...)` 示例**
+- bugfix.md 中 派发契约 Step 3 L62-67 列 4 个注入变量，**同样无 `run_in_background` 项**
+
+结论：**orchestrator 派发时的 `run_in_background` 值完全由 LLM 自由决定，无 prompt 层约束**。这是 issue #19 的直接根因。
+
+### F2. 5 agent prompt 的 dispatch hint 扫描
+
+`agents/developer.md` / `agents/tester.md` / `agents/reviewer.md` / `agents/dba.md` / `agents/research.md` —— grep `run_in_background|前台|后台|foreground|background` **0 命中**（过滤 DEC-008 gate 相关则降到 0）。agent 本体不感知派发形态（符合 DEC-008 设计 ——"agent 不知派发形态，orchestrator 层 gate 是唯一可执行点"，见 DEC-008 理由 (1)）。
+
+### F3. DEC-004 原始 assumption vs DEC-008 patch
+
+- **DEC-004 决定 6 原文**（`docs/decision-log.md` L210）："所有 subagent dispatch 默认开启（不做 critical_modules 二级过滤）；用户可设 `ROUNDTABLE_PROGRESS_DISABLE=1` 关掉"
+- **隐含 assumption**（design-doc §3.8 L266 明言）：所有 Task 派发都是**后台派发**（`run_in_background: true`），主会话对 subagent 内部不可见
+- **DEC-008 patch**：触发条件从"所有 Task" 收紧为 "`run_in_background: true` 的 Task"。gate 前移解决"前台派发双份信号"问题 —— **但并未规定派发本身应选哪个 mode**
+
+### F4. Claude Code Task 工具的文档语义
+
+源：`Task` 工具 description（Claude Code 官方）。关键条款：
+
+> **Foreground vs background**: Use foreground (default) when you need the agent's results before you can proceed — e.g., research agents whose findings inform your next steps. Use background when you have genuinely independent work to do in parallel.
+
+> When an agent runs in the background, you will be automatically notified when it completes — do NOT sleep, poll, or proactively check on its progress. Continue with other work or respond to the user instead.
+
+**官方默认 = foreground**。官方 background 使用场景 = "genuinely independent work in parallel"。
+
+### F5. 前台派发的 dogfood 观察（3 来源交叉验证）
+
+1. **design-doc §3.8 L270**：前台 Task 子 agent 的 Bash/Read/Edit/Write 工具调用以**缩进形式实时显示**在主会话输出里
+2. **用户 memory `feedback_foreground_agent_no_monitor`**：前台 Task 子 agent 缩进输出已实时显示，Monitor 仅 `run_in_background: true` 时需要
+3. **本会话 issue #18 reviewer 派发实录**：前台 subagent 派发期间主会话阻塞等 Task 返回，无 Monitor 启动，final message 带完整 review summary 直接可读
+
+**一致结论**：前台 Task = 主会话阻塞 + 子 agent 工具调用缩进流实时可见 + Task 返回 final message。
+
+### F6. 后台派发的能力与代价
+
+来自 DEC-004 + design-doc §3.1-3.3：
+- 不阻塞主会话 → 可在同一 assistant message 并行 issue N 个 Task
+- subagent 内部**完全不可见** → Monitor 是唯一 phase 级进度通道
+- 需 Bash（生成 `progress_path`）+ Monitor（`tail -F | jq | awk`）+ 4 变量注入 —— 每派发 ~6 次工具调用 overhead
+- progress schema + agent prompt `## Progress Reporting` section（每 agent ~20 行）+ Content Policy helper（DEC-007）
+
+## 对比分析（3 选项的事实层）
+
+### 选项 1：补齐规则（保留 DEC-004/008 + 决策树）
+
+**现有基建**（零改动）：Step 3.5 完整，Monitor + jq + Content Policy helper 全在
+
+**需改造**：
+- `commands/workflow.md` / `commands/bugfix.md` 新增"`run_in_background` 选择规则"章节
+- 可选：5 agent prompt 各声明"本角色默认派发 mode"（critical_modules 命中 4/5，改动面大）
+
+**不改**：DEC-004/007/008，design-doc，helper
+
+**已有规则候选**（D1-D4 见下 §判据候选评估）
+
+### 选项 2：默认全前台 + 删 Monitor
+
+**现有基建**：前台派发的缩进工具流已天然可见（F5）
+
+**需改造**：
+- **删**：`commands/workflow.md` Step 3.5（全节 ~65 行）、Step 4 并行派发判定树可能需降级（并行失效）
+- **删**：5 agent prompt `## Progress Reporting` section（估 5 × 20 = 100 行）
+- **删**：`skills/_progress-content-policy.md`（DEC-007 产出）
+- **Supersede**：DEC-004（全量）、DEC-007（全量）、DEC-008（自然过时）
+- **改**：`docs/design-docs/subagent-progress-and-execution-model.md` §3.1-3.8（约 180 行）
+- **改**：`docs/decision-log.md` 3 条 Superseded 标注
+
+**能力代价**：
+- **并行派发**：Step 4 判定树的 4 条件前台场景下无意义（前台阻塞 → 无法并行）。reviewer + tester + dba 串行，wall time 翻 3×
+- **长任务 UX**：reviewer 扫全仓（80k token、3-10 min）或 tester 跑 17 suites，缩进工具流可能数百行淹没主会话
+- **subagent context 隔离**：保留（Task 本质是 subagent，不依赖 mode），但主会话消费的 tool-stream token 增加
+
+**代价量级**：DEC-004/007/008 实施投入合计约 600+ 行代码 + 文档；revert 工作量 ≈ 1 个 architect + developer + tester + reviewer 轮次
+
+### 选项 3：默认全后台 + Monitor 强制
+
+**现有基建**：DEC-004 全链路无改动
+
+**需改造**：
+- `commands/workflow.md` Step 3.5.0 gate **删除**（不再条件触发）
+- `commands/bugfix.md` Step 0.5 gate 删除
+- `docs/design-docs/subagent-progress-and-execution-model.md` §3.8 **Superseded**
+- **Supersede**：DEC-008（全量 revert）
+- **保留**：DEC-004/007
+
+**能力代价**：
+- 前台派发的缩进流可见性**主动丢弃**（Monitor summary 是 phase 级，比 tool 级信息密度低）
+- 所有小任务（bugfix 单 developer 派发）多付 Bash + Monitor 启动开销（~6 次工具调用）
+- 违反 Claude Code Task 工具 "foreground is default" 官方心智 —— plugin 层覆盖原厂默认
+
+### 选项间共有事实
+
+- 3 选项**都不影响** subagent context 隔离能力（Task 本质，与 mode 无关）
+- 3 选项**都不改** agent Resource Access / Escalation Protocol / AskUserQuestion Option Schema
+- 3 选项**都在** critical_modules hit 范围（改 commands prompt 本体 / Phase Matrix / Progress schema 之一）
+
+## 场景评估（对 3 选项同权）
+
+### S1. 小任务（bugfix hotfix / doc 补丁 / < 20k token / < 2min，单派发）
+
+- **选项 1 决策树**：若判据命中 fg → 等同现状前台；若漏判为 bg → 重现 issue #19 双份信号
+- **选项 2 全前台**：天然合适
+- **选项 3 全后台**：多付 Monitor 启动开销，收益 = phase 级 summary 替代缩进流
+
+### S2. 单长任务（reviewer 80k token 扫全仓 / tester 17 suites，单派发）
+
+- **选项 1**：若判据引入"按预估耗时" → bg，Monitor 给干净 summary
+- **选项 2**：缩进流可能数百行淹没主会话（但用户记忆 `feedback_foreground_agent_no_monitor` 表明当前 dogfood 可接受）
+- **选项 3**：等同现状 bg
+
+### S3. 并行多角色（reviewer + tester + dba 同期，估 20-30 min wall time）
+
+- **选项 1**：若判据引入"并行批 → bg" → 等同现状
+- **选项 2**：**不可行** —— 前台阻塞 → 无并行；wall time 翻 3×
+- **选项 3**：等同现状 bg
+
+### S4. developer subagent 形态（已由 DEC-005 支持 inline 逃生门）
+
+- 3 选项**对 developer 影响最小** —— inline path 不走 Task，不进入 mode 讨论
+- subagent path 命中规则：选项 1 看判据、选项 2 → fg、选项 3 → bg
+
+### S5. bugfix 流程（fan-out 窄，单 developer + 可选 reviewer/dba/tester 两阶段）
+
+- 3 选项都可串行，**没有并行刚需**
+- bugfix.md Step 3 已提"偏向 inline"（DEC-005 边界），subagent path 同 S1/S2
+
+## 判据候选评估（仅选项 1 需要）
+
+维度：按角色 / 按并行度 / 按预估耗时 / 按用户显式偏好。表格陈述可执行性（fact），不打分：
+
+| 判据 | 决策颗粒 | 可执行性（fact） | 客观代价 / 排除项 |
+|------|---------|-----------------|-------------------|
+| **D1 按角色** | 每角色一个默认值（e.g. reviewer/tester/dba/research → bg；developer subagent → bg；fg = exceptional） | agent prompt 或 commands table 硬编码；LLM 查表不判断 | 灵活性低，S1 场景的小 reviewer 也走 bg；critical_modules 命中 5 agent，改动面大 |
+| **D2 按并行度** | 并行批（≥2 Task 同 message）→ bg；单派发 → fg | orchestrator 在 issue Task 前已知是否并行，判据确定 | 单派发长任务（S2）错判成 fg，缩进流刷屏；需与 D1/D3 组合 |
+| **D3 按预估耗时** | LLM 估算 wall-time，> 2min → bg | 需 orchestrator 对子任务耗时有先验（e.g. "reviewer 扫全仓 > 2min" → bg），易漂移 | LLM 估算漂移；跨角色难校准；PR #19 issue 正文的 6 分钟 developer subagent 实录是典型反例 |
+| **D4 按用户显式偏好** | 三级：per-session `@roundtable:tester bg`/`fg` → per-project CLAUDE.md `dispatch_mode_default: fg / bg` → per-dispatch AskUserQuestion | 复用 DEC-005 三级切换心智，orchestrator 已熟悉 | 每次派发可能有 AskUserQuestion 干扰；per-project key 与 `developer_form_default` 语义重叠 |
+
+**组合候选**：
+- **D1+D2 组合**：并行批 → bg（覆盖 S3）；单派发 → 查 D1 角色默认（覆盖 S1/S2）—— 规则扁平，零用户干预
+- **D1+D4 组合**：D1 作 baseline，D4 per-session 覆盖（覆盖 S1/S2 + 用户逃生门）
+- **D2 only**：单派发无差别 fg（含 S2 长任务），并行 → bg —— 最简，但 S2 UX 差
+
+## 开放问题清单（事实层）
+
+- **P1. 选项 2 的"删 Monitor"对并行派发（S3）代价是否可接受？**（事实：当前 Step 4 判定树只在后台派发下有意义；前台无法并行；user memory 未表态对并行刚需的偏好）——`commands/workflow.md` L146-157 Step 4，`docs/decision-log.md` DEC-002
+- **P2. 选项 3 的"全后台强制"违反 Claude Code `Task` 工具官方默认（fg）的心智**：plugin 层是否应覆盖宿主默认？——`Task` 工具 description "Foreground is default"
+- **P3. 选项 1 判据组合选择（D1+D2 vs D1+D4 vs D2 only vs 其他）**：取决于用户对"orchestrator 决策确定性 vs 用户干预频率"的偏好——本 analyst 调研范围不给推荐
+- **P4. per-role 默认值（若选 D1）是否需要进入 target CLAUDE.md 业务规则层？**（事实：DEC-001 D2 "零 userConfig"边界；DEC-005 已开 `developer_form_default` 先例；但 plugin 元协议与业务规则边界在 DEC-005 FAQ Q2 有论证）——`docs/claude-md-template.md:62-70`，`docs/decision-log.md` DEC-005
+- **P5. DEC-008 要不要 Supersede？**（事实：选项 2 → DEC-008 自然过时；选项 3 → 显式 revert；选项 1 → DEC-008 保留不变）——与 P3 耦合
+- **P6. 若选项 2，Step 4 并行派发判定树的命运**：删除（前台无并行语义）/ 保留作架构锚点 / 改写成"何时升级为后台并行"—— `commands/workflow.md` L146-157
+- **P7. DEC-005 已为 developer 开 inline 逃生门；reviewer / tester / dba 是否也该有同样的 per-dispatch 决策点（issue #20 的核心）？**（事实：issue #20 与 #19 耦合 —— 若 #19 选方向 2，#20 的 inline 讨论范围缩小到 "全前台 subagent 的缩进流刷屏缓解"；若 #19 选方向 1/3，#20 独立决策）
+- **P8. dogfood 记录里"developer subagent 派发同时可见 Monitor + 缩进流"到底是哪个配置的 bug？**（issue #19 "深层问题"提出但本调研未能复现；事实：`commands/workflow.md` Step 3.5.0 gate 若正确执行则不会双份信号；疑为 orchestrator 误把 `run_in_background: true` 设在应 fg 的派发上）——需 architect 拍板是否先修这个特定 bug 再做结构性决策
+
+## FAQ
+
+### Q1: orchestrator 是什么？和 #19 的 `run_in_background` 选择是谁的决策？
+
+Orchestrator = 执行 `/roundtable:workflow` / `/roundtable:bugfix` 的**主会话 Claude**（不是独立进程或 agent，是主会话本身跑 `commands/workflow.md` 的编排逻辑）。
+
+**职责**：只做编排，不做实质设计/编码/审查（`commands/workflow.md` L306）。具体包括 Step 0 context、Step 1 规模判定、Phase Matrix 维护、pipeline 激活、Step 3.5 Monitor setup、Step 5 Escalation relay、Step 6 phase gating（A/B/C）、Step 7 INDEX 维护、Step 8 log.md flush。
+
+**对 3 类角色的派发机制**：
+
+| 角色形态 | 派发方式 | 执行位置 |
+|---------|---------|---------|
+| skill（analyst / architect） | `Skill` 工具 | 主会话（共享 context） |
+| subagent（tester / reviewer / dba / research） | `Task` 工具 | 独立 subagent context |
+| inline developer（DEC-005） | `Read agents/developer.md` + 主会话照做 | 主会话 |
+
+**关键特权**（角色没有的权限）：
+- 唯一 Writer：`docs/INDEX.md` / `docs/log.md` / exec-plan checkbox（DEC-002 shared-resource 转发避免 race）
+- 唯一 `AskUserQuestion` relayer（subagent `<escalation>` block 必须过 orchestrator）
+- 唯一 git 执行者（且仅用户显式要求）
+
+**与 #19 的关系**：DEC-004 / DEC-008 争议的 "`run_in_background` 如何选" 就是 orchestrator 在 issue `Task` 工具调用前的 LLM 级决策 —— 当前 `commands/workflow.md` 无规则约束，orchestrator 靠自由心证。issue #19 本质是"给 orchestrator 补一条派发模式选择的 prompt 层约束"，让 LLM 决策有可预测边界。
+
+## 变更记录
+
+- 2026-04-20：初稿（issue #19）

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -77,6 +77,31 @@
 
 ---
 
+### DEC-012 subagent 派发 run_in_background 选择策略（D2 并行度 + D4 两级逃生门；DEC-008 正交补齐上游）
+- **日期**: 2026-04-20
+- **状态**: Accepted
+- **上下文**: issue #19 —— DEC-008 在 `commands/workflow.md` Step 3.5.0 引入 gate（`run_in_background: true` 才启 Monitor），但**上游决策缺失**：orchestrator 如何选 `run_in_background` 的值？`commands/workflow.md` / `commands/bugfix.md` / 5 agent prompt 均无选择规则（analyst F1/F2 确认 0 规则），orchestrator 靠 LLM 自由心证。dogfood 实录显示"Monitor 通知 + 主会话缩进流双份信号"偶发（P8 bug），即误判典型。analyst 报告 3 选项对比（规则补齐 / 删 Monitor 全前台 / 强制全后台）+ 5 场景 × 3 选项矩阵 + 判据 D1-D4 浓缩为 3 个 architect 决策点
+- **决定**:
+  1. **方向 1 规则补齐**（不 Supersede DEC-004/007/008；保留所有既有投入）—— 方向 2 丢并行（S3 wall time 翻 3×）+ revert 600+ 行代价大；方向 3 违反 Claude Code Task 工具 foreground-default 官方心智
+  2. **D2 并行度核心判据**：单派发 Task（同一 assistant message 只 1 个 Task）→ `run_in_background: false`（对齐官方默认）；并行批 ≥2 Task → 全部 `run_in_background: true` + Monitor。Step 4 并行判定树不变
+  3. **D4 用户逃生门两级**：per-session 用户 prompt @声明（`@roundtable:<role> bg|fg` 或中英文等价）强制覆盖 D2；per-dispatch orchestrator 模糊时调 `AskUserQuestion`（fg/bg 两选项带 rationale）
+  4. **不引入 target CLAUDE.md 配置项**（不抬 `dispatch_mode_default`）—— 对齐 DEC-011 边界："dispatch mode 是 orchestrator 内部策略，非项目业务规则"；与 DEC-005 `developer_form_default` 有意区别（developer form 是角色形态偏好，是项目级；dispatch mode 是运行时参数选择）
+  5. **DEC-008 Accepted 保留**：DEC-012 正交补齐上游（DEC-012 选 mode → DEC-008 根据 mode 决定 Monitor 是否启）；不 Supersede
+  6. **#20 scope 边界**：本 DEC **只决策 subagent 形态（Task 派发）下的 fg/bg**；不碰"role 是否支持 inline 形态"（issue #20 独立）。若 #20 给 tester/reviewer/dba 加 inline 逃生门，inline 路径天然不经 Task，不触发本 DEC §3.4
+  7. **P8 验收点**：实施后单发 developer subagent → D2 命中 fg → DEC-008 skip Monitor → 主会话不再出现双份信号
+- **备选**:
+  - **方向 2（删 Monitor 全前台，Supersede DEC-004/007/008）**：量化评分 27 vs 方向 1 的 54；并行派发能力丢失是关键；拒绝
+  - **方向 3（强制全后台，Supersede DEC-008）**：评分 44；违反官方默认 + 小任务多付 Monitor 启动开销；拒绝
+  - **D1+D2（角色 + 并行度）**：评分 32 vs D2+D4 的 44；5 agent 或 commands 表硬编码改动面大 + critical_modules 多点命中 + 无用户逃生门；拒绝
+  - **D2 only**：评分 39；规则最扁但无用户逃生门；拒绝
+  - **D1+D2+D4（三层）**：评分 40；三层 fallback 复杂度高，D1 属过度设计（user memory `feedback_foreground_agent_no_monitor` 证前台缩进流可接受，无需 per-role 区分）；拒绝
+  - **D4 三级（+ per-project CLAUDE.md）**：违反决定 4 边界；dispatch mode 是 orchestrator 层非业务层；拒绝
+- **理由**: (1) 方向 1 保留 DEC-004/007/008 投入 + 保留并行能力 + 对齐 Claude Code 官方默认，量化评分 54 最优；(2) D2 单一判据确定性高，orchestrator 查"本 message 内几个 Task"即可决策；(3) D4 per-session 声明对齐 DEC-005 per-session 机制心智；(4) per-dispatch AskUserQuestion 兜底模糊情况，复用现有弹窗机制零新 UI；(5) 不引入 CLAUDE.md 配置项避免选项疲劳 + 保持业务规则边界；(6) P8 bug 由 D2 自动修复（单发 developer → fg）无需 targeted hotfix
+- **相关文档**: docs/analyze/dispatch-mode-strategy.md（F1-F6 事实 + 3 选项对比 + 5 场景 × 3 选项矩阵 + 判据 D1-D4 + P1-P8 开放问题）、docs/design-docs/dispatch-mode-strategy.md（含 3 项决策量化评分 + P8 验收点）、DEC-004（Progress schema 上游）、DEC-008（前台免 Monitor gate 下游，正交补齐）、DEC-005（developer 双形态心智对齐）、DEC-011（边界声明参考：内部策略不抬 CLAUDE.md）、issue #19
+- **影响范围**: `commands/workflow.md` 新增 §3.4 Dispatch Mode Selection（置于 Step 3.5 前）；`commands/bugfix.md` Step 0.5 加引用（一句）；`docs/design-docs/dispatch-mode-strategy.md` 新建；`docs/decision-log.md` 本条（置顶 dogfood DEC-011）；`docs/INDEX.md` 新增 design-doc 条目。不改 5 agent prompt；不改 DEC-001~DEC-011 任何 Accepted 条款；不改 target CLAUDE.md；不改 Step 4 并行判定树。运行时：下一次派发 subagent 时 orchestrator 走 D2→D4 树选 mode；P8 dogfood bug 自动修复
+
+---
+
 ### DEC-011 decision-log 条目顺序约定传导到目标项目（SKILL.md 补插入位置规则 + Minimal header 初始化）
 - **日期**: 2026-04-20
 - **状态**: Accepted

--- a/docs/design-docs/dispatch-mode-strategy.md
+++ b/docs/design-docs/dispatch-mode-strategy.md
@@ -1,0 +1,154 @@
+---
+slug: dispatch-mode-strategy
+source: analyze/dispatch-mode-strategy.md
+created: 2026-04-20
+status: Accepted
+decisions: [DEC-012]
+---
+
+# 前台/后台派发选择策略 设计文档
+
+## 1. 背景与目标
+
+### 背景
+
+DEC-008（issue #15）引入 `commands/workflow.md` Step 3.5.0 gate —— `run_in_background: true` 才启 Monitor，前台派发 skip。但**上游决策缺失**：orchestrator 如何选择 `run_in_background` 的值？
+
+`commands/workflow.md` / `commands/bugfix.md` / 5 agent prompt **均无** `run_in_background` 选择规则（见 analyst 报告 F1/F2），orchestrator 靠 LLM 自由心证。dogfood 实录显示"Monitor 通知 + 主会话缩进流双份信号"偶发（P8 bug），即误判典型。
+
+### 目标
+
+给 orchestrator 补一条**确定性规则**指导 `run_in_background` 选择，保留 DEC-004/007/008 所有投入，不丢并行派发能力，与 Claude Code Task 工具官方默认（foreground）对齐。
+
+### 非目标
+
+- 不动 DEC-004 Progress event schema
+- 不动 DEC-005 developer 双形态（inline / subagent）
+- 不动 DEC-007 Content Policy
+- 不动 DEC-008 前台免 Monitor gate（DEC-012 正交补齐上游）
+- 不决策 tester / reviewer / dba 是否支持 inline 形态（issue #20 scope）
+- 不引入 target CLAUDE.md 新配置项（对齐 DEC-011 边界 —— dispatch mode 属 orchestrator 内部策略）
+
+## 2. 业务逻辑
+
+### 2.1 选择规则主流程
+
+```
+orchestrator 准备发 Task 调用
+  ├─ 用户 prompt 含 per-session @声明？
+  │   ├─ "@<role> bg" / "后台派 <role>" → force background
+  │   └─ "@<role> fg" / "前台派 <role>" → force foreground
+  │   （任一匹配 → 跳过 D2，进入执行）
+  │
+  ├─ 本 assistant message 内还有其他 Task 调用？
+  │   ├─ 是（并行批 ≥2）→ 全部 `run_in_background: true` + Monitor（per DEC-008 gate）
+  │   └─ 否（单发）→ `run_in_background: false`（默认，skip Monitor per DEC-008 gate）
+  │
+  └─ 模糊（用户意图不清 / 判据边界）→ AskUserQuestion（per-dispatch）
+```
+
+### 2.2 派发模式与 Monitor 的级联
+
+| 派发模式 | DEC-008 gate | Monitor | 主会话可见 |
+|---------|-------------|---------|-----------|
+| foreground（`false` / 缺省） | skip | 不启 | 子 agent 工具调用缩进流实时回显 |
+| background（`true`） | 进入 | 启动 | 仅 Monitor phase 级 summary |
+
+DEC-012 决定派发 mode；DEC-008 决定 mode 后 Monitor 是否启动；两者串联为完整触发链路。
+
+## 3. 技术实现
+
+### 3.1 `commands/workflow.md` 修改
+
+**新增 §3.4 "Dispatch mode selection"**（位于 Step 3 artifact chain 后、Step 3.5 Progress Monitor Setup 前）：
+
+```markdown
+## Step 3.4: Dispatch Mode Selection
+
+每次 `Task` 派发前按序评估 `run_in_background`（第一匹配胜出）：
+
+1. **用户声明**：prompt 含 `@roundtable:<role> bg|fg` / "后台派 <role>" / "前台派 <role>" 等中英文等价 → 按声明
+2. **并行度**：本 assistant message 内 Task 调用数
+   - 单发 → `false`（对齐 Claude Code 默认）
+   - 并行批 ≥2 → 全部 `true`
+3. **模糊兜底** → `AskUserQuestion` fg / bg 两选
+
+前置：Step 4 并行判定必须先行，其结论是步骤 2 的输入。选完进入 §3.5.0 gate。
+```
+
+**精简记录**：本节代码块 2026-04-20 post-fix 从 16 行压至 10 行（~40% 精简），作为 issue #22 "reference density audit" 的 dogfood precedent —— 删 `（DEC-012）` title ref、删 per-session 7 种变体（保留 2 典型 + 等中英文等价兜底）、删 per-dispatch rationale/tradeoff 散文（留 AskUserQuestion 动作）、删独立"边界"段（本 Step 只处理 Task 派发天然无歧义）、前置声明合并入 1 行尾注。workflow.md 实装同步 precedent。
+
+### 3.2 `commands/bugfix.md` 修改
+
+Step 0.5 加一句引用：`bugfix 通常单 developer 派发 → D2 命中 foreground；reviewer / dba / tester 兜底派发同样走 §3.4（workflow）规则`。
+
+### 3.3 5 agent prompt 不变
+
+agent 本体不感知派发形态（DEC-008 §理由 (1)）。
+
+### 3.4 Step 4 并行判定树不变
+
+Step 4 决定"是否升级为并行派发"；DEC-012 §3.4 决定"派发模式是 fg 还是 bg"。两者正交：
+- Step 4 判否并行 → 单发 → D2 → fg
+- Step 4 判可并行 → 多发 → D2 → bg（全部）
+
+## 4. 关键决策与权衡
+
+### 决策 1：方向选择 = 方向 1（规则补齐）
+
+| 维度 (0-10) | 方向 1 ★ | 方向 2（全前台删 Monitor） | 方向 3（全后台强制） |
+|------------|---------|---------------------------|---------------------|
+| DEC 投入保留 | **10** | 2 | 9 |
+| 并行派发能力 | **9** | 2 | 10 |
+| 对齐 Claude Code 默认 | **9** | 10 | 4 |
+| 改动面 | **9**（2 commands + 1 DEC） | 3（Supersede 3 DEC + 删 600+ 行） | 6（Supersede DEC-008） |
+| 与 #20 scope | **9**（正交） | 4（scope 缩小） | 8 |
+| 主会话 UX | **8** | 6（长任务缩进流刷屏风险） | 7（phase summary 信息密度低） |
+| **合计** | **54** | 27 | 44 |
+
+### 决策 2：判据组合 = D2 + D4（两层）
+
+| 维度 (0-10) | D2+D4 ★ | D1+D2 | D2 only | D1+D2+D4 |
+|------------|---------|--------|---------|----------|
+| 规则简洁度 | **8** | 6 | **10** | 5 |
+| 用户逃生门 | **9** | 3 | 3 | **10** |
+| 覆盖 S1-S5 | **9** | 8 | 7 | **10** |
+| 改动面 | **9**（2 commands） | 6（含 5 agent 硬编码） | **10** | 6 |
+| P8 bug 修复 | **9** | 9 | 9 | 9 |
+| **合计** | **44** | 32 | 39 | 40 |
+
+- D2+D4 胜出：规则扁平 + 用户 per-session 逃生门 + per-dispatch 兜底，不引入 per-role 硬编码（避免 critical_modules 多点改动）
+
+### 决策 3：D4 层级 = 两级（per-session + per-dispatch）
+
+- 不抬 target CLAUDE.md 配置项 —— dispatch mode 是 orchestrator 层策略，不是项目业务规则，对齐 DEC-011 边界
+- 与 DEC-005 developer form 三级保持**有意区别**：DEC-005 涉及每角色形态（subagent vs inline），是项目级偏好；DEC-012 仅涉及 Task 派发时的 fg/bg 参数，是 orchestrator 运行时选择
+
+### 决策 4：DEC-008 Accepted 保留
+
+DEC-012 正交补齐 DEC-008 上游（决定 mode），不 Superseded。两者合璧：DEC-012 选 mode → DEC-008 根据 mode 决定 Monitor 是否启。
+
+### 决策 5：#20 scope 边界声明
+
+本 DEC **只决策 subagent 形态（Task 派发）下的 fg/bg**；不碰 "role 是否支持 inline 形态"（issue #20 独立决策）。若 #20 后续给 tester/reviewer/dba 加 inline 逃生门，inline 路径天然不经过 Task，不触发 §3.4。
+
+## 5. P8 验收点
+
+落地后应满足：
+
+- **单发 developer subagent 派发**：D2 命中 fg，DEC-008 gate skip Monitor。主会话仅看到缩进流，不再出现"Monitor + 缩进流双份信号"
+- **并行批派发**（reviewer + tester + dba 同期）：D2 全部 bg，每个 Task 独立 Monitor
+- **用户显式 `@<role> bg` 单发**：尊重用户，Monitor 启动（即使单发）
+- **用户显式 `@<role> fg` 并行批**：尊重用户，全部 fg 串行执行（Step 4 并行判定树应已拒，否则提示用户）
+
+**测试归档位置**：`docs/testing/dispatch-mode-strategy.md`（按需 tester 兜底；与 DEC-008 follow-up pattern `docs/testing/step35-foreground-skip-monitor.md` 对齐）。
+
+## 6. 变更记录
+
+- 2026-04-20：初稿（issue #19）；DEC-012 Accepted
+- 2026-04-20：reviewer post-fix —— W-01 section-number 统一 §3.4.5 → §3.4（6 处）；W-03 前置顺序声明；S-01 补 2 条 @声明等价模式；S-02 补 testing anchor
+- 2026-04-20：issue #22 dogfood 精简 —— workflow.md §Step 3.4 实装从 16 行压至 10 行；§3.1 代码块同步；反向收敛 S-01（过度等价列表）
+
+## 7. 待确认项
+
+（无）

--- a/docs/log.md
+++ b/docs/log.md
@@ -14,6 +14,26 @@
 
 **合并原则**：agent / skill **不直接写本文件**。每轮 workflow 由 orchestrator 按 `commands/workflow.md` §Step 8 log.md Batching 协议（bugfix 流程按 `commands/bugfix.md` §log.md Batching 简化版）收集各 agent final report 中的 `log_entries:` YAML block 聚合写入；同一 agent 在同一轮产出多份文档（如 architect 同时输出 design-doc + DEC + exec-plan）**合并为一条**，`影响文件` 列全部路径（union）；不拆多条。DEC-009 决定 2 落地。
 
+## design | dispatch-mode-strategy | 2026-04-20
+- 操作者: architect
+- 影响文件: docs/design-docs/dispatch-mode-strategy.md, docs/decision-log.md
+- 说明: issue #19 —— DEC-012 Accepted：方向 1 规则补齐（保留 DEC-004/007/008）+ D2 并行度判据（单发 fg / 并行批 bg）+ D4 两级逃生门（per-session @声明 + per-dispatch AskUserQuestion）；不抬 CLAUDE.md 配置；DEC-008 正交补齐保留；#20 scope 边界声明；P8 dogfood bug 由 D2 自动修复；3 项决策量化评分；DEC-012 置顶 dogfood DEC-011 约定
+
+## fix | dispatch-mode-strategy | 2026-04-20
+- 操作者: developer (inline)
+- 影响文件: commands/workflow.md (+16 行 §Step 3.4), commands/bugfix.md (Step 0.5 加 1 句), docs/INDEX.md (+1 条)
+- 说明: DEC-012 落地 —— workflow.md 新增 §Step 3.4 Dispatch Mode Selection（3 层 fallback：per-session → D2 并行度 → per-dispatch AskUserQuestion）；bugfix.md 引用；lint 0 命中；reviewer W-01 section-number 统一 §3.4.5→§3.4（6 处）+ W-03 前置顺序声明 + S-01 补 2 条 @声明等价模式 + S-02 testing anchor 一并 post-fix
+
+## review | dispatch-mode-strategy | 2026-04-20
+- 操作者: reviewer subagent (critical_modules 多命中 → 必落盘；orchestrator relay)
+- 影响文件: docs/reviews/2026-04-20-dispatch-mode-strategy.md (new, orchestrator 代写 —— reviewer agent 自声明 prompt 约束不允许 Write .md report，冲突于其 RA matrix，另记 issue)
+- 说明: DEC-012 终审 Approve-with-caveats（0 Critical / 3 Warning / 2 Suggestion）；W-01 section-number 贯穿 4 文档不一致 + W-03 Step 4 前置顺序 + S-01 @声明列表 + S-02 testing anchor 全部 post-fix；DEC-001~DEC-011 逐项对齐
+
+## analyze | dispatch-mode-strategy | 2026-04-20
+- 操作者: analyst
+- 影响文件: docs/analyze/dispatch-mode-strategy.md
+- 说明: issue #19 前台/后台派发选择策略调研 —— 确认根因（workflow.md/bugfix.md/5 agent 零规则，Task `run_in_background` 由 orchestrator 自由心证）；3 选项对比（规则补齐 / 删 Monitor 全前台 / 强制全后台）+ 5 场景 × 3 选项矩阵 + 判据候选 D1-D4；8 事实层开放问题 P1-P8 交 architect（P7 标注 #19/#20 耦合）；FAQ Q1 补 orchestrator 概念解释
+
 ## design | decision-log-entry-order | 2026-04-20
 - 操作者: architect
 - 影响文件: docs/design-docs/decision-log-entry-order.md, docs/decision-log.md

--- a/docs/reviews/2026-04-20-dispatch-mode-strategy.md
+++ b/docs/reviews/2026-04-20-dispatch-mode-strategy.md
@@ -1,0 +1,87 @@
+---
+slug: dispatch-mode-strategy
+reviewer: roundtable:reviewer（subagent）+ orchestrator relay
+date: 2026-04-20
+status: Approve-with-caveats
+decisions: [DEC-012]
+---
+
+# DEC-012 实施审查 —— dispatch-mode-strategy
+
+> 本 review 由 reviewer subagent 审计并经 orchestrator 转写落盘。reviewer agent 自声明其 prompt 约束不允许 Write .md 报告（"Do NOT Write report/summary/findings/analysis .md files. Return findings directly as your final assistant message"），故 findings 以对话返回，orchestrator 按 critical_modules hit 纪律代写本归档。此约束与 `agents/reviewer.md` Resource Access 的 reviews/ Write 授权存在冲突，建议另开 issue 追踪（非本 review scope）。
+
+## 审查范围
+
+- `commands/workflow.md` 新增 §Step 3.4 Dispatch Mode Selection
+- `commands/bugfix.md` Step 0.5 加 1 句 §3.4 引用
+- `docs/decision-log.md` 追加 DEC-012 置顶（DEC-011 之前）
+- `docs/design-docs/dispatch-mode-strategy.md` 新建
+- `docs/INDEX.md` 追加 design-doc 条目
+
+## 结论
+
+**Approve-with-caveats** —— 0 Critical / 3 Warning / 2 Suggestion。
+
+核心规则（D2+D4 两层 fallback）实装正确；§3.5.0 gate 串联无死角；DEC-012 6 段齐全；影响范围 ≤ 10 行满足 DEC-009 决定 10 纪律；置顶于 DEC-011 之前已 dogfood 本项目 DEC-011 约定；lint 0 命中；DEC-001~DEC-011 全对齐。
+
+## Critical
+
+（无）
+
+## Warning
+
+### W-01 · Section-number 不一致 贯穿 4 文档（高优先）
+
+- `commands/workflow.md` —— 实装为 `## Step 3.4`
+- `docs/design-docs/dispatch-mode-strategy.md` §3.1 / §3.2 / §3.4 / P8 —— 多处写 `§3.4.5`
+- `docs/decision-log.md` DEC-012 决定 6 + 影响范围段 —— 写 `§3.4.5`
+- `commands/bugfix.md` —— 对的（`§3.4`）
+
+**影响**：design-doc 的"新增位置"规格和 DEC-012 决定 6 的"不触发本 DEC §3.4.5"成为悬空指针。
+
+**修复**：统一为 `§3.4`（推荐方向；3 位小数编号观感臃肿；workflow.md 既有 Step 3.5.0 / 3.5.1 体系下 3.4 一致）。
+
+### W-02 · design-doc §3.1 代码块与 workflow.md 实装文字不逐字一致
+
+- design-doc L73 "Step 4 并行派发判定树已通过" vs workflow.md L95 "Step 4 并行判定树已判可升级"
+- 措辞不同语义等价 —— 不强制逐字对称，但需配合 W-01 section 统一
+
+### W-03 · Step 3.4 与 Step 4 并行判定树顺序描述偏弱
+
+markdown 顺序是 Step 3.4 (L90) 先于 Step 4 (L162)，读者按序阅读撞到 Step 3.4 的 D2 规则会"Step 4 并行判定树已判可升级"反向回看。
+
+**修复建议**：Step 3.4 开头加一句前置声明："**前置**：Step 4 并行判定树必须先于本 Step 执行；Step 4 的串/并行结论是 D2 的直接输入。"
+
+## Suggestion
+
+### S-01 · Per-session 声明等价列表可加 1-2 条
+
+workflow.md L94 当前：`@roundtable:<role> bg` / `@roundtable:<role> fg` / "后台派 <role>" / "前台派 <role>" / "用后台跑 <role>"。
+
+建议补：`<role> 用 bg` / `bg 跑 <role>` 等同构例子，让 LLM 模式匹配覆盖更全。非 blocker。
+
+### S-02 · P8 验收可测性加 testing anchor
+
+design-doc §5 给出 4 个验收场景是事后描述性，无自测步骤。参考 DEC-008 落地有专门 testing/ doc（`docs/testing/step35-foreground-skip-monitor.md`），建议 §5 补一行 "测试归档位置：`docs/testing/dispatch-mode-strategy.md`（按需 tester 兜底）"。非 blocker。
+
+## 决策一致性
+
+| DEC | 一致性 |
+|-----|--------|
+| DEC-001 D2（零 userConfig 边界） | ✅ |
+| DEC-002（RA matrix） | ✅ |
+| DEC-004（Progress schema） | ✅ |
+| DEC-005（developer 双形态 + per-session 心智） | ✅ |
+| DEC-006（phase gating taxonomy） | ✅ |
+| DEC-007（Content Policy） | ✅ |
+| DEC-008（前台免 Monitor gate 正交补齐） | ✅ |
+| DEC-009 决定 10（影响范围 ≤10 行纪律） | ✅ |
+| DEC-011（decision-log 置顶约定 + dogfood） | ✅ |
+
+## 推荐动作
+
+1. **必修**：W-01 section-number 统一（4 处 `§3.4.5` → `§3.4`）
+2. **建议修**：W-03 Step 3.4 / Step 4 顺序前置声明
+3. **可选**：S-01 @声明列表加 1-2 条；S-02 testing anchor
+
+W-01 修完即可合并；W-03/S-01/S-02 不阻塞合并。


### PR DESCRIPTION
## Summary

Fixes #19 —— `commands/workflow.md` / `commands/bugfix.md` / 5 agent prompt 对 `Task` 派发的 `run_in_background` 参数**无任何选择规则**，orchestrator 靠 LLM 自由心证。DEC-008 的前台免 Monitor gate 已就位但上游决策缺失，dogfood 偶发"Monitor + 缩进流双份信号"误判。

## DEC-012 决策核心

- **方向 1 规则补齐**（保留 DEC-004/007/008 全部投入）—— 量化评分 54 vs 删 Monitor 的 27 / 强制全后台的 44
- **D2 并行度核心判据**：单发 Task → `false`（对齐 Claude Code 官方默认）；并行批 ≥2 Task → 全部 `true` + Monitor
- **D4 用户逃生门两层**：per-session `@roundtable:<role> bg|fg` / 中文等价声明 → 覆盖 D2；per-dispatch `AskUserQuestion` 兜底模糊情况
- **不抬 target CLAUDE.md**（对齐 DEC-011 边界 —— dispatch mode 是 orchestrator 内部策略，非业务规则）
- **DEC-008 正交补齐保留**（不 Supersede）
- **#20 scope 边界声明**（本 DEC 只决 Task 派发的 fg/bg，不碰 inline 扩展）
- **P8 dogfood bug** 由 D2 自动修复（单发 developer subagent → fg → 免 Monitor → 不再双份信号）

## 改动清单

- `commands/workflow.md` +§Step 3.4 Dispatch Mode Selection（10 行，置于 Step 3.5 前）
- `commands/bugfix.md` Step 0.5 +1 行 §3.4 引用
- `docs/decision-log.md` +DEC-012 置顶（dogfood DEC-011 新约定）
- `docs/design-docs/dispatch-mode-strategy.md` 新建（含 3 项决策量化评分 + P8 验收点）
- `docs/analyze/dispatch-mode-strategy.md` 新建（F1-F6 事实 + 3 选项对比 + 判据 D1-D4 + P1-P8 开放问题）
- `docs/reviews/2026-04-20-dispatch-mode-strategy.md` 新建（orchestrator 代写）
- `docs/INDEX.md` / `docs/log.md` 同步

## Review + post-fix

- reviewer Approve-with-caveats（0 Critical / 3 Warning / 2 Suggestion）
- **W-01 必修**：section-number §3.4.5 → §3.4（6 处）统一 ✅
- **W-03 建议修**：Step 3.4 前置顺序声明 ✅
- **S-01/S-02**：@声明等价列表扩展 + testing anchor ✅

## In-scope follow-through

- **issue #22 dogfood precedent**：Step 3.4 实装从 16 行压至 10 行（~40% 精简），删 `（DEC-012）` title ref + 简化 @声明列表 + 删独立\"边界\"段；作为后续全局 reference density audit 的基线

## 与已有 Accepted DEC 关系

- **DEC-001 D2**（零 userConfig 边界）✅ 本 DEC 决定 4 明确不抬 CLAUDE.md
- **DEC-002** RA matrix ✅ 无触动
- **DEC-004** Progress schema ✅ 无触动
- **DEC-005** developer 双形态 ✅ 心智对齐（运行时参数 vs 角色形态有意区分）
- **DEC-006** phase gating ✅ 无触动
- **DEC-007** Content Policy ✅ 无触动
- **DEC-008** 前台免 Monitor gate ✅ 正交补齐保留 Accepted
- **DEC-009 决定 10**（影响范围 ≤10 行纪律）✅ DEC-012 影响范围 7 行合规
- **DEC-011**（decision-log 置顶）✅ DEC-012 置于 DEC-011 之前正确 dogfood

## 衍生 issue

- **#22**: docs: audit reference density in runtime prompts (token cost) —— 等 #19/#20 合入后开跑
- **#23**: bug(reviewer): agent self-declares Write .md restriction conflicting with Resource Access matrix —— 本次 orchestrator 代写兜底记录

## Test plan

- [x] `lint_cmd` 0 命中
- [x] reviewer Approve-with-caveats，caveats 全 post-fix
- [x] DEC-012 置顶 dogfood DEC-011
- [x] grep `§3\\.4\\.5` in runtime prompts = 0（仅剩 reviews/ 和 design-doc 历史记录）
- [ ] 下次 `/roundtable:workflow` 派发验证 §3.4 实际执行（orchestrator 按 D2 选 mode；主会话双份信号消失）

## 相关

- Fixes #19
- DEC-012 (new) / DEC-008 / DEC-011 / DEC-004 / DEC-005
- 衍生 #22 / #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)