### PR TITLE
design(#33): DEC-015 workflow --auto mode (design-only)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -61,6 +61,7 @@
 - [dispatch-mode-strategy.md](design-docs/dispatch-mode-strategy.md) — issue #19 subagent 派发 run_in_background 选择策略（方向 1 规则补齐 + D2 并行度判据 + D4 两级逃生门；DEC-008 正交补齐），DEC-012 Accepted
 - [decision-mode-switch.md](design-docs/decision-mode-switch.md) — issue #31 orchestrator 可切换决策模式 modal \| text（最小改动：agent 零改动 + orchestrator 渲染分支 + skill 条件分支；支持 TG / CI / 日志回放远程前端），DEC-013 Accepted
 - [bugfix-rootcause-layered.md](design-docs/bugfix-rootcause-layered.md) — issue #37 bugfix 根因分层落盘（Tier 0 对话 / Tier 1 log.md fix-rootcause entry / Tier 2 docs/bugfixes postmortem；D1-D4 锁定；C1 执行锚点 4 条 + W1-W4 post-fix），DEC-014 Accepted
+- [workflow-auto-execute-mode.md](design-docs/workflow-auto-execute-mode.md) — issue #33 `/roundtable:workflow --auto` 批量预授权 A/B 类 gate 自动采纳 recommended（CLI+env 两级优先链 / recommended 缺失强停 / #30 正交 / 4 agent 零改动），DEC-015 Accepted
 
 **Plugin 内部 include-only helper**（下划线前缀约定；非独立可激活 skill；不在用户向 skill 清单露出）：
 
@@ -71,6 +72,7 @@
 
 - active/
   - [roundtable-plan.md](exec-plans/active/roundtable-plan.md) — roundtable umbrella 实施计划（P0-P4 完成；P5 外部试装 + P6 v0.1 发布未做；24 个 unchecked 主要在 v0.1 release 环节）
+  - [workflow-auto-execute-mode-plan.md](exec-plans/active/workflow-auto-execute-mode-plan.md) — issue #33 DEC-015 auto 模式实施计划（P0 bootstrap → P1 Step 5 Escalation → P2 Step 6 A/B gating → P3-P4 inline + bugfix ref → P5-P6 tester/reviewer → P7 dogfood E2E → P8 PR）
 - completed/
   - [lightweight-review-plan.md](exec-plans/completed/lightweight-review-plan.md) — issue #9 轻量化重构（DEC-009 + DEC-010 Accepted；tree 2708→1672 / -38%；PR #17 merged）
   - [subagent-progress-and-execution-model-plan.md](exec-plans/completed/subagent-progress-and-execution-model-plan.md) — issue #7 + DEC-004/005/008（26 checkbox 全勾；PR #16 merged）

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -35,6 +35,36 @@
 
 ---
 
+### DEC-015 workflow auto-execute mode（orchestrator 读 `--auto` / `ROUNDTABLE_AUTO` 批量预授权 A/B 类 gate，自动采纳 recommended option）
+- **日期**: 2026-04-20
+- **状态**: Accepted
+- **上下文**: [issue #33](https://github.com/duktig666/roundtable/issues/33) —— `/roundtable:workflow` 默认高交互：A 类 producer-pause 等用户 `go` / B 类 approval-gate 等点选 / 内部决策点逐个阻塞。批量 dogfood / CI 非交互 / 信任型自消耗 / #43 batch 多 issue 并行依赖链下，交互成本远大于决策价值。用户已熟悉决策模板时 `recommended` 选项可直接采纳。P2 阻塞积压消化 + 解锁 #43。
+- **决定**:
+  1. **路径 B（加 flag）**（D1）：在 `/roundtable:workflow` 加 `--auto` 布尔开关，不新建独立 command；违反 DEC-010 精简心智 / 2x prompt 同步 / skill caller 感知成本的 A 方案否决
+  2. **三级优先链对齐 DEC-013**（D2）：CLI `--auto` > env `ROUNDTABLE_AUTO` > default=false；**不做**每阶段粒度 `ROUNDTABLE_AUTO=analyst,architect`（YAGNI / v1 避免组合爆炸）
+  3. **Recommended 缺失 fallback = 强停**（D3）：真 tie-break 打断，emit 审计行 `🔴 auto-halt: no recommended option at <decision_id>` 并沿用 manual 渲染路径（modal / text 按 decision_mode）；对齐 DEC-006 B 类 approval-gate 语义；拒绝"选第一个"（静默错决策）/"报错退出"（摧毁已完成 phase 产出）
+  4. **Exec-plan 策略 in auto = 按任务体量探测**（D4）：沿用 Step 1 中/大任务启发式，auto 只节约"问用户 exec-plan 要不要"的交互不改判据
+  5. **#30 / #33 顺序 = 先 #33 再 #30**（D5）：auto 豁免 A 类 gate，#30 补强 manual 路径；两 issue 正交无 merge 冲突
+  6. **Phase Matrix category 不变**（DEC-006 守约）：auto 只是 A/B 类 gate 的"批量预授权"，category 映射不变；C 类 verification-chain 现状已自动不变
+  7. **4 agent prompt 零改动**：orchestrator 读 flag 后自动采纳 recommended，agent/skill 零感知
+  8. **不抬 target CLAUDE.md**：对齐 DEC-011 / DEC-012 "dispatch mode 是 orchestrator 内部策略非项目业务规则"边界
+  9. **不豁免打断路径**：tester hard regression `<escalation>` / lint 或 test 失败 / format 解析错 / subagent escalation 无 recommended —— 这些打断路径 auto 模式零侵入保持
+  10. **Audit trail 4 事件**：`🟢 auto-go` (A 类) / `🟢 auto-accept` (B 类) / `🟢 auto-pick` (内部决策) / `🔴 auto-halt` (fallback)；归 C 类 verification-chain
+  11. **modal + auto 组合已知约束**：skill 的 `AskUserQuestion` 由 Claude Code runtime 执行，orchestrator 无法拦截返回；modal 下 skill 弹窗照常，auto 对 skill AskUserQuestion 无效；文档明示推荐搭配 `decision_mode=text` 使用
+- **备选**:
+  - **D1-A 新 command `/roundtable:autoworkflow`**：2x prompt 维护 + skill caller 感知；拒绝
+  - **D2-C 每阶段粒度 `ROUNDTABLE_AUTO=analyst,architect`**：无实际需求，YAGNI；拒绝
+  - **D3-B 选第一个**：静默错决策风险；拒绝
+  - **D3-C 报错退出**：摧毁已完成 phase 产出；拒绝
+  - **D4-A 默认写 exec-plan**：小任务浪费；拒绝
+  - **D4-B 默认跳 exec-plan**：大任务追溯成本；拒绝
+  - **D5-B 先 #30 再 #33**：#30 不在 #43 关键路径；优先级错；拒绝
+- **理由**: (1) D1 加法而非重复符合 DEC-010 精简心智；(2) D2 三级链复用 DEC-013 心智无新抽象；(3) D3 强停守住真 tie-break 不绕 DEC-006 B 类语义；(4) D4 auto 不改判据只改交互；(5) D5 解锁 #43 并行编排器依赖链；(6) Phase Matrix 不变保 DEC-006 正交；(7) 4 agent 零感知 + skill 零改动 = 最小改动面；(8) 不抬 CLAUDE.md 对齐 DEC-011/012；(9) 打断路径零侵入保障事故可召回；(10) Audit trail 让 auto 决策可事后追溯不失透明
+- **相关文档**: [docs/design-docs/workflow-auto-execute-mode.md](design-docs/workflow-auto-execute-mode.md)（完整设计 + D1 量化评分 / 决策矩阵 / 业务逻辑矩阵）、DEC-013（`decision_mode` 三级链模式同源）、DEC-006（Phase Matrix A/B/C 语义守约）、DEC-010（token 节约心智延伸）、DEC-011 / DEC-012（dispatch mode 不抬 CLAUDE.md 边界）、DEC-001（D8 / 4 agent 边界）、[issue #33](https://github.com/duktig666/roundtable/issues/33)、[issue #30](https://github.com/duktig666/roundtable/issues/30)（正交 follow-up）、[issue #43](https://github.com/duktig666/roundtable/issues/43)（下游依赖 batch 编排器）
+- **影响范围**: `commands/workflow.md` 顶部新增 Step -0 Auto Mode Bootstrap (~6 行) + Step 5 Escalation 加 `auto_mode` 分支 (~5 行) + Step 6 A 类 + B 类 phase gating 加 auto 分支 (~8 行) + Step 1 / Step 6b 加 auto 注记 (~3 行)；`commands/bugfix.md` 通过 Step -1 ref workflow.md 自动继承 (~2 行)；`docs/design-docs/workflow-auto-execute-mode.md` + `docs/exec-plans/active/workflow-auto-execute-mode-plan.md` 新建；`docs/decision-log.md` 本条置顶；`docs/INDEX.md` + `docs/log.md` 追加。**不改** 4 agent prompt / `skills/architect/SKILL.md` / `skills/analyst/SKILL.md` / `skills/_detect-project-context.md` / `skills/_progress-content-policy.md` / `README.md` / `README-zh.md` / target CLAUDE.md。**不改** DEC-001 ~ DEC-014 任何 Accepted 条款 / Phase Matrix / Step 4 并行判定树 / critical_modules 机械触发。运行时：批量 dogfood / CI / 信任场景无阻塞跑完；真 tie-break / escalation / tester hard regression / lint+test failure 依然打断保留事故可召回。
+
+---
+
 ### DEC-014 bugfix 根因分层落盘（Tier 0 对话 / Tier 1 log.md fix-rootcause entry / Tier 2 docs/bugfixes postmortem）
 - **日期**: 2026-04-20
 - **状态**: Accepted

--- a/docs/design-docs/workflow-auto-execute-mode.md
+++ b/docs/design-docs/workflow-auto-execute-mode.md
@@ -1,0 +1,252 @@
+---
+slug: workflow-auto-execute-mode
+source: 原创（issue #33）
+created: 2026-04-20
+status: Draft
+decisions: [DEC-015]
+---
+
+# `/roundtable:workflow` Auto-Execute Mode 设计文档
+
+## 1. 背景与目标（含非目标）
+
+### 背景
+
+`/roundtable:workflow` 默认高交互：每个 A 类 producer-pause（analyst ✅ / architect ✅ / Stage 9）等用户 `go`，B 类 approval-gate（Design confirmation）调 `AskUserQuestion` 等点选，内部决策点（exec-plan 要不要 / developer form 选 inline vs subagent 等）也逐个阻塞等回复。
+
+在下列场景交互成本远大于决策价值：
+
+- **批量 dogfood**：一次消化多个 P2/P3 issue，用户只想看最终 PR 合不合理
+- **CI 场景**：无人工值守，每次 gate 永久阻塞
+- **信任型自 dogfood**：用户已熟悉决策模板，`recommended` 选项可直接采纳
+- **#43 batch 编排器前置依赖**：多 issue 并行调度依赖"单 issue auto 跑完"能力
+
+### 目标
+
+引入 auto 模式：orchestrator 读 flag 后在每个决策点自动采纳 `recommended: true` 的 option，phase gate 自动推进，用户只在**真 tie-break**（无 recommended）/ **subagent escalation** / **critical_modules hard regression** 时被打断。
+
+### 非目标
+
+- **不改 Phase Matrix 语义**（DEC-006）—— auto 只是 A/B 类 gate 的"批量预授权"，category 不变
+- **不改 4 agent prompt**（developer/tester/reviewer/dba）—— orchestrator 读 flag 后自动处理，agent/skill 零感知
+- **不抬到 target CLAUDE.md**（对齐 DEC-011 / DEC-012 "dispatch mode 是 orchestrator 内部策略" 边界）
+- **不做每阶段粒度**（`ROUNDTABLE_AUTO=analyst,architect` YAGNI，v1 不造）
+- **不豁免 critical_modules tester 派发**（verification-chain C 类强制依然成立；仅 hard regression 打断）
+- **不豁免 lint + test 失败**（developer 完成后 failure 仍按 Step 6 规则 5 报告用户不静默重派）
+
+## 2. 业务逻辑
+
+### 2.1 Flag 优先链（三级，对齐 DEC-013）
+
+```
+CLI  /roundtable:workflow <task> --auto
+  ↓  覆盖
+env  ROUNDTABLE_AUTO=1
+  ↓  覆盖
+default  auto_mode = false
+```
+
+取值：`true` / `false`（布尔二态；不做 per-stage 粒度）。
+
+### 2.2 决策点行为矩阵
+
+| 决策位置 | manual 模式（现状） | auto 模式 |
+|---------|-------------------|----------|
+| A 类 producer-pause（analyst / architect / Stage 9）| 3 行 summary + 停等用户 `go` | emit `🟢 auto-go <role> ✅` 一行自动推进 |
+| B 类 approval-gate（Stage 4 Design confirmation）| `AskUserQuestion` Accept/Modify/Reject | 选项含 `recommended` → 自动 Accept；否则强停走 manual 交互（text 模式 emit `<decision-needed>`）|
+| 内部 `AskUserQuestion`（architect / analyst skill）| 弹窗等选 | 有 `recommended` → 自动采纳；否则强停 |
+| Subagent `<escalation>`（developer/tester/reviewer/dba）| orchestrator 按 decision_mode 渲染 → 等用户 | option 含 `recommended` → 自动采纳重派；否则强停渲染 |
+| C 类 verification-chain（自动交接）| 现状已自动 | 不变 |
+| Tester hard regression / lint+test failure | 打断汇报 | 打断汇报（**不受 auto 影响**）|
+| Exec-plan 豁免 | `AskUserQuestion` 询问 | 沿用 Step 1 中/大任务启发式自判；用户同步未问（`recommended` 即 "按体量决定"）|
+| Developer form 选择 (Step 6b) | `AskUserQuestion` 询问 | 沿用小任务启发式自判（inline / subagent）|
+
+### 2.3 强停打断 fallback
+
+auto 模式下遇以下情况**必须**打断（即使 flag 设 true）：
+
+1. 决策点所有 option 均无 `recommended: true`（真 tie-break；DEC-006 B 类 approval 原意保留）
+2. subagent `<escalation>` 的 options 均无 `recommended`（同上）
+3. Tester `<escalation>` bug report（业务 bug 永远人工）
+4. lint 或 test 失败（Step 6 规则 5）
+5. Format/schema 解析错误（现状行为沿用）
+
+打断渲染方式与 manual 模式完全一致（modal `AskUserQuestion` / text `<decision-needed>`）—— auto 模式对 fallback 路径零侵入。
+
+### 2.4 审计 trail
+
+每次 auto 模式自动决策必须 emit 一行可观察记录，便于用户事后追溯：
+
+- A 类：`🟢 auto-go <role> ✅ (auto_mode=on)`
+- B 类：`🟢 auto-accept <role> design (recommended: <option_label>, auto_mode=on)`
+- 决策点：`🟢 auto-pick <letter> <label> (auto_mode=on, why: <why_recommended>)`
+- fallback 打断：`🔴 auto-halt: no recommended option at <decision_id>`（此时同时渲染 manual 版决策块）
+
+这些 emit 归 C 类 verification-chain，不改 Phase Matrix category。
+
+## 3. 技术实现
+
+### 3.1 Orchestrator 实现位置
+
+**唯一改动落点**：`commands/workflow.md`（+ `commands/bugfix.md` 通过 ref 继承）。skill / agent / README 均零改动。
+
+#### 3.1.1 新增 Step -0 Auto Mode Bootstrap（置于 Step -1 之前）
+
+```markdown
+## Step -0: Auto Mode Bootstrap（DEC-015）
+
+解析 `auto_mode` = `true` | `false`（默认 `false`）。优先级：CLI `--auto` > env `ROUNDTABLE_AUTO` > default。
+
+注入：每次 `Task` 派发 prompt prefix + 每次 skill 激活 context prefix 加一行 `auto_mode: <value>`。
+orchestrator 自身按 flag 选择 Step 5 Escalation / Step 6 phase gating 的 auto / manual 分支。
+
+`auto_mode=true` 适用：批量 dogfood、CI 非交互、信任型自消耗。**不适用**于初次探索陌生决策域（recommended 缺失概率高会频繁 auto-halt）。
+```
+
+#### 3.1.2 Step 5 Escalation 加 `auto_mode` 分支
+
+在现有 `decision_mode` 分支（modal / text）**之外**叠加一层判定（auto 优先；manual fallback）：
+
+```
+2. 按 auto_mode 分支：
+   - auto_mode=true 且 option 含 recommended: true → 不调 AskUserQuestion / 不 emit <decision-needed>，
+     直接将 recommended 的决策事实注入 prompt 重派 agent；emit 审计行 `🟢 auto-pick <letter> <label> (auto_mode=on, why: <why_recommended>)`
+   - auto_mode=true 且所有 option 均无 recommended → 打断，emit `🔴 auto-halt: no recommended option at <esc-...>`，
+     然后沿用 decision_mode 渲染路径（manual fallback）
+   - auto_mode=false → 沿用 decision_mode 现行渲染（modal/text）
+```
+
+#### 3.1.3 Step 6 Phase Gating 加 `auto_mode` 分支
+
+**A 类 producer-pause**：
+
+```
+A. producer-pause —— 阶段以用户可消费产物结尾。
+   - auto_mode=false → 现行 3 行 summary 停等 `go`
+   - auto_mode=true → emit `🟢 auto-go <role> ✅ (auto_mode=on)` 一行自动推进下一 stage
+```
+
+**B 类 approval-gate**（Stage 4 Design confirmation）：
+
+```
+B. approval-gate —— Accept/Modify/Reject。
+   - auto_mode=false → 现行 AskUserQuestion / <decision-needed>（按 decision_mode）
+   - auto_mode=true 且有 recommended → 自动 Accept，emit `🟢 auto-accept <role> design (recommended: <label>, auto_mode=on)`
+   - auto_mode=true 且无 recommended → auto-halt 打断，沿用 manual 渲染
+```
+
+**C 类 verification-chain**：不变（现状已自动）。
+
+#### 3.1.4 Step 1 / Step 6b 的 "inline AskUserQuestion" 处理
+
+Step 1 规模判定模糊时 / Step 6b developer form 模糊时，orchestrator 原 spec 调 `AskUserQuestion`。auto 模式下：
+
+- auto_mode=true + 有 recommended（按启发式命中）→ 直接采纳，emit `🟢 auto-pick ...`
+- auto_mode=true + 无 recommended（罕见，启发式全过 tie）→ auto-halt
+
+### 3.2 Skill 层（architect / analyst）
+
+**零 prompt 改动**。skill 继续按 `decision_mode` 调 `AskUserQuestion` 或 emit `<decision-needed>`。auto 模式的决策采纳完全在 orchestrator 决策层，skill 不需知道 `auto_mode` 存在。
+
+**边界确认**：skill 的 `AskUserQuestion` 仅在 `decision_mode=modal` 下调；modal + auto 组合时 orchestrator 必须**拦截** `AskUserQuestion` 的返回前？—— 不现实，工具调用由 Claude Code runtime 执行。因此 modal + auto 下 skill 行为仍是"弹窗等点选"，auto 采纳只对 text 模式 `<decision-needed>` 和 orchestrator 本身的决策块生效。
+
+**实际策略**：
+- **modal + auto**：弹窗照常弹；用户体验上 auto 失效（这是 modal 的本质约束）。文档明示 auto 推荐搭配 `decision_mode=text` 使用
+- **text + auto**：完整 auto 生效路径（orchestrator 渲染 `<decision-needed>` 前读 recommended 自动采纳）
+
+### 3.3 4 Agent（developer/tester/reviewer/dba）
+
+零改动。现状已不访问 `decision_mode` / `auto_mode`，按 `<escalation>` JSON 上报，orchestrator 渲染决策块。
+
+### 3.4 与 #30 的关系
+
+#30 关注 manual 模式下 phase-end approval gate 缺失（analyst / architect silently skip）的补强。auto 模式显式豁免 A 类 producer-pause，两 issue 修改正交：
+
+- 先 #33 落地 → auto 模式 Step 6 A 类分支产生 `auto_mode=on` 路径
+- 再 #30 补强 `auto_mode=off` 路径的 summary 格式 / go 指令捕获严格度
+- 无 merge 冲突（两 issue 各自改 Step 6 A 类不同子分支）
+
+## 4. 关键决策与权衡
+
+### D1. 路径：新 command vs 加 flag
+
+**选 B（加 flag）** ★ 推荐
+
+| 维度 (0-10) | A 新 `/autoworkflow` | B `/workflow --auto` ★ |
+|------------|--------------------|----------------------|
+| prompt 复杂度 | 4（复制一套 prompt）| **9**（+~15 行条件分支）|
+| orchestrator 分支可读性 | 7（两 command 各自线性）| **8**（集中心智模型）|
+| skill 对 caller 感知 | 3（必须感知）| **10**（零感知）|
+| DEC-010 对齐 | 5（新 command 违反精简）| **10**（加法而非重复）|
+| 维护负担 | 4（2x prompt 同步）| **9**（单源）|
+| **合计** | 23 | **46** |
+
+### D2. Flag 形态
+
+**CLI `--auto` + env `ROUNDTABLE_AUTO` 两级** ★ 推荐
+
+- 沿用 DEC-013 `--decision=modal|text` + `ROUNDTABLE_DECISION_MODE` 三级链模式，心智同源
+- 不做每阶段粒度（`ROUNDTABLE_AUTO=analyst,architect`）—— YAGNI，无实际需求，v1 避免组合爆炸
+
+### D3. Recommended 缺失 fallback
+
+**强停 emit 决策块等用户** ★ 推荐
+
+- 对齐 DEC-006 B 类 approval-gate 语义（真决策不绕过）
+- 对比"选第一个"：静默错决策风险；对比"报错退出"：摧毁已完成 phase 产出
+- 打断渲染沿用 manual 路径（modal/text），零新增实现
+
+### D4. Exec-plan 策略 in auto
+
+**按任务体量探测（与 manual 同启发式）** ★ 推荐
+
+- auto 只节约"问用户 exec-plan 要不要" 的交互，不改"何时需要 exec-plan" 的判据
+- Step 1 中/大任务启发式是已有判据，orchestrator 自判即可
+
+### D5. #30 / #33 顺序
+
+**先 #33 再 #30** ★ 推荐
+
+- auto 显式豁免 A 类 gate，#30 补强 manual 路径；两 issue 正交
+- 先 #33 可批量消化 P2 积压，并解锁 #43 batch 编排器依赖链
+
+## 5. 影响文件清单
+
+- `commands/workflow.md` — 新增 Step -0 Auto Mode Bootstrap (~6 行) + Step 5 Escalation 加 auto 分支 (~5 行) + Step 6 A 类 + B 类 加 auto 分支 (~8 行) + Step 1 / Step 6b 加 auto 注记 (~3 行)
+- `commands/bugfix.md` — 通过 Step -1 ref workflow.md 自动继承；若其独立 bootstrap 段需单独引用 Step -0（~2 行）
+- `docs/design-docs/workflow-auto-execute-mode.md` — 本文档
+- `docs/decision-log.md` — DEC-015 置顶
+- `docs/exec-plans/active/workflow-auto-execute-mode-plan.md` — 执行计划
+- `docs/log.md` — orchestrator 聚合 `log_entries:` YAML flush
+
+**不改**：
+- 4 agent prompt（developer/tester/reviewer/dba）
+- `skills/architect/SKILL.md` / `skills/analyst/SKILL.md`
+- `skills/_detect-project-context.md` / `skills/_progress-content-policy.md`
+- `README.md` / `README-zh.md`（v1 不抢发布节奏；v0.0.5 release notes 补章节）
+- target CLAUDE.md 业务规则
+
+## 6. 验收标准
+
+- [ ] `/roundtable:workflow <task> --auto` 全程无阻塞跑完一个含 recommended 完整链的 medium 任务
+- [ ] `ROUNDTABLE_AUTO=1 /roundtable:workflow <task>` 等效
+- [ ] CLI `--auto` 优先级高于 env（CLI `--auto=false` 可覆盖 env 开）——**需确认语法**，见 §7
+- [ ] 某决策点 option 无 `recommended` → auto-halt 并渲染 manual 决策块
+- [ ] subagent `<escalation>` 无 recommended → auto-halt
+- [ ] tester hard regression `<escalation>` → 打断不受 auto 影响
+- [ ] lint 或 test 失败 → 打断不受 auto 影响
+- [ ] `auto_mode=true` + `decision_mode=modal` → 文档化警示"auto 对 modal skill AskUserQuestion 无效，建议搭配 text"
+- [ ] Audit trail `🟢 auto-go / auto-accept / auto-pick` + `🔴 auto-halt` 在终端 / TG 均可见
+- [ ] 4 agent prompt 0 字节改动（grep verified）
+- [ ] critical_modules tester 派发依然触发
+- [ ] dogfood：`/roundtable:workflow #43 --auto` 跑通（依赖 #33 合并后自验证）
+
+## 7. 待确认项
+
+1. **CLI flag 语法**：`--auto` 作为布尔开关（无值即真），需否支持 `--auto=false` 覆盖 env？建议：支持 `--no-auto` 显式关，与 GNU 常规对齐；无 `--auto=false` 形态（避免与 `--decision=` 形态混淆）
+2. **Step -0 vs Step -1 顺序**：auto_mode 与 decision_mode 两个 bootstrap 顺序可互换；推荐 auto_mode 先解析（Step -0），decision_mode 后（Step -1），因 auto 打断时依然需要 decision_mode 渲染
+3. **README 更新时机**：v1 落地后 release notes 是否补用户文档章节？本设计默认 v0.0.5 stable 后再加（减小 PR scope）
+
+## 8. 变更记录
+
+- 2026-04-20 初版（issue #33 architect 输出；D1-D5 一揽子 Accepted by 用户 msg 380）

--- a/docs/exec-plans/active/workflow-auto-execute-mode-plan.md
+++ b/docs/exec-plans/active/workflow-auto-execute-mode-plan.md
@@ -1,0 +1,172 @@
+---
+slug: workflow-auto-execute-mode
+source: design-docs/workflow-auto-execute-mode.md
+created: 2026-04-20
+status: Active
+---
+
+# Workflow Auto-Execute Mode 执行计划
+
+## 总览
+
+| Phase | 标题 | 预估 | 前置 | 关键风险 |
+|-------|------|------|------|----------|
+| P0 | Orchestrator bootstrap Step -0 | ~10 min | 设计确认 | flag 解析优先级歧义 |
+| P1 | Step 5 Escalation 加 auto 分支 | ~10 min | P0 | 与 decision_mode 分支嵌套顺序 |
+| P2 | Step 6 A/B 类 phase gating 加 auto 分支 | ~15 min | P1 | B 类 recommended 检测规则不清 |
+| P3 | Step 1 / Step 6b inline 决策加 auto 注记 | ~5 min | P2 | — |
+| P4 | bugfix.md ref 继承确认 | ~5 min | P3 | — |
+| P5 | Tester 对抗评审 + 回归修正 | 单轮 30 min | P4 | critical_modules 多命中 |
+| P6 | Reviewer 一致性巡视（可选） | 单轮 15 min | P5 | — |
+| P7 | dogfood E2E（跑 auto 跑一个 medium issue） | ~20 min | P6 | recommended 缺失场景覆盖不全 |
+| P8 | Closeout + PR | ~10 min | P7 | — |
+
+## P0 Orchestrator Bootstrap Step -0
+
+### 目标
+在 `commands/workflow.md` 顶部插入 Step -0 Auto Mode Bootstrap，解析 `auto_mode` bool，注入后续派发 prompt。
+
+### 任务清单
+- [ ] 在 `## Step -1: Decision Mode Bootstrap` 之前插入 `## Step -0: Auto Mode Bootstrap` 章节（~6 行）
+- [ ] 优先级链文案：CLI `--auto` > env `ROUNDTABLE_AUTO` > default=false
+- [ ] 注入策略：`Task` prompt prefix + skill activation context prefix 加 `auto_mode: <value>`
+- [ ] 使用场景提示：批量 dogfood / CI / 信任型；不适用初次探索陌生决策域
+- [ ] 确认 Step -0 在 Step -1 之前（auto_mode 解析先于 decision_mode，理由：auto-halt 时依然需要 decision_mode 渲染）
+
+### 成功信号
+- workflow.md Step -0 段可独立阅读，无循环引用
+- lint_cmd 0 命中
+
+### 风险与预案
+- 风险：flag 解析若未显式写 `--no-auto` 关闭语义，用户无法在 env 开启时临时关 →（设计待确认项 §7 item 1）推荐添加 `--no-auto` 显式关语法
+
+## P1 Step 5 Escalation 加 Auto 分支
+
+### 目标
+在 Step 5 Escalation 的 "按 `decision_mode` 分支" 步骤之前加 "按 `auto_mode` 分支" 上层判定。
+
+### 任务清单
+- [ ] 在 Step 5 第 2 步 "按 `decision_mode` 分支" 之前插入 "2a. 按 `auto_mode` 分支"
+- [ ] auto_mode=true + option 含 recommended → 直接注入决策事实重派 agent，emit `🟢 auto-pick <letter> <label> (auto_mode=on, why: <why_recommended>)`
+- [ ] auto_mode=true + 无 recommended → emit `🔴 auto-halt: no recommended option at <esc-...>` + 沿用 `decision_mode` 渲染（fallback）
+- [ ] auto_mode=false → 直接进入 `decision_mode` 分支（现状）
+- [ ] 注：已存在的 `decision_mode` text 分支下 `active channel forwarding` 规则在 fallback 路径依然生效（auto-halt 后走 manual text 渲染仍须转 TG）
+
+### 成功信号
+- Step 5 三种 auto_mode × 两种 decision_mode 路径均可追溯
+- grep `auto-pick` `auto-halt` 在 workflow.md 出现
+
+## P2 Step 6 A/B 类 Phase Gating 加 Auto 分支
+
+### 目标
+Step 6 规则 1 的 A / B / C 三档 phase gating 各加 auto_mode 子分支（C 不变）。
+
+### 任务清单
+- [ ] A 类 producer-pause：`auto_mode=true` 时 emit `🟢 auto-go <role> ✅ (auto_mode=on)` 一行自动推进，不输出 3 行 summary 也不停
+- [ ] B 类 approval-gate：`auto_mode=true` 且 option 含 recommended → 自动 Accept，emit `🟢 auto-accept <role> design (recommended: <label>, auto_mode=on)`；无 recommended → auto-halt 沿用 manual
+- [ ] C 类 verification-chain：不变（现状已自动）
+- [ ] Phase Matrix → category 映射注释保留（不改）
+
+### 成功信号
+- A / B 类 auto_mode on/off 4 路径在 prompt 中均可追溯
+- Phase Matrix 1-9 stage 映射表（在 workflow.md 顶部 matrix）无改动
+
+### 风险与预案
+- 风险：B 类 Stage 4 Design confirmation 的 architect AskUserQuestion 在 modal+auto 下由 runtime 执行 orchestrator 拦截不了 → 设计 §3.2 已说明"modal + auto skill 弹窗照常"，文档示警搭配 text
+
+## P3 Step 1 / Step 6b Inline 决策加 Auto 注记
+
+### 目标
+Step 1 规模模糊 `AskUserQuestion` 与 Step 6b developer form `AskUserQuestion` 加 auto_mode 注记。
+
+### 任务清单
+- [ ] Step 1 模糊判定处注记：auto_mode=true + 启发式命中某档 → 采纳，emit `🟢 auto-pick size=<medium|large>`
+- [ ] Step 6b 三级切换第 3 级 per-dispatch 注记：auto_mode=true + 小任务启发式命中 → inline 采纳；否则 subagent 采纳；emit `🟢 auto-pick form=<inline|subagent>`
+- [ ] 注记控制在 3 行内，不重写整节
+
+### 成功信号
+- Step 1 / Step 6b 原结构未被打散；auto 注记放子 bullet
+
+## P4 bugfix.md Ref 继承确认
+
+### 目标
+确认 `commands/bugfix.md` 的 Step -1 引用 `commands/workflow.md` 时自动继承 Step -0 Auto Mode Bootstrap。
+
+### 任务清单
+- [ ] 读 `commands/bugfix.md` Step -1 ref 段
+- [ ] 若仅引用 "Step -1 Decision Mode Bootstrap" 需扩为 "Step -0 / Step -1 Auto & Decision Mode Bootstrap"（~2 行）
+- [ ] 若是泛引 workflow.md 顶部 bootstrap 段则零改动
+
+### 成功信号
+- bugfix 路径下 `/roundtable:bugfix --auto` 与 workflow 一致生效
+
+## P5 Tester 对抗评审
+
+### 目标
+critical_modules 多命中（skill/agent/command prompt 本体 + workflow Phase Matrix + DEC-005 developer form rules）必派 tester 做对抗性评审。
+
+### 任务清单
+- [ ] 派发 roundtable:tester subagent（foreground，critical 必落盘）
+- [ ] Tester 读 workflow.md / bugfix.md / design-doc / DEC-015 做 prompt 层静态对抗
+- [ ] 评审点：flag 优先链自洽 / recommended 检测规则明确 / audit trail 完备 / fallback 不漏 / 与 DEC-006 不冲突 / 4 agent 零改动字节 verified
+- [ ] Tester 落盘 `docs/testing/workflow-auto-execute-mode.md`
+- [ ] 若有 Critical/Warning → round 2 post-fix inline 回填
+
+### 成功信号
+- Tester 报告 PASS 或 PASS-WITH-FINDINGS
+- round 2 回归后 0 Critical
+
+## P6 Reviewer 一致性巡视（可选）
+
+### 目标
+critical_modules 命中 → reviewer 走行数纪律 / 跨文件一致性巡视。
+
+### 任务清单
+- [ ] 派发 roundtable:reviewer subagent（critical 必落盘）
+- [ ] 审查：workflow.md + bugfix.md + design-doc + DEC-015 交叉一致性
+- [ ] Reviewer 落盘 `docs/reviews/2026-04-DD-workflow-auto-execute-mode.md`
+
+### 成功信号
+- Reviewer Approve 或 Approve-with-caveats
+
+## P7 Dogfood E2E
+
+### 目标
+auto 模式真跑一个 medium 任务验证闭环。
+
+### 任务清单
+- [ ] 候选：`/roundtable:workflow <某 P2 issue> --auto`
+- [ ] 观察：4 审计 emit 是否齐全 / 决策点 recommended 采纳是否正确 / auto-halt 场景命中 / lint+test failure 打断
+- [ ] 记录到 `docs/testing/workflow-auto-execute-mode.md` §dogfood 章节
+
+### 成功信号
+- auto 全链无意外阻塞
+- auto-halt / failure 打断路径命中
+
+### 风险与预案
+- 风险：recommended 缺失场景 dogfood 未覆盖 → 人工构造一次无 recommended 决策点验证 fallback
+
+## P8 Closeout + PR
+
+### 目标
+落仓 commit + push + PR open。
+
+### 任务清单
+- [ ] git commit message 含 close #33 + 设计摘要
+- [ ] PR title: `feat(workflow): add --auto mode with three-tier priority (DEC-015)`
+- [ ] PR body: 设计要点 / 影响文件 / 验收清单
+- [ ] push + gh pr create
+
+### 成功信号
+- PR 开成功
+- GitGuardian 等 check pass
+
+## 跨阶段约束
+
+- 所有 prompt 改动必须过 lint_cmd（硬编码 grep 扫描 0 命中）
+- 所有 orchestrator 决策路径的 audit trail 可在终端 / TG 观察（decision_mode=text 时转发规则 DEC-013 §3.1a 沿用）
+- critical_modules 多命中：tester 必派 + reviewer 可选但推荐
+
+## 变更记录
+
+- 2026-04-20 初版（issue #33 architect 输出，跟随 design-doc 同轮）

--- a/docs/log.md
+++ b/docs/log.md
@@ -14,6 +14,11 @@
 
 **合并原则**：agent / skill **不直接写本文件**。每轮 workflow 由 orchestrator 按 `commands/workflow.md` §Step 8 log.md Batching 协议（bugfix 流程按 `commands/bugfix.md` §log.md Batching 简化版）收集各 agent final report 中的 `log_entries:` YAML block 聚合写入；同一 agent 在同一轮产出多份文档（如 architect 同时输出 design-doc + DEC + exec-plan）**合并为一条**，`影响文件` 列全部路径（union）；不拆多条。DEC-009 决定 2 落地。
 
+## design | workflow-auto-execute-mode | 2026-04-20
+- 操作者: architect (skill, inline)
+- 影响文件: docs/design-docs/workflow-auto-execute-mode.md (new); docs/decision-log.md (DEC-015 置顶); docs/exec-plans/active/workflow-auto-execute-mode-plan.md (new); docs/INDEX.md (append design-docs + exec-plans 条目)
+- 说明: issue #33 D1-D5 一揽子 Accepted by 用户 msg 380 → architect 产出 DEC-015 (11 决定) + 完整设计（§2 业务逻辑矩阵 auto×gate / §3 orchestrator 唯一改动落点 / §4 D1 量化评分 B=46 vs A=23 / §5 影响清单明示 4 agent + 5 skill + README + CLAUDE.md 零改动）+ P0-P8 exec-plan；对齐 DEC-013 三级链 / DEC-006 Phase Matrix 守约 / DEC-010 token 节约 / DEC-011/012 不抬 CLAUDE.md 边界
+
 ## fix | dec013-active-channel-forwarding | 2026-04-20
 - 操作者: developer (inline) / tester (subagent, fg; critical_modules 多命中 → 必评审) / orchestrator
 - 影响文件: commands/workflow.md (Step 5 text 分支加 sub-bullet); skills/architect/SKILL.md (decision_mode text 段加 sub-bullet); skills/analyst/SKILL.md (decision_mode text 段加 sub-bullet); docs/design-docs/decision-mode-switch.md (新增 §3.1a + §10 变更记录追加); docs/decision-log.md (DEC-013 entry 追加 post-fix 2026-04-20 注记)


### PR DESCRIPTION
refs #33（设计提前 review；实施另走 PR）

## Summary

- 完整设计文档：`/roundtable:workflow --auto` 批量预授权 A/B 类 phase gate + 自动采纳 `recommended` option；无 recommended / subagent escalation / tester hard regression / lint+test failure 依然打断
- DEC-015 Accepted 11 决定（对齐 DEC-013/006/010/011/012）
- P0-P8 exec-plan
- **本 PR 零 prompt 改动**；实施走 follow-up PR `feat/33-auto-execute-mode-impl`

## 改动（5 files +461/-0）

- `docs/design-docs/workflow-auto-execute-mode.md` **new**（完整设计；§4 D1 量化评分 B=46 vs A=23）
- `docs/decision-log.md` DEC-015 置顶
- `docs/exec-plans/active/workflow-auto-execute-mode-plan.md` **new**（P0-P8 / 验收清单）
- `docs/INDEX.md` 同步 design-docs + exec-plans 条目
- `docs/log.md` append design entry

## 5 决策要点（见 DEC-015）

| # | 选项 | 理由摘要 |
|---|------|---------|
| D1 | B = `/workflow --auto` flag | DEC-010 精简心智 / skill 零 caller 感知 / 1 source |
| D2 | CLI `--auto` + env `ROUNDTABLE_AUTO` 两级 | 沿用 DEC-013 三级链模式 / 不做 per-stage 粒度 (YAGNI) |
| D3 | recommended 缺失 → 强停 emit 决策块 | 对齐 DEC-006 B 类 approval-gate / 拒绝选第一/报错退出 |
| D4 | exec-plan 按任务体量探测（auto 不改判据） | Step 1 中/大任务启发式已有 |
| D5 | 先 #33 再 #30 | #30 正交补强 manual 路径 / 不在 #43 关键路径 |

## 契约（可 grep verified）

- 不改 4 agent prompt（developer/tester/reviewer/dba）
- 不改 2 skill prompt（architect/analyst）
- 不改 2 helper（`_detect-project-context` / `_progress-content-policy`）
- 不抬 target CLAUDE.md 业务规则
- Phase Matrix A/B/C category 映射不变（auto 只是批量预授权）
- critical_modules tester 派发 / lint+test failure 打断 / tester hard regression 永远不受 auto 影响

## Why design-only PR

- 便于对设计内容做 focused review（11 决定 + 矩阵 + 量化评分）
- 实施 PR（`commands/workflow.md` ~22 行 + `commands/bugfix.md` ~2 行 + tester + E2E）独立走
- 减少本 PR 合并冲突面

## Test plan

- [x] 设计与 DEC-013/006/010/011/012 0 冲突（内部 cross-check pass）
- [x] lint_cmd 0 命中（5 files 全是 docs 路径，但仍跑一遍）
- [ ] 设计 review 通过 → 开 follow-up PR 落 prompt 改动
- [ ] follow-up PR 含 tester + dogfood E2E

## 关联

- refs #33（本设计）
- 依赖 #30（正交 follow-up，先 #33 后 #30）
- 解锁 #43（batch 编排器，本 PR 是 #43 依赖链首环）
- 引用 DEC-013（三级链同源）/ DEC-006（Phase Matrix 守约）/ DEC-010（token 节约延伸）/ DEC-011/012（不抬 CLAUDE.md 边界）