### PR TITLE
release: v0.0.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtable",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Multi-role AI development workflow for Claude Code. Bring analyst, architect, developer, tester, reviewer, and DBA to the same table with plan-then-execute discipline, AskUserQuestion decision popups, and design-doc-driven collaboration. Zero-config install; per-project CLAUDE.md drives everything.",
   "author": {
     "name": "duktig666",


### PR DESCRIPTION
Bump plugin.json to 0.0.3 for the v0.0.3 release.

Full release notes will be attached to the GitHub release created after this PR merges.

## Summary (since v0.0.2)
- feat(workflow): dispatch mode selection (DEC-012, #19, #24)
- feat(workflow): switchable decision mode modal|text (DEC-013, #31, #34)
- fix(architect): decision-log entry order propagation (DEC-011, #18, #21)
- docs: README English default + README-zh, Orchestrator section, exec-plan archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)