### PR TITLE
docs(#41): codify issue labeling + English titles + priority ordering in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ roundtable plugin：多角色 AI 开发工作流 Claude Code plugin。将 analys
 - **语言**：代码英文、注释中文、文档中文、回答中文
 - **Plugin prompt 文件本体**（`skills/*.md` / `agents/*.md` / `commands/*.md`）**以中文为主，关键专有名词保留英文**（工具名、字段名、DEC-xxx、env var、`Task` / `Monitor` / `AskUserQuestion` 等 Claude Code / plugin 术语不翻译）—— 约定 2026-04-19 更新，见 `feedback_roundtable_prompt_language`
 - **用户产出文档**（`docs/design-docs/` / `docs/decision-log.md` / `docs/log.md`）保持**中文**
+- **GitHub Issue / PR 标题**：英文；body / 评论可中英混合
 - **架构决策需确认**：任何影响 DEC-001（D1-D9）的改动必须走 DEC-xxx Superseded 流程
 
 ---
@@ -46,3 +47,5 @@ roundtable plugin：多角色 AI 开发工作流 Claude Code plugin。将 analys
 - 修改 `_detect-project-context.md` → 必须同步 review 所有 5 个调用方（`commands/workflow.md` / `commands/bugfix.md` / `commands/lint.md` / `skills/architect.md` / `skills/analyst.md`）
 - 新增或修改 Phase Matrix 的 stages → 必须同步更新 `commands/workflow.md` §Step 3 artifact chain 和 `docs/INDEX.md` 的 6 类 orphan 扫描清单
 - 新增用户产出文档类别（如 `benchmarks/`）→ 必须同步更新 Step 7 Index Maintenance 的 "identify category" 列表
+- 创建 issue（`gh issue create`）→ 必须加 `P0/P1/P2/P3` 标签（P0 阻塞全流程/数据损坏；P1 主干缺陷/UX 中断；P2 质量缺陷/功能缺口；P3 优化/长期议题）
+- 评估 issue 执行顺序 → 优先按 priority 排序（P0 → P1 → P2 → P3），同优先级内再看依赖 / dogfood 串联


### PR DESCRIPTION
## Summary

- `CLAUDE.md` §通用规则: GitHub Issue / PR 标题英文 (body / 评论可中英混合)
- `CLAUDE.md` §条件触发规则: `gh issue create` 必须带 `P0/P1/P2/P3` 标签 + priority 顺序评估规则

从 PR #39 DEC-014 scope 溢出剥离 (reviewer W2)。

## Why

1. 英文标题便于国际协作 + GitHub 搜索；body 中文保留表达密度
2. P0-P3 标签强制让 analyst/architect 评估"先做哪个"有客观锚点 (#37 #38 #40 已带标签，CLAUDE.md 补记既成约定)
3. priority 优先 > 依赖 避免 P3 优化拖 P0

## 不改

- 任何 DEC
- 5 agent prompt / skill / command
- `docs/claude-md-template.md` (本规则只对 roundtable 项目自身，不传导 target)

## Test plan

- [x] lint 不涉及 (只改 CLAUDE.md markdown)
- [x] 无 agent prompt 改动
- [x] scope 单一 (只 +3 行)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)