### PR TITLE
fix(prompts): dedupe 产出 and created fields in agent/skill final message (#29)

### DIFF
--- a/agents/dba.md
+++ b/agents/dba.md
@@ -138,3 +138,4 @@ echo '{"ts":"<iso-utc>","role":"dba","dispatch_id":"{{dispatch_id}}","slug":"{{s
 ## 完成后
 
 - 不直接写 log.md —— 若审查落盘，`log_entries:` YAML 上报（`prefix: review` / `slug: db-[slug]` / `files` / `note` 含 Critical/Major 数量），orchestrator 按 Step 8 flush
+- **Final message 输出规范**（issue #29）：**唯一**机读产出字段是 `created:` YAML（Step 7；若有新建 db review 文档）+ `log_entries:` YAML。**禁止**额外输出 `产出:` / `Outputs:` 自然语言文件清单 —— orchestrator 生成用户可见 summary

--- a/agents/developer.md
+++ b/agents/developer.md
@@ -115,6 +115,7 @@ target CLAUDE.md 的「工具链覆盖」覆盖以上默认。
 - exec-plan 功能全部完成 → 移到 `{docs_root}/exec-plans/completed/`
 - 不自动改 design-docs；发现实现与 design-docs 不一致时 escalate
 - 不直接写 log.md —— 在 final message `log_entries:` YAML block 上报，orchestrator 按 workflow Step 8 flush
+- **Final message 输出规范**（issue #29）：**唯一**机读产出字段是 `created:` YAML（Step 7 契约；若有新建文件）+ `log_entries:` YAML。**禁止**额外输出 `产出:` / `Outputs:` 自然语言文件清单 —— orchestrator 生成用户可见 summary，subagent 自带 summary 重复浪费 token
 
 ## 报告格式
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -119,3 +119,4 @@ echo '{"ts":"<iso-utc>","role":"reviewer","dispatch_id":"{{dispatch_id}}","slug"
 
 - 不直接写 log.md —— 若审查落盘，在 `log_entries:` YAML 上报（`prefix: review` / `slug` / `files` / `note` 含 Critical/Major 数量），orchestrator 按 Step 8 flush
 - 代码与决策不一致时在审查报告里明确标 "与 DEC-xxx 不一致"
+- **Final message 输出规范**（issue #29）：**唯一**机读产出字段是 `created:` YAML（Step 7；若有新建 review 文档）+ `log_entries:` YAML。**禁止**额外输出 `产出:` / `Outputs:` 自然语言文件清单 —— orchestrator 生成用户可见 summary

--- a/agents/tester.md
+++ b/agents/tester.md
@@ -124,4 +124,5 @@ created: YYYY-MM-DD
 
 - 不直接写 log.md；若产出测试计划 / 关键 testing 文档，`log_entries:` YAML block 上报，orchestrator 按 Step 8 flush
 - 代码层面的测试新增不进 log_entries（归 git log）
+- **Final message 输出规范**（issue #29）：**唯一**机读产出字段是 `created:` YAML（Step 7；若有新建 testing 文档）+ `log_entries:` YAML。**禁止**额外输出 `产出:` / `Outputs:` 自然语言文件清单 —— orchestrator 生成用户可见 summary
 - 发现业务 bug → 先 emit `phase_blocked` 再 `<escalation>`，附复现测试路径

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -351,7 +351,7 @@ created:
     description: Feature X design
 ```
 
-**单一产出字段原则**（issue #29）：`created:` 是 final report 文件清单的**唯一机读源**；`log_entries.files[]` 与之一致（Step 8）。角色**禁止**在 final message 额外输出 `产出:` / `Outputs:` 自然语言文件清单 —— orchestrator 从 `created:` 路径 + `description:` 生成用户可见 A 类 producer-pause summary，skill/agent 自带 summary 会与 orchestrator 生成重复。
+**单一产出字段原则**（issue #29）：`created:` 是 final report **新建文件**清单的**唯一机读源**；`log_entries.files[]` 可额外包含 **修改**文件（两者互补非冗余：`created[]` → INDEX.md / `log_entries.files[]` → log.md），不要求字面 equal。Step 6.1 A 类模板的 `产出：` 行**归 orchestrator 生成**（基于 `created[].path` + `description`）；角色**禁止**在 final message 自写 `产出:` / `Outputs:` 自然语言文件清单（避免与 orchestrator 侧重复）。`tests/*` / `src/*` 代码文件不进 `created:`（INDEX.md 只识 `docs/` 6 类），归 git log。
 
 Fallback：`/roundtable:lint` 周期性审计 orphan。**角色从不自行编辑 `INDEX.md`**。
 

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -351,6 +351,8 @@ created:
     description: Feature X design
 ```
 
+**单一产出字段原则**（issue #29）：`created:` 是 final report 文件清单的**唯一机读源**；`log_entries.files[]` 与之一致（Step 8）。角色**禁止**在 final message 额外输出 `产出:` / `Outputs:` 自然语言文件清单 —— orchestrator 从 `created:` 路径 + `description:` 生成用户可见 A 类 producer-pause summary，skill/agent 自带 summary 会与 orchestrator 生成重复。
+
 Fallback：`/roundtable:lint` 周期性审计 orphan。**角色从不自行编辑 `INDEX.md`**。
 
 ---

--- a/docs/log.md
+++ b/docs/log.md
@@ -14,6 +14,15 @@
 
 **合并原则**：agent / skill **不直接写本文件**。每轮 workflow 由 orchestrator 按 `commands/workflow.md` §Step 8 log.md Batching 协议（bugfix 流程按 `commands/bugfix.md` §log.md Batching 简化版）收集各 agent final report 中的 `log_entries:` YAML block 聚合写入；同一 agent 在同一轮产出多份文档（如 architect 同时输出 design-doc + DEC + exec-plan）**合并为一条**，`影响文件` 列全部路径（union）；不拆多条。DEC-009 决定 2 落地。
 
+## fix-rootcause | dedupe-produce-created | 2026-04-21
+- 操作者: orchestrator (inline bugfix)
+- 影响文件: skills/architect/SKILL.md (+1 行 §完成后); skills/analyst/SKILL.md (+1 行 §完成后); agents/developer.md (+1 行); agents/tester.md (+1 行); agents/reviewer.md (+1 行); agents/dba.md (+1 行); commands/workflow.md (Step 7 +1 行 "单一产出字段原则")
+- 分析: |
+    issue #29 P2 bug —— architect final message 同时输出 `产出:` 自然语言清单 + `created:` YAML 结构化清单，两者描述同一批文件路径冗余。
+    根因：5 skill/agent prompt 的 "完成后" 段仅规定 `log_entries:` / `created:` 机读契约，未禁自由文本 `产出:` 重复输出；习惯性模板导致 token 浪费 + orchestrator 解析歧义（两处来源不一致风险）。
+    修复：7 处 prompt inline 加"Final message 输出规范"条款，明示 `created:` 是唯一机读源；workflow.md Step 7 契约补"单一产出字段原则"。orchestrator 端从 `created:` 自动生成 A 类 producer-pause summary，skill/agent 不再自带。
+    验证：lint 0 命中；后续 /roundtable:workflow 派发观察 final message 应不再含 `产出:` 段。
+
 ## test-plan | phase-end-approval-gate | 2026-04-21
 - 操作者: tester (subagent, fg; critical_modules 3/3 命中 → 必落盘)
 - 影响文件: docs/testing/phase-end-approval-gate.md (new)

--- a/docs/reviews/2026-04-21-dedupe-produce-created.md
+++ b/docs/reviews/2026-04-21-dedupe-produce-created.md
@@ -1,0 +1,82 @@
+---
+slug: dedupe-produce-created
+source: issue #29 P2 bug fix (branch fix/29-dedupe-produce-created, HEAD c740ab0)
+created: 2026-04-21
+description: issue #29 dedupe produce vs created 终审 reviewer 报告
+---
+
+# issue #29 dedupe `产出:` vs `created:` —— 终审报告
+
+## 审查范围
+
+- 7 prompt 文件 inline 加 "Final message 输出规范" 条款
+  - `skills/architect/SKILL.md` / `skills/analyst/SKILL.md`
+  - `agents/developer.md` / `agents/tester.md` / `agents/reviewer.md` / `agents/dba.md`
+- `commands/workflow.md` Step 7 +1 段 "单一产出字段原则"（含 c740ab0 post-fix 扩写）
+- `docs/log.md` fix-rootcause entry
+- `docs/testing/dedupe-produce-created.md`（tester 复审报告）
+
+全部命中 `critical_modules`（skill/agent/command prompt 本体）。
+
+## 与既有 DEC 兼容性
+
+| DEC | 关系 | 判定 |
+|-----|------|------|
+| DEC-006（producer-pause A 类模板）| orchestrator emit `产出:` 行，agent/skill 禁写 | post-fix 明示分工，兼容 |
+| DEC-009（log_entries union）| `log_entries.files[]` 可含 updates，`created[]` 仅新建 | post-fix "互补非冗余"语义，兼容 |
+| DEC-014（fix-rootcause tier-1）| log.md entry 三段齐全 | 兼容 |
+| DEC-013（decision_mode text）| 不涉及 final-message schema 之外路径 | 正交 |
+
+## 7 prompt 文件措辞一致性
+
+- 7 处均带 "final message" 作用域限定词 —— 不波及落盘文档正文 ✅
+- 7 处均引 "issue #29" 便追溯 ✅
+- 尾句细差：developer/tester "浪费 token"；reviewer/dba/architect/analyst 无此字样 —— nit，不阻塞
+- `created:` + `log_entries:` 双字段契约在各角色中均正确 cross-ref 到 Step 7 / Step 8 ✅
+
+## tester W1/W2 post-fix 实质性
+
+对比 2f5b101 vs c740ab0 `commands/workflow.md:354`：
+
+- **W1**（A 类模板 `产出：` 字面 vs 禁令冲突）：post-fix 扩写明示 "Step 6.1 A 类模板的 `产出：` 行**归 orchestrator 生成**（基于 `created[].path` + `description`）；角色**禁止**在 final message 自写" —— 谁 emit 谁禁字面已消歧，W1 实质吸收 ✅
+- **W2**（`log_entries.files[]` vs `created[].path` 校验）：post-fix 扩写 "两者互补非冗余：`created[]` → INDEX.md / `log_entries.files[]` → log.md，不要求字面 equal" —— 互补语义 + 落盘目标分离已写清，W2 实质吸收 ✅
+- **附带超额吸收**：新版明示 "`tests/*` / `src/*` 代码文件不进 `created:`（INDEX.md 只识 `docs/` 6 类），归 git log" —— 覆盖 tester W3 的 `tests/` INDEX 污染担忧，超范围吸收 ✅
+
+## Follow-up 可后续处理（均 Suggestion 等级）
+
+- **W4**（历史 design-doc 正文 `## 产出` 段是否被误伤）：作用域限定词已正确；若未来观察到 LLM 过度合规，再补一句"仅限 final message stdout"即可
+- **S1**（7 处尾句风格微差）：nit，可下一轮 prompt polish 合并
+- **S2**（Step 7 条款位置）：当前可接受
+- **S3**（dogfood E2E 观察点清单）：建议由用户实测 `/roundtable:workflow` 首轮派发后，把 O1-O4 观察点记录回 log.md 或 dogfood 归档
+
+## Critical
+
+无。
+
+## Warning
+
+无新增（tester 报告 W1/W2 inline post-fix 已吸收；W3 超额吸收；W4 non-blocking）。
+
+## Suggestion
+
+- **R1**（选吸收，与 S1 相关）：未来 prompt polish 轮次中统一 7 处尾句（目前 skill 侧 "skill 本层自带 summary 会与 orchestrator 生成重复" vs agent 侧混用 "浪费 token"）
+- **R2**（follow-up）：首次完整 `/roundtable:workflow` dogfood 后补一节 `## Dogfood 验证` 到本文件或 `docs/testing/dedupe-produce-created.md`，记录 O1-O4 观察结果
+
+## Lint
+
+`grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` → 0 命中 ✅
+
+## 结论
+
+**Approve**。
+
+- 0 Critical / 0 新 Warning / 2 Suggestion（均 follow-up 级）
+- tester W1/W2 inline post-fix 实质吸收，非贴补
+- 7 prompt 文件措辞一致、`final message` 作用域限定词正确
+- 与 DEC-006 / 009 / 014 / 013 全部正交或兼容
+- lint 0 命中，critical_modules 改动面小、可控
+- PR 级验收：#29 P2 bug"architect final 不再双字段"已从契约层 + 7 处 prompt 双闭环，dogfood 实测归用户
+
+## 变更记录
+
+- 2026-04-21 reviewer 终审 —— Approve；0 Critical / 0 Warning / 2 Suggestion / tester W1-W3 已吸收 / W4+S1-S3 non-blocking follow-up

--- a/docs/testing/dedupe-produce-created.md
+++ b/docs/testing/dedupe-produce-created.md
@@ -1,0 +1,150 @@
+---
+slug: dedupe-produce-created
+source: issue #29 P2 bug fix（commit 2f5b101 on fix/29-dedupe-produce-created）
+created: 2026-04-21
+description: issue #29 dedupe produce vs created fix 对抗审查测试计划
+---
+
+# 禁 `产出:` 自然语言清单 / 保留 `created:` YAML 唯一机读源 对抗审查测试计划
+
+## 审查范围
+
+本次 bug fix 改动 8 文件 +18 行：
+
+- `skills/architect/SKILL.md` §完成后 +1 行 "Final message 输出规范"
+- `skills/analyst/SKILL.md` §完成后 +1 行 "Final message 输出规范"
+- `agents/developer.md` §完成后 +1 行
+- `agents/tester.md` §完成后 +1 行
+- `agents/reviewer.md` §完成后 +1 行
+- `agents/dba.md` §完成后 +1 行
+- `commands/workflow.md` Step 7 +1 段 "单一产出字段原则"
+- `docs/log.md` `fix-rootcause` entry
+
+全部落在 `critical_modules`（skill / agent / command prompt 本体）命中范围，故本审查必落盘。
+
+## 覆盖现状
+
+- lint_cmd `grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/"` 0 命中
+- 无代码层测试（纯 prompt 包）；验证走 prompt 语义 + dogfood
+- 本修复暂无 dogfood E2E 观察点记录
+
+## 对抗审查 Findings
+
+### Critical
+
+无。
+
+### Warning
+
+#### W1 —— A 类 producer-pause 3 行模板"产出：" 字样与禁令字面冲突（可读性陷阱）
+
+**定位**：`commands/workflow.md:245`（Step 6.1 A 类模板示例块）含字面 `产出：` 行；`commands/workflow.md:354` Step 7 新增条款禁 agent/skill 输出 `产出:` / `Outputs:` 自然语言清单。
+
+**风险**：LLM 在 prompt 内同时看到「A 类模板里 orchestrator emit 的 summary 含 `产出：`」与「skill/agent 禁输出 `产出:`」时，边界（谁 emit）并非每次都从上下文精准推断出来。某些 subagent 可能保守理解为"既然有 `产出：`字样就可以我也跟着写"或者"完全不碰这 2 字"，两种误读都偏离设计意图。
+
+**当前缓解**（已在 7 处 prompt 内强调）："orchestrator 从 `created:` 路径 + `description:` 生成用户可见 A 类 producer-pause summary，skill/agent 自带 summary 会与 orchestrator 生成重复"。语义已到位，但字面边界仍靠读者跨节对齐。
+
+**建议**（non-blocking）：在 workflow.md Step 6.1 A 类模板示例块或 Step 7 单一产出字段段落加一句"`产出：` 行由 orchestrator 基于 `created:` 自动生成；agent/skill final message 不得自行 emit 本行或等价自然语言清单"。
+
+#### W2 —— `log_entries.files[]` 与 `created[].path` 一致性谁校验未写清
+
+**定位**：`commands/workflow.md:354`（Step 7 新增条款，"`log_entries.files[]` 与之一致（Step 8）"）。
+
+**风险**：条款只声明"应当一致"，未声明校验时机与失配策略：
+- 是 orchestrator 每次 Step 8 flush 前做差集对比？
+- 失配时以哪边为准？（`created:` 是 INDEX 源 / `log_entries.files[]` 是 log.md 源 —— 两处落盘目标不同）
+- 失配时报错 / 警告 / union / 静默？
+
+潜在失配场景：角色新建 3 文件但 log_entries 只 union 了 2 条；或 log_entries 含已存在文件的 update 记录（`created:` 不列）。两种都算 "log.md 扩张 / INDEX 遗漏" 或反之。
+
+**建议**：Step 7 或 Step 8 任一节加一句 "orchestrator flush 前 union 两源；`created[]` 是新建文件权威、`log_entries.files[]` 可额外含 updates"，或明示"失配时以 created[] 为准，log_entries.files[] 补集仅写进 log.md 不入 INDEX"。目前解释由读者自行推导，中长期可能在并发派发场景踩坑。
+
+#### W3 —— 测试代码 vs 测试计划 的 `created:` 边界对 tester 未足够显式
+
+**定位**：`agents/tester.md:125`（"代码层面的测试新增不进 log_entries（归 git log）"）和 `agents/tester.md:127`（新条款）。
+
+**风险**：新条款禁 `产出:` 自然语言但没重申"测试代码不进 `created:`"这条既有边界。新手 LLM 读到"唯一机读产出字段是 `created:` YAML"可能把 `tests/` 下新测试文件也塞进 `created:`，污染 INDEX.md（INDEX 只识别 `docs/` 6 类 artifact，不识 `tests/`）。
+
+**当前缓解**：tester.md `## Resource Access` 「新建文件 description」走 orchestrator Step 7；`## 完成后` 第 2 条区分"代码层 vs 测试计划"；Step 7 `{docs_root}/` 6 类清单未列 `tests/`，orchestrator 侧有过滤可能性。
+
+**建议**（non-blocking）：tester.md 新条款改写 "**唯一**机读产出字段是 `created:` YAML（Step 7；**仅限 testing 文档等 `{docs_root}/` 产出，不含 `tests/` 代码**）"。其他 4 agent 无此二义性。
+
+#### W4 —— 向后兼容：既有 design-doc 的 `## 产出` section 是否被误伤
+
+**定位**：实况扫描 `docs/design-docs/phase-transition-rhythm.md:64` 含 `产出：` 字样（文档正文内的设计说明，不是 final message）。
+
+**风险**：新条款字面 "禁止在 final message 额外输出 `产出:` / `Outputs:` 自然语言文件清单"。作用域限定短语是 "final message"，理论上不应波及落盘文档正文。但：
+
+1. 某些 LLM 在本次派发中**同时**写 design-doc 正文**与**输出 final message 时，可能保守把正文里也去掉 `产出:` 字样（过度合规）
+2. 历史文档正文的 `产出:`（如 phase-transition-rhythm.md:64）会不会在下次 architect 迭代时被当"存量违规"误删
+
+**当前缓解**：7 处新增条款全部带 "final message" 作用域限定词。语义正确。
+
+**建议**：若未来出现 LLM 过度合规删除文档正文 `产出:`，加一句"仅限 final message stdout；落盘文档正文的 `## 产出` / `产出：` 段落属业务内容，不受本条款约束"。本轮可不加，留作 follow-up。
+
+### Suggestion
+
+#### S1 —— 7 处表述基本一致，微调可更统一
+
+**定位**：7 处新增条款措辞对比：
+
+- architect/analyst skill：`**禁止**在 final message 额外输出 ... —— orchestrator 会从 ...`
+- developer/tester/reviewer/dba agent：`**禁止**额外输出 ... —— orchestrator 生成用户可见 summary，subagent 自带 summary 重复浪费 token`（developer tester 多一句 "浪费 token"；reviewer/dba 少"浪费 token"）
+
+发现细差：developer.md:118 尾句 "subagent 自带 summary 重复浪费 token"；tester 同；reviewer/dba 无。analyst/architect skill 句尾 "skill 本层自带 summary 会与 orchestrator 生成重复"。
+
+**建议**：统一尾句风格（可保留 skill vs agent 差异但同类内部一致）。nit，不阻塞。
+
+#### S2 —— `commands/workflow.md:354` 条款位置可再优化
+
+**定位**：Step 7 末段新条款 "**单一产出字段原则**（issue #29）"。
+
+**观察**：条款置于 Step 7 Index Maintenance 尾、Fallback 句之前。语义与 Step 7 主旨（INDEX 维护）部分相关但跨越到 final message 规范；放 Step 8（log.md batching）之前做桥段落也合理。
+
+**建议**：当前位置可接受；未来如果 Step 7/8 之间出现更多跨节约束，考虑抽一个独立 §Step 7.5 或 Final Message Schema 段。nit。
+
+#### S3 —— 缺 dogfood E2E 观察点清单
+
+**定位**：`docs/log.md:24`（fix-rootcause entry 验证段）写"后续 /roundtable:workflow 派发观察 final message 应不再含 `产出:` 段"但没具体观察清单。
+
+**建议**：follow-up 补一条观察点：
+- O1：架构/分析 skill 在 Stage 3/2 收尾 `log_entries:` + `created:` YAML 后是否还跟自然语言 `产出:` 段
+- O2：developer/tester/reviewer/dba subagent final report 头部摘要段是否省掉 `产出:` 行
+- O3：orchestrator A 类 producer-pause 3 行 summary 是否正确从 `created:` 自动生成（不是 skill/agent 自写）
+- O4：测试 tester 派发后 INDEX.md 不意外多出 `tests/` 条目（W3 相关）
+
+可写 `docs/testing/dedupe-produce-created.md` §观察点 或 log.md append。
+
+### Positive
+
+- **P1**：修复遵守 producer-pause 既有边界（不动 orchestrator A 类模板本身；agent/skill 单向约束；orchestrator 从 `created:` 生成仍合约）
+- **P2**：7 处措辞均含 "final message" 作用域限定词，正确限制副作用不波及文档正文
+- **P3**：新条款全部引 issue #29 便追溯；与 Step 7 `created:` 契约 / Step 8 `log_entries:` 契约 cross-ref 清晰
+- **P4**：lint 0 命中，未引入硬编码外部名 / 路径
+- **P5**：`docs/log.md` fix-rootcause entry `tier=1` 格式齐全（操作者 / 影响文件 / 分析三段），遵守 DEC-014
+
+## 矛盾 / 兼容性检查
+
+### 与 DEC-006 producer-pause A 类 3 行模板
+- 模板 `产出：` 行由 orchestrator emit，不归 agent/skill；新条款限定 "skill/agent final message 不得自行输出"，**语义兼容**
+- 字面层的"字 `产出：` 出现在 workflow.md 内部两处"可能读者混淆见 W1
+
+### 与 DEC-009 log_entries `files:` union 规则
+- log_entries.files[] 是 log.md flush 源；created[] 是 INDEX.md flush 源
+- 新条款声明两者应一致 —— 互补非冗余，**语义兼容**，校验细节见 W2
+
+### 与 DEC-014 fix-rootcause entry 格式
+- log.md:17-24 entry 格式遵守 tier=1（无 tier=2 postmortem 引用），**兼容**
+
+### 与 DEC-013 decision_mode text
+- 不涉及（新条款纯 final message 产出规范，不改 `<decision-needed>` emit 路径）
+
+## 结论
+
+- **可合并**（未发现 Critical 或 Warning 阻塞项）
+- 4 个 Warning 均为语义边界澄清 / 向后兼容 nit，均可 follow-up issue 吸收
+- 强烈建议至少处理 W1（A 类模板 `产出：` 字面冲突一句话注释）与 W2（一致性校验规则一句话澄清）—— 两项在下次 A 类转场派发前易被 LLM 误读，合并至本 PR 成本 <2 行
+
+## 变更记录
+
+- 2026-04-21 tester 对抗审查 —— 0 Critical / 4 Warning (W1-W4) / 3 Suggestion (S1-S3) / 5 Positive (P1-P5)；结论可合并，建议至少吸收 W1+W2

--- a/skills/analyst/SKILL.md
+++ b/skills/analyst/SKILL.md
@@ -170,3 +170,5 @@ created: YYYY-MM-DD
 ## 完成后
 
 不直接写 log.md —— in-session output 末尾 `log_entries:` YAML 上报（`prefix: analyze`），orchestrator 按 Step 8 flush。
+
+**Final message 输出规范**（issue #29）：**唯一**机读产出字段是 `created:` YAML（Step 7 契约）+ `log_entries:` YAML（Step 8 契约）。**禁止**额外输出 `产出:` / `Outputs:` 自然语言文件清单 —— orchestrator 会从 `created:` 路径生成用户可见 summary，skill 本层自带 summary 会与 orchestrator 生成重复。

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -219,6 +219,7 @@ status: Active
 
 - 新决策 → 追加 `{docs_root}/decision-log.md`（直写；置顶 / 最新在前；DEC 是 architect 权威源；详见下面 "decision-log 条目顺序约定"）
 - 不直接写 log.md —— `log_entries:` YAML（`prefix: analyze | design | decide | exec-plan`）上报；同轮多文档合并为一条 entry；orchestrator 按 Step 8 flush
+- **Final message 输出规范**（issue #29）：**唯一**机读产出字段是 `created:` YAML（Step 7 契约）+ `log_entries:` YAML（Step 8 契约；`log_entries.files[]` 与 `created[].path` 一致）。**禁止**在 final message 额外输出 `产出:` / `Outputs:` / 任何自然语言版文件清单 —— orchestrator 会从 `created:` 路径 + `description:` 生成用户可见的 A 类 producer-pause 3 行 summary；skill 本层自带 summary 会与 orchestrator 生成重复。
 - 冲突时列 diff 等用户裁决，绝不默默覆盖
 
 ### decision-log 条目顺序约定（DEC-011）


### PR DESCRIPTION
## Summary

P2 bug — architect/analyst/developer/tester/reviewer/dba emitted both `产出:` free-form list **and** `created:` YAML schema for the same file set. Token bloat + orchestrator parse divergence risk.

## Fix

Add "Final message 输出规范" directive to 6 skill/agent prompts + `commands/workflow.md` Step 7 contract:

- `created:` YAML is the **single machine-readable source** for new-file paths
- `log_entries.files[]` may additionally include **modified** files (complement, not duplicate: `created[]` → INDEX.md / `log_entries.files[]` → log.md)
- Step 6.1 A-class template `产出：` line is **orchestrator-generated** (from `created[].path` + `description`) — agents/skills forbidden to self-write
- `tests/*` / `src/*` code files never go into `created:` (INDEX.md recognizes `docs/` only)

## Scope

9 files, +252 lines (incl. tester + reviewer reports). No DEC change. critical_modules hit: skill/agent/command prompt body (7 prompt files touched).

## Quality gates

- **tester**: 0 Critical / 4 Warning (W1/W2/W3 Step 7 clarity + W4 backward compat nit) / 3 Suggestion / 5 Positive; lint 0 hits
- **W1/W2/W3 inline post-fix**: orchestrator-vs-agent 归属 明示 / `created[]` vs `log_entries.files[]` 互补规则 / `tests/*` `src/*` 边界
- **reviewer**: **Approve**, 0 Critical / 0 new Warning / 2 Suggestion (follow-up); compatible with DEC-006 / 009 / 013 / 014
- **lint**: 0 hits

## Test plan

- [x] Lint 0
- [x] Adversarial review (tester)
- [x] Independent review (reviewer)
- [ ] Dogfood next workflow run — agent final message no longer contains `产出:` section

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)