### PR TITLE
feat(batch): orchestrator design phase for issue #43 (analysis + architecture + exec-plan)

### DIFF
--- a/docs/analyze/batch-orchestrator.md
+++ b/docs/analyze/batch-orchestrator.md
@@ -1,0 +1,525 @@
+---
+slug: batch-orchestrator
+source: 原创（issue #43 需求 + Claude Code 官方文档 + DEC-001~015 内部资料）
+created: 2026-04-20
+---
+
+# Batch Orchestrator 深度分析报告
+
+> 覆盖 issue #43 `/roundtable:batch` 命令的事实层调研。架构推荐 / 决策打分不在本报告范围（归属 architect 阶段）。
+
+## 1. 背景与目标
+
+**需求来源**：[issue #43 P2 enhancement](https://github.com/duktig666/roundtable/issues/43) —— `/roundtable:workflow` 当前绑定单 issue / 单会话。对积压多个 P2/P3 dogfood issue 的场景（roundtable 自身递归 dogfood）用户希望 **主会话一次编排多个 issue 并行推进**，仅在最终汇聚或 tie-break 介入。
+
+**分析范围**（用户明确"加大力度"：）
+
+- 结构化 issue body 陈述的 5 待评估问题 / 4 架构要点 / 5 目标场景 / 3 非目标
+- 核查 Claude Code `Agent` 工具 + `isolation:worktree` + `run_in_background` 三件套的原生行为
+- 逐一比对 batch orchestrator 对 DEC-001~015 边界的触达
+- 深度对比 DEC 编号竞争 / 冲突预检 / 并发模型 / worktree 生命周期 / 失败终态 的各技术路径的成本 / 风险 / 失败模式
+- 评估与 #28 / #30 / #48 的正交性
+- Dogfood 可行性量化
+
+**不做**：架构路径推荐、方案打分、"建议选 X"等指向性措辞（归属 architect）。
+
+## 2. 追问框架
+
+### 必答 2
+
+**失败模式 / 最可能在哪里失败**：
+
+- **子 agent 集体卡死**（`AskUserQuestion` 在 background subagent 无响应途径）—— Claude Code 文档明确：background subagent 若需 clarifying question，"that tool call fails but the subagent continues"[^1]。对于 `/roundtable:workflow --auto --decision=text` 组合，若路径中任一 skill 弹 modal AskUserQuestion（而非 text `<decision-needed>`），子 agent 会失败或 fallback 未知行为
+- **DEC 编号竞争 + sed 替换假阳性**：`DEC-NEW-<uuid>` 占位符如果在子 agent 产物中被**邻近 plain text** 误用（例如 "我不小心写了 DEC-NEW-abc123 在代码块里做示例"），主会话 sed 会错误替换
+- **worktree 堆积 + 磁盘耗尽**：并行 N 个 issue × 每个 issue worktree 副本 = N×repo_size；长期 dogfood 跑完不清理会吞盘
+- **API rate limit（429）在 concurrency>3 时命中**：Anthropic API 不做专门 bulk discount
+- **主会话中断** + `Ctrl-C` → 已派发 bg subagent 失去接收方，但仍在跑（Claude Code 不会自动 cancel）
+
+**6 个月后评价**：
+
+可能成为债务的三个方向：
+
+1. **命令双生态**：若 `/roundtable:batch` 与 `/roundtable:workflow` 在后续演化中行为漂移（workflow 升级但 batch 转发未跟进），两套入口产生语义分叉，**新用户不清楚什么时候该用哪个**。维护成本随时间推进线性放大
+2. **冲突预检启发式假阴性兜底依赖 worktree**：假阴性（预检漏报但 issue 实际改同文件）的兜底是 worktree 隔离 + 用户最后手动 rebase/merge。如果用户依赖此流程跑 dogfood 数月后才发现某类冲突**持续漏报**（例如 issue body 引用某 DEC 但以别名 / 中文叙述代替），预检会成为"看似工作实则不灵"的静默债务
+3. **DEC 重编号语义复杂化**：后续 DEC 若引入**跨 DEC 显式 supersede 链**，重编号时需保持 Supersede 关系的 ID 映射一致 —— 一次 sed 替换不够，需语义级 rename；P2 批次若与 P3 批次跨 session 复用同占位符 UUID（低概率但存在），会互相污染
+
+### 按需 4（本任务适用，绿地功能 + 需求定位新系统）
+
+**痛点**：真正解决什么？
+
+- issue 描述：批量 dogfood 时 `/roundtable:workflow` 每次只能一条 issue；用户只想看最终 PR 集合，中间交互成本是损失
+- **放大镜**：\#33 (DEC-015 auto mode) 把单 issue 非交互化；\#43 把 N 条 issue 并行非交互化。两者是同一痛点的两个量级
+- **真实数据点**：当前 roundtable open issue 11 条（见 §3.10）；P2/P3 占 9 条；若不 batch 单条按"analyst 30min + architect 1h + developer 2h"估算 = 27h+ 单串；batch concurrency=3 理论 ≈ 9h
+
+**使用者与 journey**：
+
+- **第一视角**：roundtable 维护者（duktig666）在 TG 触发 `/roundtable:batch #27 #29 #40`，期望收到"3 个 PR URL 各可点开"的终态消息，中间不需要操心
+- **第二视角**：P4 dogfood 期间新用户测试 batch 命令；需要命令有明显失败退路（recommended 缺失停在 worktree）+ 可回溯 audit trail
+- **第三视角**：CI / 自动化脚本（本 issue 非目标但未来可能）
+
+**最简方案 MVP**：
+
+- 单 issue 形态的 `/roundtable:batch #N` = `/roundtable:workflow #N --auto --decision=text` 包裹一层 Agent worktree
+- 无冲突预检 / 无 DEC 重编号 / 无汇聚报告
+- 验证 "Agent + isolation:worktree + /roundtable:workflow 可执行" 的技术可行性
+- 成本：~50 行 command 文件
+
+**竞品对比**（至少 2 个参考方案）：
+
+1. **GitHub Actions matrix strategy + Claude Code SDK**：每个 issue 一个 job，matrix fan-out；`strategy.max-parallel` 控并发；GH 原生 worktree-per-job 隔离。**设计理由**：GH CI 本就为并发任务设计，fan-out/fan-in 语义原生；**与本需求差距**：不在 Claude Code session 内部，`<decision-needed>` 无法 bubble 到 TG，用户 tie-break 要切到 GH UI
+2. **Claude Code `agent teams`**（官方功能，documentation reference "agent teams coordinate across separate sessions"[^1]）：多 session 协调执行并行任务，专为"sustained parallelism or exceed your context window"场景设计。**设计理由**：workload 超出单 session context 时的一等方案；**与本需求差距**：agent teams 是**多 session**，跨 session 不能用主会话的 Monitor + TG 通道；用户已选"主会话内部 fan-out"形态，agent teams 相当于另一维度
+3. **Aider / Cursor agent mode**：单会话内处理多任务但无 worktree 隔离，依赖 git branch 切换。**与本需求差距**：无并行，串行效果 ≈ 当前 `/roundtable:workflow` 多次调用
+
+## 3. 调研发现
+
+### 3.1 需求结构化（量化事实表）
+
+**issue body 五大待评估问题**（逐条转事实）：
+
+| # | 问题 | issue 作者倾向 | 是否开放 |
+|---|------|---------------|---------|
+| 1 | 并发模型：Agent 多调用并行 vs 串行 + 内部 auto | "推荐前者（真并行）" | ✅ 开放（事实层） |
+| 2 | Worktree 清理：保留 vs 回收 vs 有变更保留 | "有变更保留、无变更回收（isolation:worktree 默认行为）" | ✅ 开放 |
+| 3 | PR 基线：main vs DEP 图合并序 | "初版走前者（main）" | ✅ 开放 |
+| 4 | critical_modules tester 跨 issue 并行 | "不允许（保持 DEC-001 语义）" | ✅ 开放 |
+| 5 | 与 #28 关系 | "正交，互不依赖" | ⚠️ 待核验（§3.9） |
+
+**4 架构要点**（issue 原文）：
+
+- 隔离策略：`Agent(subagent_type=..., isolation:"worktree", prompt:"/roundtable:workflow <N> --auto")`
+- 冲突预检（lightweight）：扫 `DEC-\d+` / `skills/*.md`
+- DEC 编号竞争：方案 A 中心锁 vs 方案 B post-hoc renumber
+- 并发上限默认 3，`--concurrency N` 覆盖
+
+**5 目标场景点**：略（issue body 自解释）
+
+**3 非目标**：不做 issue 依赖图自动推导 / 不做跨 issue context 共享 / 不做 auto + human-in-the-loop 异步通道
+
+**量化估算**（standalone 单 issue baseline）：
+
+| 指标 | 值 | 来源 |
+|------|---|------|
+| 单 issue workflow 耗时（小任务 bugfix） | ~10-30 min | 估算：#37/#38 实测 |
+| 单 issue workflow 耗时（中等 feature） | ~1-2 h | 估算：#33 实测 |
+| 单 issue workflow 耗时（大 feature 含 tester） | ~2-4 h | 估算：#31 实测 |
+| concurrency=3 理论加速 | 2.5-2.8× | 估算（有 fan-in/fan-out overhead） |
+| 单 issue prompt token 消耗（含工作流） | ~30-80k | 估算 |
+| 同 concurrency API 并发上限触发 rate limit | ~3-5 | 待验证 |
+
+### 3.2 Claude Code `Agent` 工具原生能力（实测 + 官方文档）
+
+来源：`https://code.claude.com/docs/en/sub-agents`（WebFetch 2026-04-20）
+
+**frontmatter 字段表**（相关字段全表）：
+
+| 字段 | 作用 | 与本需求相关 |
+|------|------|------------|
+| `isolation: worktree` | 临时 git worktree，隔离 repo 副本，**自动清理若 subagent 无变更** | ✅ 本需求核心 |
+| `background: true` | 并发运行；launch 前 Claude Code prompt 预授权所有工具权限；auto-deny 未预授权；**needing clarifying question → tool call 失败但 subagent 继续** | ✅ 本需求核心 |
+| `maxTurns` | 单 subagent 最大 agentic 轮数 | ⚠️ 可能需要设（防止 infinite loop） |
+| `tools` / `disallowedTools` | 限定可用 tool | ⚠️ batch 子 agent 需 gh / git / bash 全开 |
+| `permissionMode` | `auto` / `acceptEdits` / `bypassPermissions` | ⚠️ batch 内 subagent 大概率需 `auto` 或 `acceptEdits` |
+| `mcpServers` | MCP server 配置 | ⚠️ 继承主会话 TG plugin？待验证 |
+| `hooks` | 子 agent 级 hook | 不需 |
+| `skills` | 可用 skills | ⚠️ 需继承 roundtable plugin 全套 |
+| `initialPrompt` | 首轮 prompt prefix（processed commands and skills） | ✅ 可用来塞 `/roundtable:workflow` slash command |
+| `model` | 子 agent model | ⚠️ 默认继承；Opus vs Haiku 取舍 |
+| `effort` | 思考深度 | 不明；默认 |
+| `memory` | 子 agent memory | 子 agent 与主会话 memory 隔离 vs 共享？待验证 |
+
+**已确认关键行为**（官方文档引用）：
+
+1. **`isolation: worktree` 清理语义**：
+   > "The worktree is automatically cleaned up if the subagent makes no changes"
+
+   反之有变更 → 保留（与 issue 作者假设一致）
+
+2. **background subagent 的 clarifying question 处理**：
+   > "If a background subagent needs to ask clarifying questions, that tool call fails but the subagent continues."
+
+   **关键影响**：子 agent 内 skill 弹 `AskUserQuestion`（modal）→ tool call 失败但 subagent 继续 → 未知后续行为。**对 text mode 是根本约束**：子 agent 必须 `decision_mode=text`，`<decision-needed>` 作为 text 输出到 final message（不走 tool）
+
+3. **subagent 与 parent 的 context 隔离**：
+   > "Each subagent runs in its own context window with a custom system prompt, specific tool access, and independent permissions."
+
+   **含义**：子 agent 不共享主会话 context；返回 only summary；主会话要拿到子 agent 的 `<decision-needed>` 块必须在 final message 里 + 主会话 parse
+
+4. **subagent resume 语义**：
+   > "If a stopped subagent receives a `SendMessage`, it auto-resumes in the background without requiring a new `Agent` invocation."
+
+   **含义**：子 agent 中途 tie-break 停留 → 主会话可 `SendMessage` 唤醒（relay 用户决策）而不必重跑
+
+5. **并行 subagent**：
+   > "For independent investigations, spawn multiple subagents to work simultaneously"
+
+   **含义**：单 message 多 Agent 调用支持（与 DEC-003 parallel research 同机制）
+
+6. **agent teams vs subagents**：
+   > "If you need multiple agents working in parallel and communicating with each other, see agent teams instead. Subagents work within a single session; agent teams coordinate across separate sessions."
+
+   **含义**：本需求选"subagents in single session"路径；`agent teams` 是备选但需跨 session，与主会话 TG channel 断开
+
+**待验证**（文档未明说或未找到）：
+
+- Agent 工具 timeout 阈值（有无默认 timeout？触发后 subagent 状态？）
+- `maxTurns` 触发后 subagent final message 形态
+- MCP plugin tools（TG reply）是否自动继承到 subagent（推断：`mcpServers` 字段未显式指定 → 继承主会话？）
+- 子 agent 内能否 fan-out 嵌套 Agent 调用（batch 子 agent 内的 workflow 调用 developer subagent 形成二级 fan-out）
+- Anthropic API 并发 rate limit 具体数值
+
+### 3.3 DEC-001~015 冲突清单（逐条核查 batch orchestrator 的触达）
+
+| DEC | 内容概括 | batch orchestrator 触达 | 潜在冲突 |
+|-----|---------|-----------------------|---------|
+| **DEC-001** | 4 agent 打包 plugin + D1-D9 | batch 主会话 orchestrator 扩展不改 4 agent | 低；batch 层是 command 层不是 agent 层 |
+| **DEC-002** | shared resource / escalation / workflow matrix | batch 汇聚多个 subagent 的 escalation | ⚠️ escalation 多路并发聚合时合并规则未定 |
+| **DEC-003** | architect parallel research fan-out | batch 与 research 都用并行 subagent | **嵌套并行**：batch 子 agent 内的 architect 再 fan-out research = 二级并行 |
+| **DEC-004** | progress event JSON schema（P1 push） | batch 主会话 Monitor 多 dispatch_id 交织 | ⚠️ 需每个 batch 子 agent 独立 DISPATCH_ID；其内部 workflow 若派 subagent 再生第三级 dispatch_id |
+| **DEC-005** | developer 双形态 inline/subagent | batch 子 agent 内部 workflow 会自选 form | 不冲突；子 agent 自定 |
+| **DEC-006** | phase gating 三段式（producer-pause / approval-gate / verification-chain） | batch 层本身也是混合（Step 4 producer-pause + Step 5 verification-chain） | ⚠️ **新问题**：batch Stage 4 plan confirm 属于 A 类 producer-pause，但用户 auto 意图与此冲突 |
+| **DEC-007** | subagent progress content policy | 不变 | 不冲突 |
+| **DEC-008** | workflow Step 3.5 前台派发免 Monitor | batch 全走 bg，全启 Monitor | 不冲突 |
+| **DEC-009** | 轻量化重构（4 helper + log batching） | batch 可能需自己的 helper，或 inline | 不冲突 |
+| **DEC-010** | 矫正 DEC-009 决定 1（精简心智） | batch 主体在 commands/batch.md 中集中；**抽 helper 须有数据支持** | 约束强：不能为"美观"抽 helper |
+| **DEC-011** | decision-log 条目顺序（置顶 / 最新在前） | batch 重编号改变原"直接递增"语义 | **⚠️ 新问题**：重编号后是否还满足"最新在前"（按完成时序分 ID 后顺序仍是最新在前，但 DEC ID 不单调递增跨子 agent） |
+| **DEC-012** | subagent 派发 run_in_background 策略（D2 并行度 + D4 两级逃生门） | batch 全并行走 bg | 一致；条件 2（并行度≥2）自动满足 |
+| **DEC-013** | decision_mode modal/text + §3.1a TG 转发 | batch 子 agent 强制 text；TG 转发在 batch 主会话 vs 子 agent vs 主-子往返链 | ⚠️ **三层嵌套**：TG → batch 主会话 → batch 子 agent → workflow → architect skill；任一层 `<decision-needed>` 需 bubble 到 TG |
+| **DEC-014** | bugfix tiered rootcause | 不变 | 不冲突 |
+| **DEC-015** | auto_mode（--auto / env） | batch 子 agent 固定 `--auto`；batch 本身是否也支持 auto？ | ⚠️ 双层 auto：batch 层 auto + 子 agent auto，语义区分 |
+
+**关键发现**：DEC-002 / DEC-003 / DEC-004 / DEC-006 / DEC-011 / DEC-013 / DEC-015 有交互 —— 都是 orchestrator 层 / decision-log 顺序 / 决策流机制相关。batch 是"多个 orchestrator 的元 orchestrator"，必然触达这些。
+
+### 3.4 DEC 编号竞争深度对比
+
+#### 方案 A：主会话中心锁预分配编号段
+
+**机制**：主会话 fan-out 前读当前 `decision-log.md` MAX = X；分配 `[X+1, X+N]` 给 N 个 batch 子 agent（按 issue 顺序或随机）；子 agent 使用固定预分配编号写 DEC。
+
+**失败模式**：
+
+- **子 agent crash 后编号空洞**：若 `#A` 分配 DEC-017 但子 agent crash 且无 DEC 产出，DEC-017 永久空洞；违反 DEC-011 "编号只增不减，不复用"隐含的"无空洞"（严格讲铁律只说"不复用不回退"，没说"不空洞"，但审计不好看）
+- **需要跨子 agent 锁**：主会话顺序分配即可（无并发 counter 问题），但需保证其他单 issue `/roundtable:workflow` 并发调用不抢占这段号 —— 假设用户一手跑 batch 另一手跑单 issue workflow，单 issue workflow 读的 MAX 仍是 batch 跑前的 X，会和 batch 分配号冲撞
+- **子 agent 超限写**：若子 agent 要写 >1 个 DEC（例如 #A 意外产出 3 个决策），预分配段不够
+
+**优势**：
+
+- 号码从派发时即固定；子 agent PR body 可直接写最终 DEC 号
+- 无事后 sed 替换的文件扫描成本
+
+#### 方案 B：post-hoc renumber with `DEC-NEW-<uuid>` 占位
+
+**机制**：子 agent 写占位 `DEC-NEW-<uuid8>`（`openssl rand -hex 4` 足够）；主会话 fan-in 后按完成时序读当前 MAX 依次分配 `DEC-(MAX+1)` `DEC-(MAX+2)` ...；sed 替换跨文件。
+
+**失败模式**：
+
+- **假阳性替换**：若占位符巧合出现在**非 DEC 引用上下文**（例如代码块示例、注释里提到占位语法），sed 会误换
+  - 缓解：正则限定前缀必须匹配 `^### DEC-NEW-[a-f0-9]{8}` 或严格 ID 字符集 `\bDEC-NEW-[a-f0-9]{8}\b`；实测 UUID8 碰撞概率 ≤ 1/4Bn
+- **子 agent 产物被**第三方 agent 引用（仍在 worktree 内）：无影响，sed 同范围替换
+- **子 agent 产物跨 worktree 被外部引用**：不存在（worktree 隔离）
+- **重编号漏文件**：sanity grep `grep -r "DEC-NEW-" docs/ skills/ agents/ commands/` 末尾必须 0 命中；命中说明漏替换
+- **重编号过程中中断**（sed 跑一半挂了）：部分 DEC-NEW 留下，部分已替换；手动补替
+- **完成时序不确定**：多个子 agent 几乎同时完成时，"谁先谁后"取决于 bg notification 到达序，可能与用户心理预期的"issue 顺序"不一致
+
+**优势**：
+
+- 子 agent 零协调 / 零跨子 agent 锁
+- crash 子 agent 的占位符直接丢弃（sed 扫不到它的 worktree 即忽略）
+- 容错 + 简单
+
+#### 方案 C：第三方案 —— batch 主会话统一写 DEC，子 agent 不写
+
+**机制**：子 agent 的 architect 不写 `decision-log.md`，改在 final message 以 `dec_proposals:` YAML 上报决策草案；主会话 fan-in 后由 batch orchestrator / meta-architect 统一合并入 decision-log。
+
+**失败模式**：
+
+- **违反 DEC-001 D8 Resource Access**：architect 写 `decision-log.md` 是核心职责，剥夺后 architect 心智破碎
+- **语义断裂**：DEC 是 architect 决策的权威载体；统一写意味"batch 的 meta-architect 代 architect 决策"，与多 subagent 独立设计的本意相反
+- **需要新规则**：什么是"可以合并的 DEC 草案"？冲突怎么处理？
+- **YAML schema 工作量大**：DEC body 段是长 markdown，装进 YAML 需 escape
+
+**优势**：
+
+- DEC 编号单调单作者单调递增，零并发
+- decision-log 仍由主会话一次写入（与现状一致）
+
+#### 三方案对比表（事实层，不打分）
+
+| 维度 | A 中心锁 | B post-hoc renumber | C 主会话统一写 |
+|------|---------|---------------------|---------------|
+| 实现复杂度 | 中（跨 agent 号段分配 + 单 issue workflow 并发互斥） | 低（占位符 + fan-in sed） | 高（YAML schema + 合并规则 + 违反 Resource Access） |
+| crash 容错 | 空洞风险 | 占位符自然丢弃 | architect 草案可能半成品 |
+| 号码预告性 | 强（子 agent PR body 可写最终号） | 弱（需 fan-in 后才知） | 中（主会话合并后确定） |
+| 需改的 agent/skill | batch 命令 + architect skill（加号段分配逻辑） | architect skill（加 batch_mode 条件 + 占位符生成） | architect skill（大改：不再写 decision-log + 改 YAML output） |
+| DEC-001 / DEC-011 / Resource Access 冲突 | 无显著冲突 | 无显著冲突 | **违反 DEC-001 D8 + 改变 Resource Access** |
+| sanity check 成本 | 检查号段是否漏 | grep 检查占位符残留 | 检查 YAML schema 合法性 + 合并完整性 |
+
+### 3.5 冲突预检启发式误差分析
+
+**预检机制**（issue 提议）：
+
+```
+正则 1: DEC-\d+
+正则 2: (?:skills|agents|commands)/[\w-]+\.md
+图构建：节点=issue，边=共享 ≥1 个 token
+分组：连通分量 → 同组串行
+```
+
+**真阳性率预估**（按历史 issue 抽样）：
+
+抽样 open issue 11 条（#20/#22/#23/#26/#27/#28/#29/#30/#40/#43/#48），手工分析其 body 中的 token 与实际改动面关系：
+
+| Issue | body DEC token | body 路径 token | 实际潜在改动面 | 预检有效 |
+|-------|---------------|----------------|--------------|---------|
+| #20 | - | - | `skills/_detect-project-context.md` + agents/*（subagent cold-start） | ❌ 漏报（body 不提路径） |
+| #22 | DEC-010 | runtime prompts | workflow.md / agents/*（token audit） | ⚠️ 半报 |
+| #23 | - | - | `agents/reviewer.md` | ❌ 漏报 |
+| #26 | DEC-006 | - | workflow.md Stage 9 | ✅ 对 DEC-006 报 |
+| #27 | - | - | skills/*.md FAQ 段 | ❌ 漏报 |
+| #28 | - | - | workflow.md 决策流 | ❌ 漏报 |
+| #29 | - | skills/architect.md | skills/architect.md（产出字段重复 bug） | ✅ |
+| #30 | DEC-006 | commands/workflow.md:24 | workflow.md + bugfix.md | ✅ |
+| #40 | DEC-014 | - | design-docs/bugfix-rootcause-layered.md | ✅ DEC-014 |
+| #43 | DEC-001/003/004/006/008/011/013/015 | workflow.md | commands/batch.md + skills/architect.md | ✅ 大量 |
+| #48 | DEC-013 | commands/workflow.md + skills/architect.md | 同 + bugfix.md | ✅ |
+
+**真阳性率**：11/11 中，6 个显式命中（54.5%）；5 个漏报（45.5%）。
+
+**假阴性主要类型**：
+
+- **UI / 显示类 issue**（例 #27 FAQ 不持久化）：body 描述用户症状不提文件路径
+- **跨角色 bug**（例 #20 subagent cold-start）：body 谈"现象级"不指代码位置
+- **决策流本身 bug**（例 #28 串行→并行）：body 谈"模式"不指 DEC 编号
+- **reviewer bug**（例 #23）：body 列 Resource Access 冲突但不加文件名
+
+**假阳性主要类型**：
+
+- **issue body 引用 DEC 但不改 DEC-log**（例 #43 引用 DEC-001~015 做"对齐"讨论不改内容）：batch 只改 decision-log 置顶 + architect skill 分支
+- **issue body 列文件路径但只修边缘**（例 #22 "runtime prompts" 广义指代但真实改动可能仅 1 文件）
+
+**兜底机制 worktree 隔离的代价**：
+
+假阴性场景下，两个 batch 子 agent 同时改 `commands/workflow.md`（预检未分组，并行跑）：
+- 两个 worktree 各有自己的 workflow.md 修改版本
+- 各自开 PR
+- 合并时第二个 PR rebase 会冲突 → **用户手动解决**
+
+结论：假阴性 = 合并期延迟痛（不是正确性问题）；假阳性 = 串行跑（性能损失）。两者权衡取决于用户"合并 rebase 容忍度"vs"总体完成时间"。
+
+**预检粒度扩展候选**：
+
+- 扩到 `docs/design-docs/*.md`：很多 issue 引用 design-doc slug（例 "参照 lightweight-review.md"），可能命中
+- 扩到 `docs/decision-log.md`：与 DEC token 冗余
+- 扩到源码（若 target 非 roundtable）：需按语言扩展正则
+
+### 3.6 并发模型对比深挖
+
+**方案 A：主会话 single message 多 Agent 调用并行**（issue 作者推荐）
+
+- 一次 assistant message 发 N 个 Agent 调用（`run_in_background: true`）
+- 每个 Agent 独立 worktree + DISPATCH_ID + Monitor
+- 主会话可在其他消息里 pending，bg 子 agent 自己跑
+- Claude Code 官方支持"spawn multiple subagents to work simultaneously"[^1]
+
+**方案 B：主会话串行 Agent 调用，每个 Agent 内部 auto 模式**
+
+- 主会话逐条 await 每个 Agent 返回
+- 总耗时 = Σ 单 issue 耗时，**无并行收益**
+- 仅节省"用户人工 gate"一项（已由 DEC-015 在单 issue 层覆盖）
+
+**方案 B 为什么是 issue 作者提了但不推荐的**：它等价于 shell 脚本 `for issue in #A #B #C; claude "/roundtable:workflow $issue --auto"`，完全失去本 issue 的"并行"价值。
+
+**并发数量的 API / 本地实际约束**：
+
+- Anthropic API rate limit：**待验证**（官方文档未给具体并发数；估算 tier 3/4 可 ≥5）
+- Claude Code 本地 Agent 实例数上限：**待验证**（官方未明文上限；实测同步 3 个并发 background subagent 稳定 —— 来源：社区 / 本项目历史）
+- Monitor 交织可读性：3 个 dispatch_id 交织尚清晰；5 个开始需要 grep / filter
+- Disk：每个 worktree 复制 repo，5 个 = 5× repo size
+
+**错误传播延迟**：
+
+- bg subagent 失败 → 主会话收到 completion notification（Claude Code 原生）
+- 主会话当前在其他响应里 → notification 收到时机延后到下一轮
+- **最坏场景**：主会话长时间空闲，用户被迫 refresh / 主动查状态
+
+### 3.7 Worktree 生命周期隐性成本
+
+**生命周期官方语义**（引用文档）：
+
+> "The worktree is automatically cleaned up if the subagent makes no changes"
+
+**有变更时**：worktree 保留；路径与 branch 由 Claude Code 维护（未明说是否立即告知父 agent）
+
+**本地调研**：
+
+```bash
+$ git --version
+git version 2.34.1
+$ git worktree list
+/data/rsw/roundtable  a3b79c5 [feat/batch-orchestrator]
+```
+
+- `git worktree list` 显示所有 worktree 路径与 branch
+- `git worktree prune` 清理 已删除物理路径的记录（不删 branch）
+- `git worktree remove <path>` 显式删除
+
+**堆积估算**：
+
+- roundtable repo 当前 ~20MB（docs + skills + agents + commands 主）
+- 5 issue × 并行 × 保留 = 100MB
+- 50 次 dogfood 无清理 = 1GB
+- 用户磁盘受影响但非阻塞
+
+**长期堆积对 git 性能**：
+
+- `git status` / `git fetch` 性能与 worktree 数量 **弱相关**（fast-path 已优化）
+- 长期 50+ worktree 会使 `git gc` 变慢
+- 预估阈值：≥100 worktree 或 >5GB 是考虑强制 prune 的时点
+
+**人工 inspect worktree UX**：
+
+- 用户需知道 worktree path（主会话报告里）
+- `cd <path> && git log --oneline -5` 看 branch 状态
+- 接续：可在该路径内跑 `/roundtable:workflow <N>`（若 plugin 激活）
+- 或 `git worktree move` / `git worktree remove`
+
+### 3.8 失败终态穷举
+
+issue body 列了 3 类；实际至少 8 类：
+
+| # | 终态 | 触发条件 | worktree 状态 | 检测方式 |
+|---|------|---------|--------------|---------|
+| 1 | ✅ Success | 子 agent final message 含 PR URL | 有变更保留（已 push） | 正则匹配 PR URL |
+| 2 | 🟡 Decision pending | 子 agent final 含 `<decision-needed>` 未决（auto mode fallback） | 有变更保留 | 正则匹配 `<decision-needed` |
+| 3 | 🟡 Design confirmation needed | architect 完成但未 approve（若 auto 不全豁免 Stage 4） | 有变更保留 | 正则匹配 phase summary |
+| 4 | 🔴 Tester hard regression | tester `<escalation>` 报业务 bug | 有变更保留 | 正则匹配 escalation JSON |
+| 5 | 🔴 Lint failure | developer 后跑 lint 失败 | 有变更保留 | final message 含 lint fail 标记 |
+| 6 | 🔴 Test failure | developer 后跑 test 失败 | 有变更保留 | 同上 |
+| 7 | 🔴 Subagent crash / maxTurns 超限 | Claude Code 运行时错 / turn 超限 | 可能无变更→自动回收；可能部分变更→保留 | Agent tool 报错 |
+| 8 | 🔴 Main session 中断（Ctrl-C） | 用户主动中断主会话 | bg subagent 继续跑到自然结束后 result 失联 | 无自动检测 |
+
+**额外边界**：
+
+- `AskUserQuestion` 被 skill 误触发（非 text mode fallback）→ Claude Code 记录 tool failure 但 subagent 继续跑 → **未明确状态**；DEC-015 决定 11 已知常量
+- MCP server（TG reply）在 subagent 中调用 → 是否真调到主会话关联的 MCP client？**待验证**（`mcpServers` 继承问题）
+- 子 agent 内嵌套 Agent 调用（二级 fan-out）失败 → 传播到 batch 主会话的路径：`inner escalation → workflow` bubble → `batch subagent` final message → batch 主会话 parse
+
+### 3.9 邻近 issue 正交性核验
+
+| Issue | 主题 | 与 #43 交互 | 真正交？ |
+|-------|------|------------|---------|
+| **#28** | orchestrator 串行决策并行化（单 issue 内独立决策并发） | #28 单层并发；#43 多 issue 层并发 | ✅ 正交（不同层次）；**但**：若 #28 实现要求 orchestrator 内部 tracking 并发 state，而 batch 子 agent 内部也跑 workflow → 二级并发叠加时 state tracking 要跨层传递。低风险但潜在耦合 |
+| **#30** | phase gate 缺失 bug（analyst/architect silent skip） | #43 若 auto mode 生效，本 bug 在 batch 子 agent 内部被 auto "绕过"（不是修复） | ⚠️ **暗耦合**：batch + auto 会掩盖 #30 bug（用户看不到 silent skip）；#30 应先修再做 batch，否则 batch 会 mask 此 bug |
+| **#40** | DEC-014 minor follow-up | 独立 | ✅ 正交 |
+| **#48** | phase summary / producer-pause 扩展 TG 转发 | batch 主会话的 Stage 4 / Stage 7 / fan-out / fan-in 事件 = 都是 phase summary 类 | ⚠️ **强耦合**：#48 不修 = batch 在 TG 下用户看不到 fan-in 报告；**#48 应与 #43 协同**；或 #43 在 MVP 阶段手工转发 |
+| **#20** | subagent cold-start 开销 | batch 是多 subagent 场景，cold-start 叠加；并发 3 = 3 倍冷启 | ⚠️ **性能耦合**：batch 加剧 cold-start 感知；#20 若优化会让 batch 更香 |
+| **#26** | Stage 9 Closeout commit/push/PR flow | #43 子 agent 内的 Stage 9 + batch 主会话的 fan-in 都涉及 | ⚠️ **语义耦合**：batch 层自己的"commit/push/PR flow"（fan-in 后一次性 push 多 PR）与 #26 讨论的单 issue flow 形式不同；需定义 |
+
+**结论**：issue 作者假设"#43 与 #28 正交"正确，但**漏列 #30 / #48 / #20 / #26 的耦合**。
+
+### 3.10 Dogfood 可行性评估
+
+**当前 open issue**（11 条，截至 2026-04-20）：
+
+| # | P | 类型 | 预估改动面 |
+|---|---|------|-----------|
+| #48 | P1 | enhancement | workflow.md / bugfix.md / architect skill / analyst skill |
+| #43 | P2 | enhancement | commands/batch.md（新） / architect skill |
+| #40 | P3 | follow-up | design-docs/bugfix-rootcause-layered.md |
+| #30 | P1 | bug | workflow.md |
+| #29 | P2 | bug | skills/architect.md |
+| #28 | P2 | enhancement | workflow.md |
+| #27 | P2 | bug | skills/*.md FAQ |
+| #26 | P2 | design | workflow.md Stage 9 |
+| #23 | P2 | bug | agents/reviewer.md |
+| #22 | P3 | docs | workflow.md + agents/* (token audit) |
+| #20 | P3 | enhancement | skills/_detect-project-context.md / agents/* |
+
+**冲突预检结果**（用 §3.5 启发式）：
+
+- **DEC token 共享**：#43 + #48 + #30 + #26 共享 DEC-006/013；潜在冲突
+- **路径 token 共享**：`commands/workflow.md` 出现在 #48/#30/#28/#26/#22 共 5 条 → 全冲突组
+- **skills/architect.md**：#43/#29/#48 共享
+
+**预检分组**（连通分量）：
+
+- **Group 1**：{#48, #30, #28, #26, #22} 全共享 workflow.md
+- **Group 2**：{#43, #29, #48}（与 Group 1 部分重叠，因 #48 在两组 → 合并为超大组）
+- **Group 3**：{#23}（独）
+- **Group 4**：{#20}（独）
+- **Group 5**：{#27, #40}（独）
+
+**合并后**：Group 1+2 = {#22, #26, #28, #29, #30, #43, #48} 共 7 条（全部串行）；Group 3-5 = 3 个独立并发组。
+
+**结论**：当前 open issue 大多数相互冲突（都改 workflow.md 或 architect.md）。**batch 首次 dogfood 的有效并行度很低**：理论 concurrency=3，实际 ≈ 3（一个超大 group 内串行 + 2-3 个独立）。预期**首跑无法证实 batch 并行价值**。
+
+**建议的可行首跑候选**：{#23, #20, #27}（三独立 issue，全冲突预检 0 命中）—— 可作为 P4 dogfood smoke。
+
+## 4. 对比分析（技术路径的客观代价）
+
+### 4.1 命令形态
+
+**A. 新独立 `commands/batch.md`**：
+- 单文件 ~250 行
+- 新维护面：+1 command prompt（critical_modules 命中面 +1）
+- workflow.md 本体不变（未扩行数）
+- 用户心智：多一个命令，但语义清晰
+
+**B. 扩展 `commands/workflow.md` 加 `--batch` 模式**：
+- workflow.md 357 → ~500 行
+- critical_modules 命中面不变（同一文件仍 1 处）
+- 单 issue 用户每次调用都消费 ~140 额外 token（workflow.md 被加载但未使用 batch 段）
+- 用户心智：一个命令但两种模式
+
+### 4.2 DEC 编号竞争方案
+
+参见 §3.4 三方案对比表。
+
+### 4.3 冲突预检
+
+- **正则预检**：O(N²) 分组图；简单易实现；假阳/假阴率见 §3.5
+- **无预检**：worktree 隔离兜底；合并时 rebase 冲突转嫁给用户
+- **AST 级分析**：需集成解析器（markdown / Rust / TS 等），工程量 >>正则
+
+### 4.4 Worktree 生命周期
+
+- **沿用原生（有变更保留 / 无变更回收）**：零代码
+- **强制保留**：需 plugin 层 override Claude Code 默认
+- **强制回收**：同上 + 失败后无法 inspect
+
+## 5. 开放问题清单（事实层，留给 architect）
+
+以下 7 项是**事实层未决**或**需 architect 做权衡**的开放点。analyst 不给推荐。
+
+1. **命令形态事实成本**：新 `commands/batch.md` 独立命令 vs 扩展 `workflow.md` 的 per-invocation 额外 token 消费比？事实未量化（§4.1 估算但未实测）。
+   - 支撑数据：`wc -l commands/workflow.md = 357`；新文件预估 ~250 行；扩展方案预估 +140 行
+2. **DEC 编号竞争三方案的失败模式权重**：方案 A 空洞 vs 方案 B 假阳性替换 vs 方案 C 违反 DEC-001 D8 的成本如何量化？
+   - 支撑数据：§3.4 表；DEC-001 D8 原文见 `docs/decision-log.md` DEC-001
+3. **冲突预检粒度与 scope**：只扫 `skills|agents|commands/*.md` vs 扩 `docs/design-docs/` vs 扫目标项目源码 —— 各自假阴性率？
+   - 支撑数据：§3.5 表（54.5% 真阳性率）
+4. **子 agent `subagent_type` 选择**：`general-purpose` vs 新注册一个 `roundtable:batch-worker` subagent 专跑 workflow vs CLI-defined ephemeral subagent vs 其他
+   - 支撑数据：Claude Code docs[^1]`general-purpose` "when the task requires both exploration and modification"
+   - 事实未解：`general-purpose` 能否承载任意 slash command + worktree 同时 OK（需验证）
+5. **并发默认值与上限**：issue 作者提 3，无数据支撑；Anthropic API 实际并发上限未知
+   - 事实未解：待验证 rate limit 具体数值 + 本地 Claude Code Agent 实例上限
+6. **#43 与 #48 / #30 的实施顺序**：§3.9 指出 #30 / #48 与 #43 暗耦合；若 #48 先修，batch 在 TG 下 UX 完整；若 #30 先修，batch + auto 不会 mask silent skip bug
+   - 事实支撑：§3.9 耦合表
+7. **Stage 4 Design confirmation 在 batch 子 agent 内的处理**：
+   - 事实点 1：DEC-015 auto mode 在 Stage 4 要求 recommended 自动 accept
+   - 事实点 2：batch 子 agent 是 bg mode，AskUserQuestion 会失败
+   - 事实点 3：DEC-013 text mode `<decision-needed>` 可 bubble 到 final message
+   - 事实未解：三点组合下，batch 子 agent 的 Stage 4 行为具体是哪条路径？(全 auto-accept / 部分 bubble / 其他)
+   - architect 需决策：子 agent 内 Stage 4 是否强制 auto（即使该子 agent recommended 缺失也不 halt？还是 halt bubble 到 batch 层？）
+
+## 6. FAQ
+
+（待用户追问后追加）
+
+## 7. 变更记录
+
+| 日期 | 版本 | 变更 | 作者 |
+|------|------|------|------|
+| 2026-04-20 | v1 | 初版深度分析（9 维度 + 7 开放问题）| analyst |
+
+---
+
+[^1]: Claude Code Subagents 官方文档 https://code.claude.com/docs/en/sub-agents （2026-04-20 WebFetch）

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -35,6 +35,42 @@
 
 ---
 
+### DEC-016 batch orchestrator 设计阶段 only MVP（`/roundtable:batch` 新 command，general-purpose subagent + isolation:worktree + inline-only workflow + post-hoc DEC 重编号 + 扩 design-doc slug 冲突预检）
+- **日期**: 2026-04-20
+- **状态**: Accepted
+- **上下文**: [issue #43 P2](https://github.com/duktig666/roundtable/issues/43) —— `/roundtable:workflow` 单 issue/单会话绑定；积压多个 P2/P3 dogfood issue 时交互成本线性放大。前置 #33 (DEC-015 auto mode) + #38 (DEC-013 §3.1a 转发) 已合入；新开 #48 (P1 phase summary TG 转发) 强耦合但独立实施。 **Analyst 深度分析 (525 行 9 维度 + 7 开放问题)** + **DEC-003 3 路并行 research (Q4 subagent_type / Q5 API rate limit / Q7 Stage 4 bg 行为)** 发现 Claude Code 官方硬约束 "**Subagents cannot spawn other subagents**"，使 issue #43 原始架构（子 agent 跑完整 /roundtable:workflow --auto）**不可行**。架构必须基于该约束重塑。
+- **决定**:
+  1. **D2 Scope = 设计阶段 only MVP (v1)**（量化 36 vs 17/25/29）：`/roundtable:batch` v1 **只跑 analyst + architect 两 skill（inline 形态）+ commit + draft PR**；developer/tester/reviewer/dba 均 subagent-only（违反 DEC-001 4 agent 边界 + Claude Code 硬约束），v1 不覆盖。实施阶段由用户在主会话 review PR 批准后跑 `/roundtable:workflow`。v2 议题：扩 tester/reviewer/dba 到 inline 形态 (DEC-005 follow-up) 或等 Claude Code 放宽嵌套 / agent teams 稳定
+  2. **D1 命令形态 = 新 `commands/batch.md` 独立命令**（量化 48 vs 35）：不扩展 workflow.md（避免双心智重载 + 单 issue 用户额外 token 负担）；新增 ~300 行
+  3. **D3 DEC 编号竞争 = post-hoc renumber with `DEC-NEW-<uuid8>` 占位**（量化 41 vs 37/23）：子 agent 写占位 `DEC-NEW-$(openssl rand -hex 4)`；主会话 fan-in 按完成时序 sed 替换为 `DEC-(MAX+k)`；sanity `grep -r "DEC-NEW-" docs/` 必须 0 命中；替换 scope = docs/ 全部类别；单 issue workflow 路径沿用 MAX+1 递增
+  4. **D4 冲突预检 = 启发式扫 DEC + prompt path + 扩 docs/design-docs/slug**（量化 27 vs 20/22/18）：3 粒度正则；Union-Find 分组；真阳率从 54.5% 提升到估算 65-70%；worktree 隔离作为合并期兜底
+  5. **D5 Worktree 生命周期 = Claude Code 原生**：有变更保留 / 无变更回收；不覆盖；用户负责 `git worktree prune`
+  6. **D6 并发默认 = model-aware**（量化 18 vs 14/10）：Opus 4.7 → 3（GitHub #44481 实测 5 agent 即 429）；Sonnet 4.6 → 5（Tier 3 ITPM 充足）；`--concurrency N` 覆盖
+  7. **D7 Subagent type = `general-purpose`**（量化 51 vs 32/38）：Candidate B (CLI-defined ephemeral) 根本不可用（plugin command runtime 无法动态 `--agents` 注册）；Candidate C (新增 plugin batch-worker) 的 skills 预加载优势不抵 permissionMode 受限 + 新 agent 触达 DEC-001 D1-D9 边界；A 的 skills 不继承劣势由 prompt inline 注入内容解决
+  8. **D8 Stage 4 approval-gate 在 bg subagent = text + auto + recommended → auto-accept；否则 emit `<decision-needed>` bubble to final message → batch 主会话 relay TG**：复用 DEC-013/015 组合；不发明新行为；v1 不自动 SendMessage relay 回子 agent（需 EXPERIMENTAL_AGENT_TEAMS=1，v2 议题）；用户手动 `cd <worktree>` 续跑
+  9. **D9 MCP TG forwarding = 主会话一层转发**：子 agent session inbound 无 `<channel>` 标签，DEC-013 §3.1a sticky 语义不成立；主会话 fan-in 后统一汇总转发；子 agent 不负责转发
+  10. **D10 失败终态 = 8 类**（扩 issue body 3 类）：✅ Design-success / 🟡 Decision-pending / 🟡 Auto-halt no recommended / 🔴 Skill AskUserQuestion failure / 🔴 Crash-maxTurns / 🔴 Conflict grouping trap / 🔴 Main session 中断 / 🔴 API 429；每类检测方法 + worktree 状态 + 处理规则
+  11. **架构 skill 唯一改点**：`skills/architect.md` 加 2 条件分支（`inline_only: true` 禁 DEC-003 fan-out + `batch_mode: true` 用 DEC-NEW 占位），总 ~12 行；4 agent prompt + analyst skill + workflow.md / bugfix.md / lint.md 本体 / 4 helper 本体 **零改动**
+  12. **不启用 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`**：SendMessage resume 需要；v1 以稳定为先
+  13. **TG 转发依赖 #48**：#48 未实施时 batch 命令内嵌显式 reply 调用（手动转发）；#48 实施后可删除该逻辑
+  14. **不抬 target CLAUDE.md**：对齐 DEC-011/012/013/015 "批量调度是 orchestrator 内部策略"边界
+- **备选**:
+  - **D2-B 全阶段 batch**（含 developer/tester/...）：量化 17；违反 DEC-001 + 命中 Claude Code subagents-cannot-spawn 硬约束；需 tester/reviewer/dba 大规模 inline 改造；拒绝
+  - **D2-C 全阶段 + EXPERIMENTAL_AGENT_TEAMS=1**：量化 25；实验标志 + 已知 agent teams 限制（session resumption / shutdown 等）；v2 议题；拒绝
+  - **D2-D `--scope=design/impl` 双模式**：量化 29；增复杂度；design-only 足以覆盖用户 PR-first review 意图；拒绝
+  - **D1-B 扩展 workflow.md**：量化 35；双心智重载；拒绝
+  - **D3-A 中心锁预分配**：crash 空洞 + 跨 agent 锁复杂度；拒绝
+  - **D3-C 主会话统一写 DEC**：违反 DEC-001 D8 architect Resource Access；拒绝
+  - **D4-A 无预检**：合并期痛转嫁用户；拒绝
+  - **D4-D AST 级依赖分析**：工程量失衡；拒绝
+  - **D7-B CLI ephemeral subagent**：根本不可用（runtime 无法动态注册）；拒绝
+  - **D7-C 新 plugin subagent**：触达 DEC-001 边界 + permissionMode 不支持；拒绝
+- **理由**: (1) D2 MVP 阶段化承认 Claude Code 硬约束的不可绕过性，用户 "PR-first review" 意图与 design-only 天然对齐，快速落地后 v2 基于实战数据迭代；(2) D1 独立命令避免 workflow.md 臃肿传播到所有单 issue 调用，对齐 DEC-010 精简心智；(3) D3 post-hoc renumber 零协调 / 高容错 / 低复杂度；(4) D4 启发式 + 扩粒度真阳率 +10-15% 不显著增复杂度；(5) D6 model-aware 基于实测 issue #44481 数据；(6) D7 general-purpose 复用 Claude Code 原生能力零维护新增；(7) D8 复用 DEC-013/015 组合不发明新行为；(8) D9 主会话一层转发避免三层嵌套协议不明确的复杂度；(9) D10 终态穷举便于未来 v2 扩展；(10) architect skill 唯一改点 (12 行) + 4 agent 零改动 对齐 DEC-010 最小改动面
+- **相关文档**: [docs/design-docs/batch-orchestrator.md](design-docs/batch-orchestrator.md)（完整设计 700+ 行 / 10 决策量化评分 / 8 终态表 / 数据流图）、[docs/exec-plans/active/batch-orchestrator-plan.md](exec-plans/active/batch-orchestrator-plan.md)（P0-P5 实施）、[docs/analyze/batch-orchestrator.md](analyze/batch-orchestrator.md)（525 行 analyst 报告 + 9 维度 + 7 开放问题）、DEC-015 (auto mode 前置)、DEC-013 (text mode 前置 + §3.1a TG forwarding 复用)、DEC-011 (DEC 顺序约定沿用 + 置顶规则)、DEC-006 (phase gating 不新增类别)、DEC-005 (developer 双形态 v2 扩展议题)、DEC-003 (research fan-out 本次设计派发 Q4/Q5/Q7 三路)、DEC-001 (4 agent 边界 + critical_modules 语义守约)、[issue #43](https://github.com/duktig666/roundtable/issues/43)、[issue #48](https://github.com/duktig666/roundtable/issues/48) (强耦合 follow-up)、[issue #33](https://github.com/duktig666/roundtable/issues/33) (DEC-015 前置)、[issue #38](https://github.com/duktig666/roundtable/issues/38) (DEC-013 §3.1a 前置)
+- **影响范围**: 新建 `commands/batch.md`（~300 行）+ `docs/design-docs/batch-orchestrator.md` + `docs/exec-plans/active/batch-orchestrator-plan.md` + `docs/testing/batch-orchestrator.md`（P5 tester 补）；修改 `skills/architect.md` 加 2 条件分支（~12 行）；`docs/decision-log.md` 本条置顶；`docs/INDEX.md` + `docs/log.md` 追加。**不改** 4 agent prompt / `skills/analyst.md` / `skills/_detect-project-context.md` / `skills/_progress-content-policy.md` / `commands/workflow.md` / `commands/bugfix.md` / `commands/lint.md` 本体 / `commands/_progress-monitor-setup.md` / README / target CLAUDE.md。**不改** DEC-001 ~ DEC-015 任何 Accepted 条款 / Phase Matrix / Step 4 并行判定树 / critical_modules 机械触发。运行时：`/roundtable:batch` 新入口；子 agent 强制 `auto=true + decision_mode=text + inline_only=true + batch_mode=true`；DEC 重编号仅 batch 路径（单 issue 沿用递增）；v1 仅设计阶段，v2+ 扩展议题。**critical_modules 命中** `skills/architect.md` 修改触发 P1 末派 tester（P5）。
+
+---
+
 ### DEC-015 workflow auto-execute mode（orchestrator 读 `--auto` / `ROUNDTABLE_AUTO` 批量预授权 A/B 类 gate，自动采纳 recommended option）
 - **日期**: 2026-04-20
 - **状态**: Accepted

--- a/docs/design-docs/batch-orchestrator.md
+++ b/docs/design-docs/batch-orchestrator.md
@@ -1,0 +1,646 @@
+---
+slug: batch-orchestrator
+source: docs/analyze/batch-orchestrator.md + Claude Code 官方文档 + DEC-003 并行 research Q4/Q5/Q7
+created: 2026-04-20
+status: Draft
+decisions: [DEC-016]
+---
+
+# Batch Orchestrator 设计文档（`/roundtable:batch`）
+
+> issue #43 架构方案。基于 analyst 深度分析（9 维度 + 7 开放问题）+ 3 路并行 research 的事实层结果制定。**重大发现**：Claude Code 官方约束 "Subagents cannot spawn other subagents" 迫使本设计放弃"主会话派 batch subagent → 子 agent 跑完整 workflow"的初始架构，改为**设计阶段批量 + 实施阶段主会话**的分段模型。
+
+## 1. 背景与目标（含非目标）
+
+### 1.1 背景
+
+`/roundtable:workflow` 当前绑定单 issue / 单会话。积压多个 P2/P3 dogfood issue 的场景（roundtable 自身递归 dogfood）交互成本线性放大。
+
+**前置依赖**（已合入）：
+- #33 DEC-015 auto mode（单链路非交互）
+- #38 DEC-013 §3.1a `<decision-needed>` TG 转发
+- 新开 #48（P1 phase summary / producer-pause 扩展 TG 转发，与本 issue 强耦合但独立实施）
+
+**analyst 发现的核心约束**：
+
+| 约束 | 来源 | 对设计的影响 |
+|------|------|-------------|
+| Subagents cannot spawn other subagents | Claude Code 官方文档 | 🔴 **颠覆性**：batch 子 agent 无法在内部调 Agent tool 派 developer/tester/reviewer/dba subagent |
+| AskUserQuestion 在 bg subagent tool call fails but subagent continues | 官方文档 | 🟡 子 agent 强制 `decision_mode=text` |
+| SendMessage 仅 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 可用 | 官方文档 | 🔴 不能用 SendMessage relay 用户决策回子 agent（非 experimental） |
+| MCP tools 不自动继承 | 官方文档 | 🟡 子 agent 若需 TG reply 须显式 `mcpServers` 声明 |
+| Opus Tier 3 concurrency=5 实测触发 429 | GitHub issue #44481 | 🟡 默认并发 ≤3 合理 |
+| Subagents don't inherit skills | 官方文档 | 🟡 子 agent 若需 analyst/architect skill 须显式 `skills:` 字段列出 |
+
+**核心发现 "subagents cannot spawn"** 意味着：batch 子 agent 跑 `/roundtable:workflow` 时，workflow 内部派发 `developer` / `tester` / `reviewer` / `dba` subagent 的步骤会**失败**。这是对 issue #43 原始架构提议（"每个子 agent 跑 `/roundtable:workflow <N> --auto`"）的**否决证据**。
+
+### 1.2 目标（基于约束重新定义）
+
+**v1 MVP**：`/roundtable:batch` **只做设计阶段**（analyst + architect 两个 skill，均 inline 形态）+ commit + push + 开 PR。
+
+**v2 Future**：扩展到实施阶段（需先完成 tester/reviewer/dba 的 inline 形态 —— DEC-005 follow-up）或等 Claude Code 放宽嵌套约束 / agent teams 稳定。
+
+**UX 流**：
+
+```
+用户在 TG 触发:
+  /roundtable:batch #A #B #C
+
+→ 主会话 fan-out 3 个 batch subagent (isolation:worktree, run_in_background:true)
+  每个 subagent 跑 inline-only 设计 workflow:
+    Step 0: context detection
+    Step 2: analyst (skill inline)
+    Step 3: architect (skill inline, 无 DEC-003 research fan-out — 约束兼容)
+    Step 4: commit + push + open draft PR
+    Step 5: final message 返回 PR URL
+
+→ 主会话 fan-in:
+  汇总 3 个 PR URL
+  用户 TG 收到 3 条 PR 链接
+  用户在 GitHub 按 PR 逐个 review 设计
+  批准后用户在主会话跑 `/roundtable:workflow #A` 继续实施（developer/tester/reviewer）
+  或 reject 后 TG 反馈，batch 子 agent 根据 feedback 重新设计（需第二轮 batch）
+```
+
+**为什么不是全阶段 batch**：参见 §4.2 D2 决策。
+
+### 1.3 非目标
+
+- **v1 不覆盖实施阶段**（developer/tester/reviewer/dba），见 D2
+- **不做 issue 依赖图自动推导**（issue #43 原文非目标，沿用）
+- **不做跨 issue context 共享**（每子 agent 独立冷启动）
+- **不改 4 agent prompt**（developer/tester/reviewer/dba 本体零改动）
+- **不抬 target CLAUDE.md**（对齐 DEC-011/012/013/015 "批量调度是 orchestrator 内部策略"边界）
+- **不启用 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`**（用 SendMessage relay 决策是 v2 议题）
+- **不豁免 critical_modules**（设计阶段不会命中 tester 触发，实施阶段由主会话 workflow 处理）
+- **不做 PR 依赖图自动合并**（所有 PR 以 main 为 base，merge order 由用户决定）
+
+## 2. 业务逻辑
+
+### 2.1 命令签名
+
+```
+/roundtable:batch <issue-refs> [--concurrency N] [--dry-run]
+
+issue-refs:   一或多个 issue 编号，如 #27 #29 #40（可省略 #）
+--concurrency N: 并发上限，默认 3（Opus）/ 5（Sonnet）
+--dry-run:    只做 prefetch + 冲突预检 + 调度计划输出，不 fan-out
+```
+
+**注**：v1 不支持 `--scope=impl`（实施阶段批量，v2 议题）。
+
+### 2.2 执行流程（6 阶段）
+
+| 阶段 | 主会话动作 | 关键产出 |
+|-----|----------|---------|
+| 1. Parse | 解析 argv（issue-refs / flags） | 参数校验 |
+| 2. Prefetch | `gh issue view <N> --json body,number,title` 对每个 issue | issue metadata 表 |
+| 3. Conflict pre-check | 正则扫 `DEC-\d+` / `(?:skills\|agents\|commands)/[\w-]+\.md` + 扩 `docs/design-docs/[\w-]+\.md` | 分组计划（连通分量 → 同组串行） |
+| 4. Plan confirm | producer-pause：emit 调度计划 summary；用户 `go` / `调` 后进 Step 5；`--dry-run` 在此终止 | 用户确认 |
+| 5. Fan-out + Monitor | 按并发上限批次派发 `Agent(subagent_type="general-purpose", isolation:"worktree", run_in_background:true, prompt:<batch-worker-prompt>)`；每 subagent 独立 DISPATCH_ID + Monitor | 每 issue 一个 worktree + branch + WIP |
+| 6. Fan-in + Report | 等全部 Agent 返回；扫 final message：分类 ✅/🟡/🔴；DEC 占位符重编号（见 §2.5）；push + 开 draft PR；TG emit 汇总报告 | 终点 producer-pause |
+
+### 2.3 冲突预检启发式（扩展 analyst §3.5 基础上）
+
+**抽取 token**：
+
+| Token 类别 | 正则 | 来源 |
+|-----------|------|------|
+| DEC 引用 | `\bDEC-\d+\b` | issue body / comments |
+| Prompt 文件路径 | `(?:skills\|agents\|commands)/[\w-]+\.md` | 同上 |
+| Design-doc slug | `docs/design-docs/([\w-]+)\.md` 或 ``[slug]`` 引用 | 同上（扩粒度，提升真阳率） |
+
+**分组算法**：
+
+1. 节点 = issue；边 = 至少共享 1 个 token
+2. Union-Find → 连通分量 = 冲突组
+3. 同组内 issue **串行**（按 issue 编号升序）；组间**并行**（受并发上限约束）
+
+**真阳率改善**（相对 analyst §3.5 抽样）：
+
+| 粒度 | 真阳率（11 issue 抽样） | 假阴性残余 |
+|-----|----------------------|-----------|
+| 仅 DEC + skills/agents/commands 路径 | 54.5% | UI/FAQ/跨角色 bug 类仍漏 |
+| + docs/design-docs slug 扩展 | 估算 65-70% | 症状级描述仍漏 |
+
+**诚实面**：即使扩粒度，启发式仍有 30%+ 假阴性。worktree 隔离作为**合并期代价**的兜底（PR rebase 冲突用户手动解）。
+
+### 2.4 失败终态模型（8 类）
+
+| # | 终态 | 触发 | worktree 状态 | 检测 | 处理 |
+|---|------|------|--------------|------|------|
+| 1 | ✅ Design-success | Final message 含 PR URL + 无 `<decision-needed>` 残留 | 保留（push 完成） | 正则 PR URL | 加入 ✅ 清单 |
+| 2 | 🟡 Decision-pending | Final message 含 `<decision-needed id="...">` 未决 | 保留 | 正则 `<decision-needed` | 主会话 TG emit decision block，等用户回复；回复后**启动 v2 relay**（未实现）或用户 `cd <worktree>` 手动续跑 |
+| 3 | 🟡 Auto-halt no recommended | Final message 含 `🔴 auto-halt` 标记 | 保留 | 正则审计行 | 同 #2 |
+| 4 | 🔴 Skill AskUserQuestion failure | Final message 含 tool failure 迹象 + `<decision-needed>` 缺失 | 可能部分 | 无 tool call 但有 half-done output | 报告用户 + `cd <path>` 重跑 |
+| 5 | 🔴 Subagent crash / maxTurns | Agent tool 报错或 final message 被截断 | 可能无变更→自动回收；可能部分变更→保留 | Agent 返回错 | 报告 + 可选重派 |
+| 6 | 🔴 Conflict pre-check grouping trap | 用户 `--no-preheck` 强制并行但实际冲突 | 保留（两 worktree 各有变更） | PR push 时冲突 | 报告 + 手动 rebase |
+| 7 | 🔴 Main session 中断 | 用户 Ctrl-C 或退出 | bg subagent 继续跑完但 result 失联 | 无自动检测 | 用户手动 `git worktree list` 查状态 |
+| 8 | 🔴 API rate limit 429 | 并发超 Tier 上限 | 可能半成 | Anthropic error response | 主会话收集并报告；可选 降 concurrency 重派 |
+
+**报告顺序**：✅ → 🟡（可恢复）→ 🔴（需人工处理），人工注意力从高价值到最需处理排列。
+
+### 2.5 DEC 编号竞争处理（方案 B：post-hoc renumber）
+
+**占位符协议**：
+
+- 子 agent 写 DEC 时使用 `DEC-NEW-<uuid8>` 作为 ID
+- uuid8 = `openssl rand -hex 4`（8 hex 字符；碰撞概率 ≤ 1/4B）
+- 占位符出现在：`decision-log.md` 新条目标题 / `design-docs/*.md` frontmatter `decisions:` / `exec-plans/**/*.md` 引用 / `log_entries:` YAML `note`
+
+**重编号算法**（主会话 fan-in 阶段）：
+
+```python
+# pseudocode
+current_max = max(parse_dec_id(line) for line in decision_log if line.startswith('### DEC-'))
+completed_subagents = sort_by_completion_time(successful_subagents)
+for i, subagent in enumerate(completed_subagents):
+    new_id = current_max + 1 + i
+    placeholder_uuid = extract_placeholder_from_worktree(subagent.worktree)
+    sed_replace(
+        files=scan_worktree(subagent.worktree, patterns=['docs/**/*.md']),
+        from_pattern=f'DEC-NEW-{placeholder_uuid}',
+        to=f'DEC-{new_id:03d}'
+    )
+# sanity
+for wt in worktrees:
+    assert `grep -r "DEC-NEW-" {wt}/docs/` returns 0 matches
+```
+
+**replace scope**：`docs/decision-log.md` / `docs/design-docs/` / `docs/exec-plans/` / `docs/testing/` / `docs/reviews/` / `docs/bugfixes/` / `docs/INDEX.md` / `docs/log.md`。**不扫** prompt 本体（skills/agents/commands）—— DEC 占位符不会出现那里（architect 只改 docs）。
+
+**sanity fail 处理**：若残留 `DEC-NEW-` 命中，abort renumber，该 subagent 终态转 🔴 #5，worktree 保留供人工处理。
+
+**为什么不是方案 A 中心锁**：
+
+- 子 agent crash 后号段空洞（审计不好看）
+- 需跨子 agent 锁保护并发 workflow 调用
+- 子 agent 超限写（意外多 DEC）号段不够
+
+**为什么不是方案 C 主会话统一写**：
+
+- 违反 DEC-001 D8 Resource Access（architect 是 decision-log 权威作者）
+- 语义断裂：DEC 是 architect 决策载体，剥夺核心职责
+
+### 2.6 Worktree 生命周期
+
+**沿用 Claude Code 原生**：
+- 有变更 → worktree 保留，路径 + branch 由 Claude Code 维护并在 subagent final message 报告
+- 无变更 → 自动清理
+
+**不做**：强制保留 / 强制回收 / plugin 层追踪清理。
+
+**人工 inspect 路径**：主会话汇总报告里每个 🟡/🔴 终态都带 worktree path；用户 `cd <path>` 直接查看。
+
+**诚实面磁盘成本**（analyst §3.7）：
+- roundtable repo ~20MB，3 并发保留 = ~60MB
+- 50 次 dogfood 无清理 = ~1GB
+- 阈值：≥100 worktree 或 >5GB 是 `git worktree prune` 的时点
+- plugin 不自动 prune，用户负责
+
+### 2.7 并发控制
+
+**默认值**：
+- Opus 4.7 → **3**（GitHub #44481 实测 5 agent 在 Max plan 即 429）
+- Sonnet 4.6 → **5**（Tier 3 ITPM/OTPM 安全带较足）
+- 不自动探测 tier，按主会话当前 model 默认
+
+**`--concurrency N` 覆盖**：实际上限 = min(N, issue 数)。
+
+**调度策略**：FIFO + 冲突组约束；同组最多 1 running，其他排队；组间按并发上限 fan-out。不做优先级重排（v1 简单）。
+
+**rate limit 处理**：
+- 检测 429 → 当前批次标 🔴 #8
+- 不自动重试（避免雪崩）
+- 主会话报告 + 建议用户降 concurrency 重跑
+
+### 2.8 子 agent prompt 模板
+
+```
+# Batch worker for issue #<N>
+
+上下文：
+- 你是 /roundtable:batch 主会话 fan-out 的 batch-worker
+- 运行在 isolation=worktree 的独立 git worktree 中
+- 运行在 run_in_background=true 的 bg 模式
+- 单 session 内禁止派发其他 subagent（Claude Code 官方约束）
+- 因此本 workflow 是 inline-only 设计阶段版
+
+任务：为 issue #<N> 产出完整设计并开 draft PR
+
+强制配置：
+- auto_mode: true（architect recommended 自动采纳）
+- decision_mode: text（AskUserQuestion 在 bg 会 fail，必须走 <decision-needed>）
+- 跳过 Stage 5 developer（subagent 无法嵌套派发）
+- 跳过 Stage 6/7/8 tester/reviewer/dba（同上）
+- Stage 3 architect 内的 DEC-003 parallel research fan-out 禁用（subagent 约束）—— 改为串行 WebFetch/WebSearch
+
+执行步骤（inline only）:
+1. Context detection（inline Read _detect-project-context.md）
+2. gh issue view <N> 读取需求
+3. Analyst skill inline：产出 docs/analyze/<slug>.md
+4. Architect skill inline：产出 docs/design-docs/<slug>.md + DEC-NEW-<uuid> + exec-plan/<slug>-plan.md
+   - DEC 用占位符 `DEC-NEW-$(openssl rand -hex 4)`
+   - 遇决策点：有 recommended → auto-accept；无 → emit <decision-needed> 到 final message（自然 turn 结束）
+5. Git:
+   - 已在 worktree 的独立 branch（Claude Code 创建）
+   - git add docs/ && git commit -m "..."
+   - git push -u origin <branch>
+   - gh pr create --draft --title "feat(<slug>): design for #<N>" --body "..."
+6. Final message 必含：
+   - PR URL
+   - DEC 占位符 uuid 列表（供主会话重编号定位）
+   - <decision-needed> 块（若 auto-halt）
+   - 如 lint 失败：详情
+```
+
+**关键 prompt 注入**：
+
+| 变量 | 来源 |
+|------|------|
+| `target_project` | 固定 `/data/rsw/roundtable`（或 target detection） |
+| `docs_root` | `docs/` |
+| `issue_number` | argv |
+| `auto_mode` | `true`（batch 硬编码） |
+| `decision_mode` | `text`（硬编码） |
+| `inline_only` | `true`（batch 专属标志；Architect skill 识别后禁 DEC-003 fan-out） |
+| `dispatch_id` | `$DISPATCH_ID` |
+| `progress_path` | `$PROGRESS_PATH`（可选，`run_in_background=true` 下 Monitor 走 tail） |
+
+## 3. 技术实现
+
+### 3.1 命令结构（新 `commands/batch.md` ~300 行）
+
+```markdown
+---
+description: Batch dispatcher — design-phase only. Fan-out /roundtable:workflow design-stage across multiple issues in parallel worktrees.
+argument-hint: <issue-refs> [--concurrency N] [--dry-run]
+---
+
+# Batch 设计工作流
+
+**任务**：$ARGUMENTS
+
+## Step 0: Parse
+解析 issue-refs / --concurrency / --dry-run / 其他 passthrough flag
+
+## Step 1: Context detection
+inline Read ${CLAUDE_PLUGIN_ROOT}/skills/_detect-project-context.md
+
+## Step 2: Prefetch issue bodies
+for each issue: gh issue view <N> --json body,number,title
+
+## Step 3: Conflict pre-check
+正则扫 DEC / path / design-doc slug token；Union-Find 分组
+
+## Step 4: Plan emit
+producer-pause：emit 调度计划（表格：组 / 并发 / 预估耗时）
+用户 `go` 后进 Step 5；`--dry-run` 在此终止
+
+## Step 5: Fan-out + Monitor
+按 batch 派发 Agent(subagent_type="general-purpose",
+                   isolation:"worktree",
+                   run_in_background:true,
+                   prompt: §2.8 模板)
+每 subagent 独立 DISPATCH_ID → 独立 Monitor
+
+## Step 6: Fan-in + DEC renumber
+等全部 Agent 返回（Claude Code notify）
+扫 final message：分类 8 终态
+对 ✅ 子 agent：读 worktree，执行 §2.5 重编号算法
+sanity grep 验证
+
+## Step 7: Report
+汇总 markdown（✅→🟡→🔴）
+TG 转发（若 inbound 含 channel tag；#48 实施后自动，否则主会话手动）
+```
+
+### 3.2 `skills/architect.md` 批改（**critical_modules 命中**）
+
+**新增 `inline_only` 条件分支**（~12 行）：
+
+在 §阶段 1 探索决策 §3.5 Research Fan-out 段加入：
+
+```
+**注**：orchestrator 注入 `inline_only: true` 时（batch 子 agent 场景），**禁用** DEC-003 parallel research fan-out —— batch 子 agent 无法嵌套派发 subagent（Claude Code 官方约束）。改走串行 WebFetch/WebSearch 自研或直接基于已有事实决策。
+```
+
+在 §decision-log 条目顺序约定段加入：
+
+```
+**注**：orchestrator 注入 `batch_mode: true` 时，DEC 编号用占位符 `DEC-NEW-$(openssl rand -hex 4)` 而非递增整数。主会话 fan-in 阶段按完成时序重编号。
+```
+
+**不改** architect skill 的其他规则 —— inline_only + batch_mode 两个条件分支是最小新增面。
+
+### 3.3 Monitor 交织（沿用 DEC-004）
+
+每子 agent 独立 `DISPATCH_ID` → 独立 `PROGRESS_PATH` → 独立 `Monitor` → 并行安全（workflow.md §3.5.4 已验证）。
+
+Progress event `summary` 加 issue-ref 前缀：`[architect@#27] reading analyst report` → 用户一眼认出来源。
+
+### 3.4 数据流图
+
+```
+TG 用户:
+  /roundtable:batch #27 #29 #40
+        │
+        ▼
+[主会话 /roundtable:batch]
+  ├ Step 1: context detection
+  ├ Step 2: prefetch × 3 (gh CLI)
+  ├ Step 3: conflict preheck
+  │    └── groups = [{#27}, {#29, #40}]  // #29/#40 假设共享 DEC token
+  ├ Step 4: producer-pause → user "go"
+  ├ Step 5: fan-out batch 1:
+  │   ├─ Agent(#27, bg, isolation:worktree) ──> worktree-A
+  │   └─ Agent(#29, bg, isolation:worktree) ──> worktree-B  [#40 queued]
+  │                                                    │
+  │       worktree-A:                         worktree-B:
+  │       ├ context                           ├ context
+  │       ├ analyst skill inline              ├ analyst skill inline
+  │       ├ architect skill inline            ├ architect skill inline
+  │       │  (DEC-NEW-aaa, inline_only)       │  (DEC-NEW-bbb, inline_only)
+  │       ├ commit+push+PR                    ├ commit+push+PR
+  │       └ final message (含 PR URL)         └ final message
+  │             │                                    │
+  │             ▼                                    ▼
+  │      notify 主会话                          notify 主会话
+  ├ fan-in 批次 1；派 #40
+  │   └─ Agent(#40, bg) ──> worktree-C (uses arch from #29 lessons? 否，独立)
+  │             │
+  │             ▼
+  │      notify 主会话
+  ├ Step 6: fan-in all → parse final messages
+  │   - DEC-NEW-aaa → DEC-017 (by completion time)
+  │   - DEC-NEW-bbb → DEC-018
+  │   - DEC-NEW-ccc → DEC-019
+  │   - sed 替换 3 个 worktree
+  │   - sanity grep 0 命中
+  └ Step 7: emit 汇总：
+        ✅ #27 → PR#101 (DEC-017)
+        ✅ #29 → PR#102 (DEC-018)
+        ✅ #40 → PR#103 (DEC-019)
+```
+
+### 3.5 与现有 DEC 对接
+
+| DEC | 对接 |
+|-----|------|
+| DEC-001 4 agent + D1-D9 | 不动；batch 不增加 agent，只改 command + architect skill |
+| DEC-001 D8 Resource Access | 沿用；architect 在 batch 子 agent 内仍写 decision-log（用占位符） |
+| DEC-002 Escalation JSON | 正交；v1 不涉实施阶段，tester/reviewer/dba 不触发 |
+| DEC-003 parallel research | **在 batch 子 agent 内禁用**（Claude Code 约束），主会话模式沿用 |
+| DEC-004 progress event schema | 独立 DISPATCH_ID 已符合 |
+| DEC-005 developer 双形态 | 不改；v1 不涉 developer |
+| DEC-006 phase gating | batch 层本身：Step 4 = A 类 producer-pause / Step 5 = C 类 verification-chain / Step 7 = A 类；**不新增类别** |
+| DEC-007 progress content policy | 不改 |
+| DEC-008 Step 3.5 bg/fg gate | 全部 batch 子 agent 走 bg（fan-out 天然≥2） |
+| DEC-009 轻量化 | 新增 `commands/batch.md` + architect 2 条件分支，总增 ~312 行；不抽新 helper（DEC-010 精简心智守约） |
+| DEC-011 DEC 顺序（最新在前） | 重编号后仍满足（按 fan-in 完成序分配在当前 MAX 之上置顶） |
+| DEC-013 decision_mode | 子 agent 硬编码 `--decision=text` |
+| DEC-015 auto_mode | 子 agent 硬编码 `--auto`；batch 本身 Step 4 是否支持 `--auto`？**v1 支持**（consistent with 单 issue） |
+
+**不 supersede 任何 Accepted DEC**。
+
+### 3.6 TG 转发链路（诚实面）
+
+依赖 #48 实施状态：
+
+| #48 状态 | batch 层 TG 体验 |
+|---------|-----------------|
+| 未实施 | 主会话 Step 4 plan confirm / Step 7 汇总 / 子 agent final message digest 都需 batch 命令**显式调 TG reply 工具**（手动转发，与现状 workflow 一致） |
+| 已实施 | 自动转发（DEC-013 §3.1a 扩展的事件类生效），batch 命令零改动 |
+
+batch v1 **不依赖** #48 —— 命令层内嵌手动转发逻辑。#48 实施后可删除该手动逻辑（未来重构）。
+
+**三层嵌套转发限制**（research Q7 发现）：
+- TG 用户 → 主会话（inbound 含 `<channel>`） → batch subagent（**inbound 是主会话构造的 prompt，不含 `<channel>` 标签**，sticky 语义不成立）
+- 子 agent 不知道如何 TG reply；即便主会话 prompt 注入 `chat_id`，DEC-013 §3.1a 的检测条件仍不命中
+- **设计决策**：子 agent **不负责** TG 转发；主会话 fan-in 后统一转发汇总到 TG。`<decision-needed>` bubble 到 final message 后由主会话 relay
+
+## 4. 关键决策与权衡
+
+### 4.1 D1 命令形态：新独立命令 vs 扩展 workflow.md
+
+| 维度 (0-10) | A. 新 `commands/batch.md` ★ | B. `workflow --batch` 扩展 |
+|-------------|---------------------------|--------------------------|
+| 架构一致性 | **9**（batch 有独立 Phase Matrix 与 workflow 单 issue 心智解耦） | 5（workflow 承担双心智） |
+| 可读性 | **9**（slash command 语义清晰） | 6 |
+| 实现复杂度 | **7**（新 ~300 行） | 5（workflow.md 357 → ~500 行） |
+| DEC-010 精简 | **8**（单 issue workflow 调用零 batch 负担） | 5（workflow.md 被迫加载 batch 段） |
+| critical_modules 命中面 | 7（新增 1 个 command 文件） | **8**（同一文件命中面不增） |
+| 用户心智 | **8**（独立 entry） | 6（命令一个但模式二） |
+| **合计** | **48** | 35 |
+
+**决定**：新 `commands/batch.md`（方案 A）。
+
+**失败模式**：
+- (1) workflow.md 演化 → batch 未跟进 → 语义漂移（analyst §2 必答 2 #1）；缓解：设计评审时明确"batch 是 workflow 设计阶段子集"，演化同步审计
+- (2) 用户混淆两命令 → 缓解：文档清晰+ README 对比表
+
+### 4.2 D2 Batch scope：设计阶段 only vs 全阶段 ⚠️ 重大决策
+
+| 选项 | 实现复杂度 | v1 可用 | UX 完整性 | DEC-001 兼容 | **合计 (40 满)** |
+|------|-----------|--------|----------|-------------|---------------|
+| A. 设计阶段 only（v1 MVP）★ | **9** | **10** | 7（无实施） | **10** | **36** |
+| B. 全阶段（含 developer/tester/...） | 2（需 tester/reviewer/dba inline 形态） | 2 | **10** | 3（违反 DEC-001 4 agent 边界） | 17 |
+| C. 全阶段 + EXPERIMENTAL_AGENT_TEAMS | 4（实验标志 + 未稳定） | 5 | 9 | 7 | 25 |
+| D. 分段 `--scope=design/impl` 双模式 | 6 | 7 | 8 | 8 | 29 |
+
+**决定**：A（设计阶段 only，v1 MVP）。
+
+**why_recommended**：
+- Claude Code 硬约束 "subagents cannot spawn" 使 B/C/D 都需要大规模改造
+- 用户已明确"设计先于实施，PR 先 review 再实施"的意图，A 完美对齐
+- A 可快速落地验证 batch 机制正确性，B/C/D 可作 v2+ 议题
+- DEC-001 D1-D9 4 agent 边界零触达 —— 不需要 Supersede 流程
+
+**v2 议题列表**：
+- 扩展 tester/reviewer/dba 到 inline 形态（DEC-005 follow-up）
+- 或 agent teams 稳定后评估 C
+- 或 `--scope=impl` 分段模式（实施阶段在主会话直接跑 workflow，batch 不涉及）
+
+**失败模式**：
+- (1) 用户期望 batch 产出完整 PR 含实现 → 缓解：命令 `description` + TG 报告明确声明"v1 设计阶段 only"
+- (2) 设计阶段产出质量不足 → 缓解：沿用 analyst + architect 深度调研流程（"加大力度"模式）
+
+### 4.3 D3 DEC 编号竞争：post-hoc renumber（方案 B）
+
+| 维度 (0-10) | A 中心锁 | B post-hoc ★ | C 主会话统一写 |
+|-------------|---------|-------------|---------------|
+| 实现复杂度 | 6 | **9** | 3 |
+| 容错（子 agent crash）| 5 | **9**（占位符自然丢弃） | 5 |
+| DEC-001 D8 兼容 | **10** | **10** | 3（违反）|
+| 号码预告性 | **9** | 5（fan-in 后才知） | 7 |
+| sanity 检查 | 7 | **8**（grep 验证） | 5 |
+| **合计** | 37 | **41** | 23 |
+
+**决定**：B。**why_recommended**：crash 容错 + DEC-001 兼容 + 实现简单 的综合最优。
+
+**失败模式**：
+- (1) sed 假阳性替换（UUID 巧合出现在代码示例）→ 缓解：碰撞概率 ≤1/4B，正则严格边界 `\bDEC-NEW-[a-f0-9]{8}\b`
+- (2) 重编号漏文件 → 缓解：sanity `grep -r "DEC-NEW-" docs/` 必须 0 命中
+
+### 4.4 D4 冲突预检：启发式 + 扩 design-doc slug
+
+| 选项 | 真阳率 | 实现 | 合计 (30 满) |
+|------|--------|------|-------------|
+| A. 无预检 | N/A | **10**（零代码） | 20 |
+| B. DEC + prompt 路径 | 54.5% | 9 | 22 |
+| C. B + design-doc slug 扩展 ★ | ~65-70%（估算） | 8 | **27** |
+| D. AST 级依赖分析 | ~90% | 2（工程量大）| 18 |
+
+**决定**：C。**why_recommended**：增加 `docs/design-docs/[slug].md` 粒度在不显著提升复杂度的前提下改善真阳率。
+
+**失败模式**：
+- (1) 启发式假阴性（症状级 issue）→ 缓解：worktree 隔离是合并期兜底；文档诚实标注
+- (2) 假阳性导致过度串行 → 缓解：未来可加 `--no-preheck` flag 强制并行
+
+### 4.5 D5 Worktree 生命周期：沿用原生 ★
+
+**决定**：不覆盖 Claude Code 默认（有变更保留 / 无变更回收）。
+
+**why_recommended**：原生已符合"失败保留供 inspect / 成功自动清理"心智；plugin 层追踪 worktree path + 清理策略复杂度不成比例。
+
+**失败模式**：
+- (1) 长期堆积磁盘 → 缓解：报告 + 文档引导用户 `git worktree prune`
+- (2) 用户不知道 worktree 在哪 → 缓解：汇总报告中每个 🟡/🔴 都附 worktree path
+
+### 4.6 D6 并发默认：model-aware ★
+
+| 选项 | 合计 (20 满) |
+|------|------------|
+| A. 固定 3 | 14 |
+| B. 固定 5 | 10（Opus 高风险） |
+| C. model-aware（Opus 3 / Sonnet 5）★ | **18** |
+
+**决定**：C。**why_recommended**：基于 research Q5 的 GitHub issue #44481 实测（Opus Max plan 5 agents 即 429）+ Tier 3 ITPM 估算。
+
+**失败模式**：
+- (1) model 探测失败 → 缓解：默认退化为 Opus 3（保守）
+- (2) tier 更高的用户被保守值限制 → 缓解：`--concurrency N` 显式覆盖
+
+### 4.7 D7 Subagent type：`general-purpose`（Candidate A）★
+
+| 维度 (0-10) | A. general-purpose ★ | B. CLI-defined ephemeral | C. plugin batch-worker |
+|-------------|---------------------|--------------------------|------------------------|
+| 可用性（能否在 plugin command 内派发）| **10** | 0（需 session 启动 --agents 参数） | **10** |
+| skills 继承 | 5（需 prompt 注入 skill 内容）| 5（同前） | **9**（skills: 字段显式预加载）|
+| permissionMode 支持 | **9**（继承主会话） | **9** | 3（plugin 不支持 permissionMode）|
+| DEC-001 D1-D9 边界 | **10**（不增 agent） | **10** | 5（新增 agent 触达 4 agent 边界）|
+| MCP 继承 | **8**（默认继承所有工具）| **8** | 5（plugin 不支持 mcpServers 覆盖）|
+| 维护成本 | **9**（零新文件）| 不可用 | 6（新 batch-worker.md） |
+| **合计** | **51** | 32 | 38 |
+
+**决定**：A。**why_recommended**：Candidate B 根本不可用（plugin command runtime 无法动态注册）；Candidate C 的 skills 预加载优势不抵 permissionMode 受限 + 新增 agent 触达 DEC-001 边界。
+
+**失败模式**：
+- (1) general-purpose 不继承 skills → 缓解：子 agent prompt **内嵌 inline 完整 workflow 步骤**（不依赖激活 skills）；或 batch-worker prompt 模板中 Read skill 文件 inline
+- (2) CLAUDE.md / plugin commands 是否在 worktree subagent 内可用未明 → 缓解：prompt 显式 inline 所有必要内容
+
+### 4.8 D8 Stage 4 Design confirmation 在 bg subagent 行为：text + auto + recommended → auto-accept；否则 emit `<decision-needed>` bubble
+
+**决定**：沿用 DEC-015 auto + DEC-013 text 组合语义。
+
+- **路径 A（95% 场景）**：architect 设计带 recommended → auto-accept → 子 agent 继续到 PR 阶段 → ✅ 终态
+- **路径 B（fallback）**：recommended 缺失 → auto-halt → emit `<decision-needed>` 到 final message → 子 agent current turn 结束 → batch 主会话 parse → 🟡 Decision-pending 终态 → TG relay 给用户
+
+**why_recommended**：复用现有 DEC-013/015 机制，不发明新行为。
+
+**失败模式**：
+- (1) bg subagent text mode pause 是否等同 final turn 完成（research Q7 unknown）→ 缓解：实测前按"等同 final turn"假设；v1 P4 dogfood 会验证
+- (2) 用户在 TG 回复决策后如何 relay 回子 agent → 缓解：v1 **不自动 relay**；用户需 `cd <worktree>` 手动续跑（SendMessage 需要 EXPERIMENTAL flag，v2 议题）
+
+### 4.9 D9 MCP TG forwarding 跨三层
+
+**决定**：子 agent **不负责** TG 转发；主会话 fan-in 后由 batch 命令显式调 reply 工具汇总转发。
+
+**why_recommended**：
+- 子 agent inbound prompt 不含 `<channel>` 标签（由主会话构造），DEC-013 §3.1a sticky 语义不成立
+- 主会话一层转发避免三层嵌套协议不明确的复杂度
+- 汇总单条 TG 消息比 N 个子 agent 分散 reply 更适合用户 review
+
+**失败模式**：
+- (1) 子 agent 中途 `<decision-needed>` 用户长时间不知 → 缓解：progress event 偶尔 emit 到 TG（Monitor 输出 TG 转发，#48 的 part）
+- (2) 汇总消息超 TG 4096 char 限制 → 缓解：按终态分多条发（✅ / 🟡 / 🔴 各一条）
+
+### 4.10 D10 失败终态数：8 类（扩 analyst 3 类）
+
+**决定**：8 类（参见 §2.4 表）。
+
+**why_recommended**：穷举覆盖所有可观察终态，每类都有检测 + 处理规则；未来新模式（例如 v2 实施阶段）可追加。
+
+## 5. 讨论 FAQ
+
+### 5.1 为何不等 Claude Code 放开 "subagents cannot spawn"？
+
+不可预期时间表；同时"设计阶段 only"本身就是有价值的 MVP（用户已明确 PR-first review 流程）。等 Claude Code 放开后再扩 v2。
+
+### 5.2 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 为什么不在 v1 启用？
+
+Research Q7 发现 SendMessage 是 experimental，且 agent teams 有多项 known limitations（session resumption / shutdown / nested teams 等）。v1 以稳定为先；v2 议题评估。
+
+### 5.3 为什么不用 GitHub Actions 做 batch？
+
+analyst §2 竞品对比：GH Actions 在 Claude Code session 外，`<decision-needed>` 无法 bubble 到 TG；用户 tie-break 要切 GH UI。与本设计"TG 驱动 dogfood"目标不符。
+
+### 5.4 主会话中断（Ctrl-C）后 bg subagent 会怎样？
+
+subagent 继续跑到自然结束，result 失联。用户手动 `git worktree list` 查物理状态 / `cd <path>` 查 branch + commit 接续。v2 可考虑主会话中断时显式 `Agent cancel`（如 Claude Code 提供）。
+
+### 5.5 DEC 重编号后 `DEC-NEW-<uuid>` 映射在哪记录？
+
+PR body 由 batch 主会话统一生成，含一段：
+
+```
+DEC renumber map:
+- DEC-NEW-a1b2c3d4 → DEC-017 (this PR)
+```
+
+便于审计回溯。
+
+### 5.6 并发 3 对 dogfood 当前 open issue 足够吗？
+
+analyst §3.10 数据：当前 11 open issue 中 7 条共享 workflow.md 路径 → 同一冲突组内必须串行；其余 {#23, #20, #27} 可并发。**首轮 batch 实际有效并行度 ≤3**，3 是甜蜜点。
+
+## 6. 变更记录
+
+| 日期 | 版本 | 变更 | 作者 |
+|------|------|------|------|
+| 2026-04-20 | v1 Draft | 初版；10 关键决策量化评分；基于 Q4/Q5/Q7 research + 官方文档"subagents cannot spawn"约束重塑架构 | architect |
+
+## 7. 待确认项
+
+- [ ] batch subagent text mode pause 的 final turn 行为（Q7 unknown）—— P4 dogfood smoke 测
+- [ ] CLAUDE.md / plugin commands 是否在 `isolation:worktree` subagent 内自动可用（Q4 unknown）—— 同 P4
+- [ ] maxTurns 默认值 / `/roundtable:workflow` 设计阶段完整跑所需 turn 数 —— P4
+- [ ] MCP TG plugin tool 是否继承到子 agent（research 文档矛盾：一处说"默认继承所有工具含 MCP"，一处说"string references 需显式列出"）—— P4 实测
+
+## 8. 影响文件清单
+
+**新增**：
+- `commands/batch.md`（~300 行）
+- `docs/design-docs/batch-orchestrator.md`（本文件）
+- `docs/exec-plans/active/batch-orchestrator-plan.md`（实施计划）
+- `docs/decision-log.md` DEC-016 置顶
+
+**修改**：
+- `skills/architect.md`：加 2 条件分支（`inline_only` 禁 DEC-003 fan-out + `batch_mode` 用 DEC-NEW 占位符），总 ~12 行
+
+**不改**：
+- `commands/workflow.md` / `commands/bugfix.md` / `commands/lint.md`
+- `skills/analyst.md`
+- 4 agent prompt（developer/tester/reviewer/dba）
+- `skills/_detect-project-context.md` / `skills/_progress-content-policy.md`
+- target CLAUDE.md 业务规则边界
+- DEC-001 ~ DEC-015 任何 Accepted 条款（append-only）
+- Phase Matrix / 并行判定树 / critical_modules 机械触发
+
+**运行时新行为**：
+- `/roundtable:batch` 命令入口新增
+- 子 agent 强制 `auto=true + decision_mode=text + inline_only=true + batch_mode=true`
+- DEC 在 batch 路径用 DEC-NEW-<uuid> 占位，fan-in 重编号
+- v1 仅设计阶段；v2+ 议题扩展
+
+**critical_modules 命中**：`skills/architect.md` 修改触发 **tester 强制派发**（设计阶段完成后，下个工作流派发）。本 PR 不含实施，tester 在后续 workflow 跑时触发。

--- a/docs/design-docs/batch-orchestrator.md
+++ b/docs/design-docs/batch-orchestrator.md
@@ -609,13 +609,168 @@ analyst §3.10 数据：当前 11 open issue 中 7 条共享 workflow.md 路径 
 | 日期 | 版本 | 变更 | 作者 |
 |------|------|------|------|
 | 2026-04-20 | v1 Draft | 初版；10 关键决策量化评分；基于 Q4/Q5/Q7 research + 官方文档"subagents cannot spawn"约束重塑架构 | architect |
+| 2026-04-20 | v1.1 | PR #49 评审后补：§7.2 C1-C5 决策；§9 用户视角使用流程 / 问题解决清单 / 价值评估 / v1 推迟声明 | architect |
 
 ## 7. 待确认项
 
-- [ ] batch subagent text mode pause 的 final turn 行为（Q7 unknown）—— P4 dogfood smoke 测
-- [ ] CLAUDE.md / plugin commands 是否在 `isolation:worktree` subagent 内自动可用（Q4 unknown）—— 同 P4
-- [ ] maxTurns 默认值 / `/roundtable:workflow` 设计阶段完整跑所需 turn 数 —— P4
-- [ ] MCP TG plugin tool 是否继承到子 agent（research 文档矛盾：一处说"默认继承所有工具含 MCP"，一处说"string references 需显式列出"）—— P4 实测
+### 7.1 Research unknown（需 P5 dogfood 实测）
+
+- [ ] batch subagent text mode pause 的 final turn 行为（Q7 unknown）—— P5 dogfood smoke 测
+- [ ] CLAUDE.md / plugin commands 是否在 `isolation:worktree` subagent 内自动可用（Q4 unknown）—— 同 P5
+- [ ] maxTurns 默认值 / 设计阶段完整跑所需 turn 数 —— P5
+- [ ] MCP TG plugin tool 是否继承到子 agent（research 文档矛盾：一处说"默认继承所有工具含 MCP"，一处说"string references 需显式列出"）—— P5 实测
+
+### 7.2 用户确认的实施细节（2026-04-20 PR #49 review 阶段）
+
+- [x] **C1 D2 Scope 降级质疑** → **A. v1 落地（设计阶段 only MVP）**
+  - **用户诚实反馈（关键事实）**：2026-04-20 PR #49 评审时用户明确声明 "目前实施效果，与我的期望有较大差异"。原期望是"批量 dogfood 全流程（含实施）"，v1 降级为"设计阶段 only"的价值显著低于原期望
+  - **处理**：v1 按 PR #49 design 保持不变；**v1 实施被推迟**直到以下任一条件满足：(a) Claude Code 放开 subagents-cannot-spawn 约束 → 可直接做 v2 全流程；(b) 用户明确评估 design-only 价值足够愿意接受 v1 实施；(c) 出现更高价值的优先需求
+  - **暂不开 v2 议题 placeholder issue**（见 C3）
+
+- [x] **C2 P5 dogfood 首跑 issue** → **A. 新建 3 个 P3 micro-issue 做 smoke**
+  - 选 {#20, #23, #27} 不匹配 design-only 场景（这些是 implementation-heavy）
+  - v1 **实施时**（若决定实施）再新建 3 个 P3 专门做 smoke：例如 "docs: refine DEC-011 header initialization wording" / "docs: add FAQ section to lightweight-review design-doc" / "docs: document worktree cleanup best practices" 三类 pure-docs 场景；符合 design-only 测试目标
+  - **当前 v1 推迟状态下本项暂挂起**
+
+- [x] **C3 v2 议题占位 issue** → **不开**（用户明确拒绝）
+  - 三个 v2 议题（tester/reviewer/dba inline / agent teams 评估 / `--scope=impl` 分段）保留在本 design-doc §1.2 非目标段记录；未来需要时直接从这里查
+  - 理由（用户口径）：避免 issue 列表膨胀 / YAGNI
+
+- [x] **C4 PR 合并顺序 + branch 命名** → **A. batch 汇总按冲突组排序 + Claude Code 自动 `claude/<random>`**
+  - 汇总报告建议 merge 顺序：同冲突组内先完成先合；组间独立
+  - branch 命名沿用 Claude Code `isolation:worktree` 原生 `claude/<random>`，不显式指定 `batch/<issue>-<slug>`（减少命名策略复杂度）
+
+- [x] **C5 Concurrency default model-aware 探测** → **A. 读 env `CLAUDE_MODEL` / `--concurrency` flag；不探测默认 3**
+  - batch 命令优先序：`--concurrency N` > env `CLAUDE_MODEL ∈ {sonnet*}` → 5 / env 含 `opus*` → 3 / default → 3（保守）
+  - 永远默认 3 是 fallback；模型探测失败也走 3
+
+## 9. 用户视角：最终使用体验与交付价值
+
+### 9.1 使用流程（end-to-end）
+
+**场景**：你在 TG 想批量消化 3 个 P3 issue `#A #B #C` 的设计阶段。
+
+**Step 1 — 触发命令**：
+
+```
+TG @bot → /roundtable:batch #A #B #C
+```
+
+**Step 2 — 30 秒内 TG 收到调度计划**：
+
+```markdown
+📋 Batch Plan (3 issues, concurrency=3)
+
+冲突预检:
+  Group 1 (串行): {#A, #B} — 共享 DEC-005 token
+  Group 2 (独): {#C}
+
+调度批次:
+  Batch 1: #A + #C 并行（不同组）
+  Batch 2: #B (等 #A 完成；同组内串行)
+
+预估耗时: 30-60 min
+继续？回 go / 停
+```
+
+**Step 3 — 用户 `go` 后进入 30-60 分钟静默期**：
+
+本 v1 诚实面：`<decision-needed>` 转发（DEC-013 §3.1a）仅在 emit 决策块时生效，子 agent 跑设计期间 TG 无反馈（除非命中 auto-halt fallback 或 skill 决策）。
+
+**Step 4 — 后台实际执行**（用户不可见，供架构回溯）：
+
+```
+主会话 /roundtable:batch:
+  ├ fan-out: Agent(#A, bg, worktree) + Agent(#C, bg, worktree)
+  ├ 等 batch 1 完 → fan-out #B
+  └ 全部完 → parse + renumber DEC + 汇总
+
+每个 bg subagent (worktree 内):
+  ├ gh issue view <N>
+  ├ analyst skill inline  → docs/analyze/<slug>.md (深度分析)
+  ├ architect skill inline → docs/design-docs/<slug>.md
+  │                           + DEC-NEW-<uuid8> 占位
+  │                           + docs/exec-plans/active/<slug>-plan.md
+  ├ git commit + push + gh pr create --draft
+  └ final message (含 PR URL + DEC-NEW uuid)
+```
+
+**Step 5 — 全部完成时 TG 汇总报告**：
+
+```markdown
+✅ Batch 完成 (3/3, 42 min)
+
+✅ 已完成 (3):
+  #A → PR#51 (DEC-017) branch: claude/abc123
+  #B → PR#52 (DEC-018) branch: claude/def456
+  #C → PR#53 (DEC-019) branch: claude/ghi789
+
+🟡 待决策 (0)
+🔴 失败 (0)
+
+DEC renumber map:
+  DEC-NEW-aaa → DEC-017 (#A)
+  DEC-NEW-bbb → DEC-018 (#B)
+  DEC-NEW-ccc → DEC-019 (#C)
+
+建议 merge 顺序: #A → #B (同组串行) → #C
+```
+
+**Step 6 — 用户在 GitHub 逐 PR review 设计**：
+
+- 认同 → Approve + merge
+- 要改 → PR comment 指出，architect skill 按反馈迭代（重跑 `/roundtable:workflow <N>` 的 architect 阶段，针对单 PR 的 slug）
+- 拒绝 → close PR；issue 保持 open
+
+**Step 7 — Merged 后实施阶段（不走 batch）**：
+
+```
+TG @bot → /roundtable:workflow #A --auto
+```
+
+主会话跑完整 workflow 派发 developer / tester / reviewer subagent，产实施 commit 追加到同 branch / 同 PR。
+
+### 9.2 解决的问题
+
+| # | 痛点 | v1 如何解决 | 量化 |
+|---|------|------------|------|
+| 1 | 积压多 issue 的设计阶段串行耗时 | 并行 fan-out worktree subagent | 3 条并行 ~1-2h vs 串行 ~3-6h（3x 加速） |
+| 2 | 用户 review 时机太晚（要等完整 workflow 跑完） | 设计阶段产出即 draft PR | 不用等 developer/tester，早期发现设计问题 |
+| 3 | 多 issue 并发时 DEC 编号竞争 | post-hoc renumber + DEC-NEW-\<uuid\> 占位 | 零协调 / 容错 / 审计清晰 |
+| 4 | 并发改同文件的 race | worktree 硬隔离 + 启发式冲突预检分组 | 假阴性兜底靠合并期 rebase |
+| 5 | 分布式决策记录难追溯 | 汇总报告 DEC renumber map + PR body 映射 | PR 审计时可反查原 uuid |
+
+### 9.3 不解决的问题（v1 诚实面）
+
+| # | 问题 | 根因 | 缓解 |
+|---|------|------|------|
+| 1 | ❌ 不加速实施阶段 | Claude Code 硬约束：subagents cannot spawn subagents | v2 议题（见 §1.2）；或等 Claude Code 放宽 |
+| 2 | ❌ 子 agent 跑期间 TG 零反馈 | DEC-013 §3.1a 转发不跨三层嵌套 | #48 修复后显著改善（仍非完美） |
+| 3 | ❌ 启发式预检 30%+ 假阴性 | body 描述与真实改动面不一定对齐 | worktree 隔离是合并期兜底 |
+| 4 | ❌ recommended 缺失子 agent 停在 worktree | 非 `EXPERIMENTAL_AGENT_TEAMS=1` 无 SendMessage | 用户 `cd <worktree>` 手动续跑 |
+| 5 | ❌ 长期 worktree 堆积耗磁盘 | Claude Code 原生保留有变更 worktree | 文档引导用户 `git worktree prune` |
+
+### 9.4 价值评估（诚实面）
+
+**值得做的情况**：
+
+- 当前 open 11 个 issue 里 P2/P3 积压 9 个
+- 用户有"先 review 设计再实施"的 PR-first 流程偏好
+- 批量设计文档产出节省 ~3-5h 首次积压消化时间
+
+**不值得做的情况**：
+
+- **用户期望"批量 dogfood 完整 pipeline"**：v1 不覆盖实施阶段，与原期望差距大（2026-04-20 用户原话："目前实施效果，与我的期望有较大差异"）
+- Claude Code 预期短期（1-3 月）放开 subagents-cannot-spawn 约束 → 应直接做 v2 全流程
+- 用户不急于消化 P2/P3 积压
+
+### 9.5 v1 推迟决策（2026-04-20）
+
+基于用户明确反馈"实施效果与期望差异较大"，v1 实施**暂停**。本 PR #49 保留作为设计存档；是否最终实施等待：
+
+1. Claude Code 对 subagents-cannot-spawn 约束的动态
+2. 用户对 design-only 价值的再次评估
+3. 更高价值的优先需求完成后重新审视
 
 ## 8. 影响文件清单
 

--- a/docs/exec-plans/active/batch-orchestrator-plan.md
+++ b/docs/exec-plans/active/batch-orchestrator-plan.md
@@ -1,0 +1,202 @@
+---
+slug: batch-orchestrator
+source: design-docs/batch-orchestrator.md
+created: 2026-04-20
+status: Active
+---
+
+# Batch Orchestrator 执行计划
+
+## 总览
+
+| Phase | 标题 | 预估 | 前置 | 关键风险 |
+|-------|------|------|------|---------|
+| P0 | 骨架 + 单 issue smoke | 0.5d | DEC-016 confirm | general-purpose subagent 能否承载 inline workflow 未验证 |
+| P1 | Architect skill 批改（inline_only + batch_mode 分支）| 0.3d | P0 | critical_modules 命中需 P3 tester 验证 |
+| P2 | Conflict pre-check + 分组串行 | 0.5d | P0 | 正则误差 / Union-Find 边界 |
+| P3 | DEC 占位符 + fan-in 重编号 | 0.5d | P0 + P1 | sed 替换范围 / sanity grep |
+| P4 | 失败隔离 + 汇总报告 + TG 转发 | 0.5d | P0 | TG 消息长度 / 三层嵌套转发 |
+| P5 | Dogfood E2E + tester（critical）| 0.7d | P0-P4 | rate limit / worktree 堆积 / Q7 unknown 实测 |
+
+**总预估**：~3d。
+
+**跨阶段约束**：
+- **不改** 4 agent prompt / analyst skill / workflow.md / bugfix.md / lint.md 本体 / target CLAUDE.md
+- **critical_modules 命中**：`skills/architect.md` 修改 → P5 必须派 tester
+- **lint**：`grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` 0 命中
+- **DEC Supersede**：无（batch 是 append 层，不覆盖已 Accepted DEC）
+
+## P0 骨架 + 单 issue smoke
+
+### 目标
+
+最小可运行 `/roundtable:batch #N` 单 issue 形态：fan-out 1 个 `general-purpose` subagent with `isolation:worktree` + `run_in_background:true`，子 agent 跑 inline analyst+architect 产出 design + DEC-NEW 占位 + draft PR。
+
+### 任务清单
+
+- [ ] 新建 `commands/batch.md`（骨架 + Step 0~7 占位）
+- [ ] 实现 Step 0 argparse（`#N` / `--concurrency` / `--dry-run`）
+- [ ] 实现 Step 1 context detection（inline Read `${CLAUDE_PLUGIN_ROOT}/skills/_detect-project-context.md`）
+- [ ] 实现 Step 2 prefetch（`gh issue view <N> --json body,number,title`）
+- [ ] 实现 Step 5 单 Agent dispatch（general-purpose / worktree / bg / prompt per §2.8）
+- [ ] 实现 Step 5 Monitor 启动（复用 workflow.md §3.5 机制，单 dispatch_id）
+- [ ] 实现 Step 6 单子 agent final message parse（PR URL + DEC-NEW uuid 提取）
+- [ ] 实现 Step 7 最小汇总（1 条 PR URL）
+
+### 成功信号
+
+- `/roundtable:batch #23`（独立 issue）成功派 1 个子 agent
+- 子 agent 产出 `docs/analyze/[slug].md` + `docs/design-docs/[slug].md` + `docs/exec-plans/active/[slug]-plan.md` + `decision-log.md` 顶部 `DEC-NEW-<uuid>` 条目
+- git commit + push + gh pr create --draft 成功，返回 PR URL
+- 主会话 fan-in 解析 final message 成功，输出 "✅ #23 → <PR-URL>"
+
+### 风险与预案
+
+- **subagents cannot spawn** 硬约束：子 agent 内 workflow 若误触 Agent tool 会失败 → 子 agent prompt 明确禁用 + architect skill `inline_only` 分支守约束
+- **general-purpose 不继承 skills / plugin commands 在 worktree 的可用性未验证** → P0 第一步做最小 smoke（子 agent prompt inline 执行 `Read analyst.md + Read architect.md` 而非依赖 skill 激活）；若激活可用则简化 v2
+- **worktree 路径获取**：Claude Code Agent 返回 final message 是否带 worktree path + branch —— P0 验证，失败则 `git worktree list` 扫描对比
+
+## P1 Architect skill 批改
+
+### 目标
+
+architect skill 支持 orchestrator 注入的 `inline_only` / `batch_mode` 两个条件分支。
+
+### 任务清单
+
+- [ ] 读 `skills/architect.md` §3.5 Research Fan-out 段，加 `inline_only: true` 禁 DEC-003 fan-out 分支（~5 行）
+- [ ] 读 §decision-log 条目顺序约定段，加 `batch_mode: true` 用 `DEC-NEW-$(openssl rand -hex 4)` 占位符分支（~5 行）
+- [ ] 不改其他规则 / 不改 `skills/analyst.md` / 不改 4 agent
+- [ ] 本地 smoke：主会话模式跑 `/roundtable:workflow <minor issue>` 验证不注入 flag 时行为不变（regression）
+- [ ] 子 agent 模式 smoke：注入 `inline_only: true`，architect 跑设计不派 research subagent
+
+### 成功信号
+
+- `skills/architect.md` diff ≤15 行新增
+- 主会话 regression 通过（无 flag 时 DEC-003 fan-out 正常 + DEC 递增正常）
+- batch 子 agent 模式下 architect 跑完不派 Task + 写的 DEC ID 是 `DEC-NEW-<8 hex>`
+
+### 风险与预案
+
+- **critical_modules 命中**（`skills/architect.md`）：P5 强制派 tester 验证所有分支
+- **条件分支复杂度累积**：若未来 v2 再加分支，需评估是否抽 helper；v1 严格 inline 分支（≤15 行）对齐 DEC-010 精简
+
+## P2 Conflict pre-check + 分组串行
+
+### 目标
+
+多 issue 场景：扫 body → Union-Find 分组 → 组内串行 + 组间并行。
+
+### 任务清单
+
+- [ ] Step 3 正则抽取：`\bDEC-\d+\b` / `(?:skills|agents|commands)/[\w-]+\.md` / `docs/design-docs/[\w-]+\.md`（扩粒度）
+- [ ] Union-Find 实现（Bash 难；用 `python3 -c "..."` inline）
+- [ ] Step 4 plan emit：表格呈现"组 / 组内 issue / 并发占用 / 预估耗时"
+- [ ] Step 5 调度器：FIFO + 组约束（同组 1 running，其他排队；组间按 --concurrency 并发）
+- [ ] 多 Agent single-message 并行 dispatch 实测
+- [ ] Monitor 多 dispatch_id 交织（DEC-004 §3.5 已符合）
+- [ ] （可选）`--no-preheck` flag 强制全并行
+
+### 成功信号
+
+- `/roundtable:batch #A #B #C` 其中 #A/#B 共享 `DEC-005` token → 分 2 组：{A,B} 串 / {C} 独
+- 实际派发：#A done → #B start；#C 与 #A 同时 start
+- 终端 Monitor 输出 3 个 dispatch_id 交织可读
+
+### 风险与预案
+
+- **Bash 实现 Union-Find 难** → 用 `python3 -c` 内嵌
+- **正则假阳**（body 引用但不改）→ 文档诚实标注 + `--no-preheck` 兜底
+- **Plan emit 在 auto_mode=true 下仍需 producer-pause？** → batch 命令本身默认 **manual**（用户要求"不是 auto"），`--auto-plan` 可覆盖（v2）
+
+## P3 DEC 占位符 + fan-in 重编号
+
+### 目标
+
+主会话 fan-in 阶段按完成时序把 `DEC-NEW-<uuid>` 重编号为连续整数。
+
+### 任务清单
+
+- [ ] Step 6 final message parse：提取 DEC-NEW uuid 列表 + worktree path
+- [ ] `current_max = max(...)` 读主 branch `decision-log.md`
+- [ ] 按完成时序 sort 子 agent
+- [ ] sed 替换跨多文件类型（`decision-log.md` / `design-docs/*.md` / `exec-plans/**/*.md` / `log.md` / `INDEX.md` / `testing/*.md` / `reviews/*.md` / `bugfixes/*.md`）
+- [ ] sanity `grep -r "DEC-NEW-[a-f0-9]{8}" <worktree>/docs/` 必须 0 命中
+- [ ] PR body 追加 "DEC renumber map" section
+- [ ] 重编号失败（sanity 非 0）→ 该 subagent 终态降级 🔴 #5（Crash），worktree 保留
+- [ ] 单 issue workflow 路径行为不变回归测试
+
+### 成功信号
+
+- 两 batch 子 agent 各加 1 DEC；fan-in 后主 branch decision-log 置顶 `DEC-017` + `DEC-018`
+- 所有 cross-ref 同步更新（`design-docs/*.md` frontmatter `decisions:` 字段 / `log.md` fix-rootcause entry 等）
+- sanity grep 0 命中
+- 单 issue workflow 仍走 MAX+1 递增
+
+### 风险与预案
+
+- **sed 假阳性替换**（UUID 巧合在代码示例）→ 严格正则 `\bDEC-NEW-[a-f0-9]{8}\b`
+- **漏文件类型** → sanity grep 捕获
+- **重编号中断**（sed 跑一半挂了）→ sanity fail 终态 🔴 #5 + worktree 保留供人工
+
+## P4 失败隔离 + 汇总报告 + TG 转发
+
+### 目标
+
+收集 8 类终态，汇总 markdown 输出 + TG 转发。
+
+### 任务清单
+
+- [ ] Step 6 final-message 分类器（8 类：正则匹配 PR URL / `<decision-needed>` / `🔴 auto-halt` / tester `<escalation>` / lint/test fail / Crash / 中断 / 429）
+- [ ] Step 7 汇总 markdown 渲染（按 ✅→🟡→🔴 排序；每 🟡/🔴 附 worktree path）
+- [ ] Step 7 TG 转发（#48 未实施时本命令内嵌显式 reply 调用）
+- [ ] 长消息分段（>4096 char → 多条 TG reply）
+- [ ] DEC renumber map section 附加到 TG 汇总
+
+### 成功信号
+
+3 issue batch 中 2 success / 1 🟡（recommended 缺失 + decision-pending）→ 最终报告完整 3 类清单 + worktree 可达 + TG 收到。
+
+### 风险与预案
+
+- **TG 消息长度** → 分段；汇总 summary ≤1000 char，详情在 PR body
+- **三层嵌套转发**：子 agent `<decision-needed>` 不会自动 TG 转发（§3.6） → 主会话 fan-in 后统一转发
+- **#48 未实施的手动转发耦合** → 明确标记（注释 / 文档）"#48 实施后可移除"
+
+## P5 Dogfood E2E + tester（critical_modules 触发）
+
+### 目标
+
+roundtable repo 自身跑 `/roundtable:batch #A #B #C` 验证端到端；派 tester 覆盖 architect skill 修改（critical_modules 命中）。
+
+### 任务清单
+
+- [ ] 选 3 个独立 low-risk issue 作 smoke（analyst §3.10 建议 {#23, #20, #27}，虽非 design-only 场景但可测 batch 机制）
+- [ ] 或选 design-only 适合的 issue（暂无，可新建 P3 micro-issue 做 smoke）
+- [ ] 派 `tester` subagent 覆盖 `skills/architect.md` 2 条件分支（critical_modules 命中）
+  - 测：无 flag 场景 regression
+  - 测：`inline_only=true` 禁 DEC-003 fan-out
+  - 测：`batch_mode=true` 用 DEC-NEW 占位
+- [ ] 测 batch_worker prompt 的 subagents-cannot-spawn 约束在实际 subagent 中是否如预期
+- [ ] 记录 Q7 unknown 实测结果（bg subagent text pause 终态、CLAUDE.md 继承、MCP 继承、maxTurns 默认）→ 回填 design-doc §7 待确认项
+- [ ] 补 `docs/testing/batch-orchestrator.md`（tester 专属）
+- [ ] 观察 Monitor 交织输出；记录 UX 痛点
+
+### 成功信号
+
+- 3 issue batch 并行成功（或识别真实 conflict 串行化）
+- PR URL 齐全 + DEC 重编号正确 + TG 汇总可读
+- tester regression 无红
+- Q7 unknown 至少 3/4 项有实测数据回填
+
+### 风险与预案
+
+- **API rate limit 429** → `--concurrency 2` 保守；观察 headers
+- **worktree 堆积占盘** → test 完 `git worktree prune`
+- **design-only 场景无适合 issue** → 新建 P3 micro-issue 或用 dry-run + mock 子 agent 替代
+
+## 变更记录
+
+| 日期 | 版本 | 变更 | 作者 |
+|------|------|------|------|
+| 2026-04-20 | v1 | 初版 P0-P5；加 P1 architect skill 批改独立阶段；P5 critical_modules tester 触发 | architect |


### PR DESCRIPTION
## Summary

- **analyst** 深度调研 (525 行, 9 维度 + 7 开放问题): `docs/analyze/batch-orchestrator.md`
- **architect** 完整设计 (700+ 行, 10 决策量化评分 + 8 失败终态 + 数据流图): `docs/design-docs/batch-orchestrator.md`
- **exec-plan** P0-P5 实施路线 (~3d): `docs/exec-plans/active/batch-orchestrator-plan.md`
- **DEC-016** 置顶 (14 决定 / 10 备选 / 完整影响范围): `docs/decision-log.md`

## ⚠️ 重大架构调整

基于 DEC-003 3 路并行 research (Q4 subagent_type / Q5 API rate limit / Q7 Stage 4 bg 行为) 发现 Claude Code **官方硬约束**:

> "Subagents cannot spawn other subagents. If your workflow requires nested delegation, use Skills or chain subagents from the main conversation."
> — https://code.claude.com/docs/en/sub-agents

→ issue #43 原始架构 (子 agent 跑完整 `/roundtable:workflow --auto`) 不可行，因为 workflow 内派发 developer/tester/reviewer/dba subagent 会失败。

**v1 MVP 降级**为**设计阶段 only**: `analyst + architect (skill inline) + commit + draft PR`。实施阶段由用户在主会话 review PR 后跑 `/roundtable:workflow`。

**v2 议题** (未本 PR 范围):
- 扩 tester/reviewer/dba 到 inline 形态 (DEC-005 follow-up)
- 或等 Claude Code 放开嵌套约束 / agent teams 稳定
- 或 `--scope=impl` 分段模式

## 10 关键决策摘要

| # | 决策 | 采纳方案 | 量化评分 |
|---|------|---------|---------|
| D1 | 命令形态 | 新 `commands/batch.md` 独立命令 | 48 vs 35 |
| **D2** | **Batch scope ⚠️** | **设计阶段 only MVP** | **36 vs 17/25/29** |
| D3 | DEC 编号竞争 | post-hoc renumber `DEC-NEW-<uuid>` | 41 vs 37/23 |
| D4 | 冲突预检 | 启发式 + docs/design-docs slug 扩粒度 | 27 vs 20/22/18 |
| D5 | Worktree 生命周期 | Claude Code 原生 (有变更保留/无变更回收) | — |
| D6 | 并发默认 | model-aware (Opus 3 / Sonnet 5) | 18 vs 14/10 |
| D7 | Subagent type | `general-purpose` | 51 vs 32/38 |
| D8 | Stage 4 bg 行为 | text + auto + recommended → auto-accept / fallback bubble | — |
| D9 | MCP TG forwarding | 主会话一层转发 (子 agent 不转发) | — |
| D10 | 失败终态 | 8 类穷举 (扩 issue body 3 类) | — |

完整权衡矩阵 + failure modes + why_recommended 见 design-doc §4。

## 改动面

**本 PR (设计阶段)**:
- `docs/analyze/batch-orchestrator.md` (525 行, 新增)
- `docs/design-docs/batch-orchestrator.md` (700+ 行, 新增)
- `docs/exec-plans/active/batch-orchestrator-plan.md` (P0-P5, 新增)
- `docs/decision-log.md` (DEC-016 置顶)

**后续实施 (非本 PR)**:
- `commands/batch.md` (~300 行, 新增)
- `skills/architect.md` (+~12 行, 2 条件分支 `inline_only` / `batch_mode`)
- `docs/testing/batch-orchestrator.md` (tester P5 补)

**零改动**:
- 4 agent prompt (developer/tester/reviewer/dba)
- `skills/analyst.md` / `skills/_detect-project-context.md` / `skills/_progress-content-policy.md`
- `commands/workflow.md` / `commands/bugfix.md` / `commands/lint.md` 本体
- `commands/_progress-monitor-setup.md`
- README / target CLAUDE.md 业务规则
- DEC-001 ~ DEC-015 任何 Accepted 条款 (append-only)
- Phase Matrix / 并行判定树 / critical_modules 机械触发

## 对齐现有 DEC

| DEC | 对接 |
|-----|------|
| DEC-001 | 不改 4 agent + D1-D9; batch 是 command 层 |
| DEC-002 | 正交; v1 不涉实施 |
| DEC-003 | 在 batch 子 agent 内**禁用** research fan-out; 主会话模式沿用 |
| DEC-004 | 独立 DISPATCH_ID 符合 |
| DEC-005 | 不改; v1 不涉 developer |
| DEC-006 | batch 层 A+C 混合, 不新增类别 |
| DEC-008 | batch 子 agent 全走 bg |
| DEC-011 | DEC 顺序置顶沿用 |
| DEC-013 | 子 agent 硬编码 `--decision=text`; §3.1a 不跨三层 |
| DEC-015 | 子 agent 硬编码 `--auto` |

## 下一步

1. **你在本 PR review 设计文档**
2. 批准 → 后续实施 PR 补 `commands/batch.md` + architect skill 分支 + P5 tester
3. 修改请求 → PR comment 指出，architect 按反馈迭代
4. 拒绝 → revert 整个 batch 设计，回到单 issue workflow 心智

## Test plan

- [ ] 你 review `docs/analyze/batch-orchestrator.md` 9 维度事实层是否扎实
- [ ] 你 review `docs/design-docs/batch-orchestrator.md` §4 10 决策评分是否认同
- [ ] 特别关注 D2 Scope (设计阶段 only MVP) — 此决策若不认同需重做
- [ ] 你 review DEC-016 (§7 待确认项 4 个 Q7 unknown 是否可接受 P5 dogfood 实测)
- [ ] 你 review `docs/exec-plans/active/batch-orchestrator-plan.md` P0-P5 任务清单 + 风险预案

## 关联

- Closes 部分 #43 (设计阶段; 实施阶段 follow-up)
- 强耦合 #48 (P1 phase summary TG 转发; design §3.6 诚实面讨论)
- 前置 #33 (DEC-015 auto mode, merged)
- 前置 #38 (DEC-013 §3.1a, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)