### PR TITLE
feat(workflow): FAQ sink protocol — auto-persist mechanism Q&A (#27)

### DIFF
--- a/commands/bugfix.md
+++ b/commands/bugfix.md
@@ -21,6 +21,8 @@ argument-hint: <bug 描述 或 issue 编号>
 
 **Phase & audit forwarding**：沿用 `commands/workflow.md` Step 5b 完整规则（DEC-013 §3.1a 扩展 / issue #48）—— active channel 下 context detection 结果（a）/ role completion digest（c）/ C 类交接（d）/ auto_mode 4 audit 事件（e）强制同步转发，`markdownv2` 结构化。**事件类 b（A 类 producer-pause）不适用 bugfix**（bugfix 流程无 A 类 pause）。详见 `docs/design-docs/tg-forwarding-expansion.md`。
 
+**FAQ sink**：沿用 `commands/workflow.md` Step 0.5 完整规则（issue #27）—— 用户直接问 roundtable 机制类问题时 orchestrator 自动沉淀到 `{docs_root}/faq.md`。
+
 ## Step 0: Project Context Detection
 
 **inline 执行 4 步检测**：`Read` `${CLAUDE_PLUGIN_ROOT}/skills/_detect-project-context.md` 并按 4 步执行（D9 → toolchain → docs_root → CLAUDE.md 加载）。**不用 `Skill` 工具**。

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -64,6 +64,59 @@ argument-hint: <task description>
 
 **转发**：active channel 下按 Step 5b 事件类 a 转发检测结果块（``` 围栏零转义）。
 
+## Step 0.5: FAQ Sink Protocol（issue #27；常驻规则，在 Step 0 之后激活）
+
+> **位置说明**（C1 修复）：本 step 虽按编号紧随 Step 0，但语义上是 **session 生命期常驻规则**，而非"执行一次"的 bootstrap。`{docs_root}` / `target_project` 必须由 Step 0 先填充，本 step 在**首次用户机制提问**到达时才激活；Step 0 完成前的任何提问**延后 sink**（先回答，等 Step 0 完成后再追加）。
+
+用户**直接提问**（非 `<escalation>` / 非 A 类菜单 `问:` / 非 skill 阶段调研）涉及 roundtable 机制时，orchestrator 回答后**自动追加** Q&A 到 `{docs_root}/faq.md`（不存在则创建 minimal header；`<project>` 字面值 = `basename(target_project)`，例如 `/data/rsw/roundtable` → `roundtable`）：
+
+```
+# <project> FAQ
+
+> 机制 / 概念 / 决策类问答沉淀。slug 级 FAQ 在各 analyst/design-docs ## FAQ 段，与本全局 FAQ 互补。
+
+---
+```
+
+**Sink 触发**（白名单启发式；用户命令覆盖；大小写不敏感匹配）：
+- **roundtable 专有术语**命中（任一）：`orchestrator` / `phase matrix` / `DEC-\d+` (regex) / `auto_mode` / `decision_mode` / `escalation` / `producer-pause` / `approval-gate` / `verification-chain` / `critical_modules` / `Resource Access` / `roundtable` / `roundtable:(architect|analyst|developer|tester|reviewer|dba)` / slug 级 DEC 名如 `DEC-015` / Step 编号如 `Step 5b` / `§3.1a`
+- **中文通用词**（`机制` / `流程` / `阶段` / `决策` / `工作流`）**必须**与上述专有术语**同句**共现才触发（避免 target 项目业务语境误伤）
+- 用户显式 `加入 FAQ` / `沉淀到 FAQ` / `add to FAQ` / `add faq` → 强制 sink（**前提**：该问仍属 roundtable 机制类；纯业务问题即使命令强制也拒绝并回 `此提问非 roundtable 机制类，未 sink；可改写为 mechanism 化表述`，W4）
+- 用户显式 `别沉淀` / `skip FAQ` / `don't FAQ` / `no faq` → 强制跳过
+- **冲突解析**：同一消息同时含强制 sink + 强制 skip 命令 → **`skip` 胜出**（保守；用户可后续手动 `加入 FAQ`）
+
+**Sink 不触发**：target 项目代码 debug / 特定错误定位 / 用户偏好讨论 / 纯闲聊 / 一次性对话 / A 类 `问:` 前缀（走 menu 循环路径到 analyst slug FAQ，DEC-006 §A）。
+
+**A 类 menu 激活期间裸问机制题**（用户无 `问:` 前缀）：Step 0.5 优先 —— 回答 + sink global FAQ，**不**进入 menu 循环（menu 循环专属 `问:` 前缀用户意图）。回答完 orchestrator 重 emit 原 A 类 menu（DEC-006 §A 菜单穷举）。
+
+**去重算法**（F1 澄清）：
+1. 追加前 `Read` `{docs_root}/faq.md`（若存在）
+2. **Tokenize**：Q 标题 lowercase + 按 `[\s\p{P}]+` split（中英混合同款，中文按字符粒度留存，英文按空格，标点剔除）
+3. **Bag-of-words Jaccard 相似度**：`|A ∩ B| / |A ∪ B|`（两个 Q 的 token 集合）
+4. **≥ 0.7** → 判重复，**不追加**，改在回复末尾 ref 已有 § 锚点
+5. 同义词（如 `orchestrator` vs `编排器`）不在本简化算法范围；follow-up 若误判率高可扩词典
+
+**条目格式**：
+
+```
+## Q: <简化问题 ≤80 字符>
+**提问于**：YYYY-MM-DD session
+**类别**：[roundtable 机制 | Phase Matrix | DEC-xxx | ...]
+
+<answer ≤500 字；超长引 docs/... 路径>
+
+---
+```
+
+**回复末尾标注**：
+- Sink 触发 → 加一行 `📚 已追加到 {docs_root}/faq.md § Q: <简化标题>`
+- 去重命中 → `📚 已有相关条目见 {docs_root}/faq.md § Q: <锚点>`
+
+**`log_entries:` 上报**：orchestrator 自造 `prefix: faq-sink` / `slug: faq-sink` / `files: [{docs_root}/faq.md]` / `note: Q-<简化> sunk`。新前缀 `faq-sink` 追加到 `docs/log.md` §前缀规范白名单（expected 一次性动作）。
+
+**与 A 类 `问:` 区别**：A 类 menu 的 `问: ...` 触发 skill 回派答 FAQ 后**返回菜单循环**（DEC-006 §A），FAQ 条目走 **analyst slug 级** `## FAQ`（analyst 报告内）；本 Step 0.5 是 **非 A 类 menu 的** 直接提问，走 **global `{docs_root}/faq.md`**。两者互补不冲突。
+
+
 ## Step 1: 任务规模判定
 
 | 规模 | 信号 | Pipeline |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,6 +24,7 @@
 |------|-----|
 | [decision-log.md](decision-log.md) | **项目决策权威注册表**（DEC-xxx），append-only |
 | [log.md](log.md) | 设计层文档时间索引（"何时、谁、动了哪份文档"） |
+| [faq.md](faq.md) | 全局 FAQ 沉淀（orchestrator 按 `commands/workflow.md` Step 0.2 自动追加机制类 Q&A；issue #27） |
 | [../CHANGELOG.md](../CHANGELOG.md) | 发布面 changelog（Keep a Changelog 格式 + SemVer） |
 | [../CONTRIBUTING.md](../CONTRIBUTING.md) | 贡献指南 + 本地测试清单 |
 
@@ -64,6 +65,7 @@
 - [workflow-auto-execute-mode.md](design-docs/workflow-auto-execute-mode.md) — issue #33 `/roundtable:workflow --auto` 批量预授权 A/B 类 gate 自动采纳 recommended（CLI+env 两级优先链 / recommended 缺失强停 / #30 正交 / 4 agent 零改动），DEC-015 Accepted
 - [tg-forwarding-expansion.md](design-docs/tg-forwarding-expansion.md) — issue #48 DEC-013 §3.1a 转发语义扩展到 5 类 orchestrator-emitted 事件（context / producer-pause / role digest / C handoff / auto_mode audit；orchestrator-only 落点；markdownv2 结构化 TG 可读性增强），append-only clarification
 - [phase-end-approval-gate.md](design-docs/phase-end-approval-gate.md) — issue #30 phase-end approval gate 统一协议（A 类 producer-pause 菜单穷举 + Q&A 循环 + architect `go-with-plan` / `go-without-plan: <理由>` 拆分；orchestrator + 2 skill 落点），DEC-006 §A append-only clarification
+- [faq-sink-protocol.md](design-docs/faq-sink-protocol.md) — issue #27 FAQ 沉淀协议（orchestrator 启发式触发 + `{docs_root}/faq.md` 全局落点 + 70% 词重叠去重 + 📚 回复标注；与 slug 级 FAQ 互补）
 
 **Plugin 内部 include-only helper**（下划线前缀约定；非独立可激活 skill；不在用户向 skill 清单露出）：
 
@@ -94,6 +96,7 @@
 - [tg-forwarding-expansion.md](testing/tg-forwarding-expansion.md) — issue #48 DEC-013 §3.1a 扩展对抗性 prompt 审查（1 Critical F13 措辞 + 7 Warning + 4 Suggestion + 2 Positive；post-fix inline 修 F13+F1/F2/F3/F4/F5/F10；F8/F9/F12/F14 follow-up；lint 0 命中）
 - [phase-end-approval-gate.md](testing/phase-end-approval-gate.md) — issue #30 phase-end approval gate 对抗审查（2 Critical F1/F2 + 4 Warning F3-F6 + 4 Suggestion + 2 Positive；post-fix inline 修 F1-F6；F7-F10 follow-up；lint 0 命中）
 - [reviewer-write-permission.md](testing/reviewer-write-permission.md) — issue #23 reviewer/tester/dba Write 权限明示对抗审查（1 Critical F4 兜底 contract + 3 Warning + 2 Suggestion + 3 Positive；post-fix 修 F4/F1/F5；F3 follow-up；lint 0）
+- [faq-sink-protocol.md](testing/faq-sink-protocol.md) — issue #27 FAQ sink protocol 对抗审查（2 High F1/F2 + 4 Medium F3-F6 + 5 Low F7-F11；post-fix 修 F1-F6；F7-F11 follow-up；lint 0）
 
 ### reviews
 
@@ -108,6 +111,7 @@
 - [2026-04-21-tg-forwarding-expansion.md](reviews/2026-04-21-tg-forwarding-expansion.md) — issue #48 DEC-013 §3.1a 扩展终审（Approve-with-caveats；0 Critical / 1 Warning W1 / 3 Suggestion R1-R3；tester post-fix 7 项全实质修复；验收 8/8；合入后跟进 R1+R2）
 - [2026-04-21-dedupe-produce-created.md](reviews/2026-04-21-dedupe-produce-created.md) — issue #29 dedupe 产出/created 终审 (Approve；tester W1-W3 实质吸收；W4+S1-S3 follow-up)
 - [2026-04-21-reviewer-write-permission.md](reviews/2026-04-21-reviewer-write-permission.md) — issue #23 reviewer/tester/dba Write 权限明示终审 (Approve-with-caveats；0 Critical / 3 Warning / 3 Suggestion / 5 Positive；自举 dogfood Step 7 兜底；F3 sentinel-vs-escalation follow-up issue 建议创建)
+- [2026-04-21-faq-sink-protocol.md](reviews/2026-04-21-faq-sink-protocol.md) — issue #27 FAQ sink protocol 终审 (Approve-with-caveats；C1 Step 0.2→0.5 位置修复 + W1-W5 inline / S2/S4 inline；W3/S1/S3 follow-up；自举 dogfood Step 7 兜底 ×2)
 
 ### bugfixes
 

--- a/docs/design-docs/faq-sink-protocol.md
+++ b/docs/design-docs/faq-sink-protocol.md
@@ -1,0 +1,144 @@
+---
+slug: faq-sink-protocol
+source: 原创（issue #27）
+created: 2026-04-21
+status: Draft
+decisions: []
+---
+
+# FAQ 沉淀协议 设计文档
+
+## 1. 背景与目标
+
+### 1.1 背景
+
+issue #27（P2 bug）：用户在 roundtable session 直接问系统机制（如"orchestrator 是什么？机制说明下"），orchestrator 当场完整回答但**未沉淀**到 FAQ。每次新会话需重新解释；知识无法积累。
+
+### 1.2 目标
+
+1. orchestrator 在回答**机制类 / 概念类 / 决策类**问题后，**自动追加** Q&A 到 `{docs_root}/faq.md`
+2. 在回复末尾显式告知用户"已追加到 `docs/faq.md`"
+3. 新会话通过 `{docs_root}/faq.md` 复用积累的知识（类似 CLAUDE.md 加载后作为 context）
+
+### 1.3 非目标
+
+- 不沉淀：用户项目代码 debug / 特定错误定位 / 一次性对话
+- 不改 analyst 的 `## FAQ` section 机制（analyst slug 级 FAQ 与本 global FAQ 互补，不合并）
+- 不改 design-docs 的 `## 5. 讨论 FAQ`（slug 级，同样互补）
+- 不自动 load `{docs_root}/faq.md` 到 session（避免大量历史 FAQ 污染每次 session context；用户可手动 `/roundtable:workflow 参考 docs/faq.md: Q xxx` 显式引用）
+
+## 2. 关键决策与权衡
+
+### 2.1 D1：FAQ 落点
+
+**选择**：**`{docs_root}/faq.md`**（target 项目根目录级）
+
+备选：
+- `docs/faq.md`（plugin 仓库级）—— 不可取：对 target 项目无用
+- analyst / architect slug 级 `## FAQ` 扩展 —— 对非 slug 绑定问题无位置
+- target `CLAUDE.md` 扩 FAQ section —— 污染 CLAUDE.md，违反"只写多角色工作流配置"边界
+
+### 2.2 D2：触发判定
+
+**选择**：orchestrator **启发式 + 白名单**触发
+
+- **触发**：提问涉及 plugin 机制 / Phase Matrix / DEC / auto_mode / decision_mode / escalation / workflow stage / Resource Access / critical_modules / roundtable 术语
+- **不触发**：target 项目代码 debug、一次性错误定位、用户自身偏好讨论、纯闲聊
+- 用户显式命令 `加入 FAQ` / `沉淀到 FAQ` → 强制触发（覆盖启发式）
+- 用户显式 `别沉淀` / `skip FAQ` → 强制跳过
+
+### 2.3 D3：Q&A 格式
+
+```markdown
+## Q: <用户原问，≤80 字符简化>
+
+**提问于**：2026-04-21 session
+**类别**：[roundtable 机制 | Phase Matrix | DEC-013 | auto_mode | ...]
+
+<orchestrator 回答，≤500 字；超长引 `docs/design-docs/...` 路径>
+
+---
+```
+
+### 2.4 D4：去重（Bag-of-words Jaccard）
+
+orchestrator 追加前 `Read` `{docs_root}/faq.md`（若存在），按 `commands/workflow.md` Step 0.5 去重算法：Q 标题 lowercase + `[\s\p{P}]+` split + bag-of-words Jaccard 相似度 `|A∩B| / |A∪B|` ≥ 0.7 → 判重不追加，回复末尾 ref 已有 § 锚点。同义词（中英 / 缩略）不在简化算法范围，follow-up 词典。
+
+## 3. 技术实现
+
+### 3.1 `commands/workflow.md` 顶部新增 Step 0.2: FAQ Sink Protocol
+
+```
+## Step 0.2: FAQ Sink Protocol（issue #27）
+
+用户直接提问（非 `<escalation>` / 非 A 类菜单 `问:` / 非 skill 阶段调研）涉及 roundtable 机制 / Phase Matrix / DEC / auto_mode / decision_mode / escalation / workflow stage / Resource Access / critical_modules / 术语时，orchestrator 回答后**自动追加** Q&A 到 `{docs_root}/faq.md`（不存在则创建含 minimal header：`# <project> FAQ\n\n> 机制 / 概念 / 决策类问答沉淀。slug 级 FAQ 在各 analyst/design-docs ## FAQ 段。\n\n---\n`）。
+
+**Sink 条件**（白名单触发；用户命令可覆盖）：
+- 提问关键词命中 roundtable 术语 / plugin 机制 / DEC / 阶段名
+- 用户显式 `加入 FAQ` / `沉淀到 FAQ` → 强制沉淀
+- 用户显式 `别沉淀` / `skip FAQ` → 跳过
+
+**Sink 不触发**：target 项目代码 debug / 一次性错误 / 用户偏好讨论 / 闲聊。
+
+**去重**：追加前 Read 已有 faq.md，≥70% 词重叠的 Q 不重复追加，改在回复末尾 ref 已有 § 锚点。
+
+**条目格式**：
+```
+## Q: <简化问题 ≤80 字符>
+**提问于**：YYYY-MM-DD session
+**类别**：[roundtable 机制 | Phase Matrix | DEC-xxx | ...]
+
+<answer ≤500 字；超长引 docs/...>
+
+---
+```
+
+**回复末尾标注**：Sink 触发 → 加一行 `📚 已追加到 {docs_root}/faq.md § Q: <简化标题>`；去重命中 → `📚 已有相关条目见 {docs_root}/faq.md § Q: <锚点>`。
+
+**`log_entries:` 上报**：orchestrator 自造 `prefix: faq-sink` / `slug: faq-sink` / `files: [{docs_root}/faq.md]` / `note: Q-<简化> sunk`（新前缀 `faq-sink` 追加到 `docs/log.md` §前缀规范；正文以 `commands/workflow.md` Step 0.5 为权威）。
+```
+
+### 3.2 `commands/bugfix.md` 继承
+
+bugfix.md Step -1 末尾加 1 行 ref：`**FAQ sink**：沿用 workflow.md Step 0.2`。
+
+### 3.3 落点清单
+
+| 文件 | 改动 |
+|------|------|
+| `commands/workflow.md` | 新增 Step 0.2 FAQ Sink Protocol（~15 行） |
+| `commands/bugfix.md` | Step -1 末尾 +1 行 ref |
+| `docs/design-docs/faq-sink-protocol.md` | 新建本文件 |
+| `docs/faq.md` | 新建 minimal header（首轮 dogfood 时被 sink 填充） |
+| `docs/INDEX.md` / `docs/log.md` | 同步 |
+
+**不改**：5 agent / 2 skill（FAQ sink 纯 orchestrator 动作）/ DEC / target CLAUDE.md 边界。
+
+## 4. 影响范围
+
+- 运行时：TG/terminal session 提问 roundtable 机制类问题后，orchestrator 多 1 次 Edit faq.md，延迟 ~1s
+- 与 DEC-006 §A producer-pause `问: ...`：不冲突 —— A 类 `问:` 是 phase-end menu 子选项（skill 回派回答 + FAQ 追加到 analyst slug 级 FAQ），本协议是 **非 A 类 menu 的** 直接提问
+
+## 5. 测试策略
+
+| 场景 | 期望 |
+|------|------|
+| 用户问 "orchestrator 是什么" | 回答 + sink 到 `docs/faq.md` + 回复末尾 📚 |
+| 用户问 "我这段代码 bug 在哪" | 回答 + **不** sink |
+| 用户重复问已在 FAQ 的机制问题 | 回答 + 去重命中提示 |
+| 用户 `加入 FAQ` 显式命令 | 强制 sink 即使启发式未命中 |
+| 用户 `skip FAQ` 显式命令 | 跳过 |
+| `{docs_root}/faq.md` 不存在 | orchestrator 创建 minimal header + 追加 |
+| bugfix session 同款问题 | 沿用 workflow Step 0.2 行为 |
+
+## 6. 变更记录
+
+- 2026-04-21 初版（issue #27，Draft）
+- 2026-04-21 post-fix（tester F1 High + F2 High + F3/F4/F5/F6 Medium 合并 inline）：
+  - F1（70% dedupe 算法）：明示 Jaccard bag-of-words，token 按 `[\s\p{P}]+` split，中英混合同款
+  - F2（`<project>` 填充）：orchestrator 用 `basename(target_project)` 填充
+  - F3（A 类 menu 裸问）：Step 0.2 优先，机制类裸问走 global FAQ sink + 回 menu，不进 `问:` 循环
+  - F4（log prefix）：新增 `faq-sink` 前缀到 `docs/log.md` §前缀规范
+  - F5（命令识别）：大小写不敏感 + `skip` vs `add` 冲突时 `skip` 胜
+  - F6（白名单漂移）：中文通用词（机制 / 流程 / 阶段 / 决策 / 工作流）**必须与 roundtable 专有术语同句共现**才触发
+  - F7-F11 Low 归 follow-up（design-doc §3.3 `{docs_root}` vs `docs` 已在 §3.3 原文就用 `{docs_root}`，F7 属 tester 读错 / GFM slug link / 并发锁 / TG 转发 / faq.md 归档策略）

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,6 @@
+# roundtable FAQ
+
+> 机制 / 概念 / 决策类问答沉淀。slug 级 FAQ 在各 analyst/design-docs `## FAQ` 段，与本全局 FAQ 互补。
+> 由 orchestrator 按 roundtable FAQ Sink Protocol 自动追加；用户可手动编辑修订。
+
+---

--- a/docs/log.md
+++ b/docs/log.md
@@ -23,6 +23,26 @@
     修复：7 处 prompt inline 加"Final message 输出规范"条款，明示 `created:` 是唯一机读源；workflow.md Step 7 契约补"单一产出字段原则"。orchestrator 端从 `created:` 自动生成 A 类 producer-pause summary，skill/agent 不再自带。
     验证：lint 0 命中；后续 /roundtable:workflow 派发观察 final message 应不再含 `产出:` 段。
 
+## review | faq-sink-protocol | 2026-04-21
+- 操作者: reviewer (subagent, fg; critical_modules 命中 → 必落盘；orchestrator relay due to subagent Write unavailable — Step 7 兜底第二次 dogfood)
+- 影响文件: docs/reviews/2026-04-21-faq-sink-protocol.md (new, orchestrator relay)
+- 说明: issue #27 终审 Approve-with-caveats —— C1 Step 0.2→0.5 位置修复 + W1/W2/W4/W5 + S2/S4 全 inline 修 / W3/S1/S3 follow-up；DEC-006/013/014/015/002/009 一致；自举验证 Step 7 兜底 contract 稳定（第二次 dogfood）
+
+## test-plan | faq-sink-protocol | 2026-04-21
+- 操作者: tester (subagent, fg; critical_modules 命中 → 必落盘)
+- 影响文件: docs/testing/faq-sink-protocol.md (new)
+- 说明: issue #27 FAQ sink protocol 对抗审查 —— 2 High (F1 70% dedupe 算法未指定 / F2 `<project>` 填充规则未定义) + 4 Medium (F3 A 类 menu 裸问歧义 / F4 log prefix 语义过载 / F5 命令识别大小写冲突 / F6 白名单中文通用词漂移) + 5 Low follow-up；lint 0 命中
+
+## fix | faq-sink-protocol | 2026-04-21
+- 操作者: orchestrator (inline post-fix)
+- 影响文件: commands/workflow.md (Step 0.2→0.5 位置移到 Step 0 后 + 位置说明段 + F1 Jaccard 算法 + F2 basename 填充 + F3 A 类裸问消歧 + F4 faq-sink 新前缀 + F5 命令识别规则 + F6 中文通用词共现约束 + W4 强制 sink 机制类前提); commands/bugfix.md (ref Step 0.5); docs/design-docs/faq-sink-protocol.md (§2.4 / §3.1 / §6 同步 post-fix); docs/log.md (§前缀规范 +faq-sink 行); docs/faq.md (头部 ref 泛化 S2)
+- 说明: tester 2 High + 4 Medium 合并 post-fix；reviewer C1 + W1-W5 + S2/S4 合并 post-fix；W3/S1/S3 归 follow-up
+
+## design | faq-sink-protocol | 2026-04-21
+- 操作者: architect (inline; bugfix-level, no full architect phase)
+- 影响文件: docs/design-docs/faq-sink-protocol.md (new); docs/faq.md (new, minimal header); commands/workflow.md (Step 0.2 新增); commands/bugfix.md (+1 行 ref); docs/INDEX.md (append design-docs + 决策与索引 faq.md 导航)
+- 说明: issue #27 P2 bug —— 用户直接问 roundtable 机制类问题 orchestrator 回答后未沉淀 FAQ。协议：白名单关键词启发式触发 + `{docs_root}/faq.md` 全局落点（不存在则创建 minimal header，`<project>` = basename(target_project)）+ Jaccard bag-of-words ≥0.7 去重 + 📚 回复标注 + `log_entries:` 自造 `prefix: faq-sink` slug `faq-sink` + 用户命令覆盖（加入 FAQ / 别沉淀，冲突时 skip 胜出，加入 FAQ 仍需机制类前提 W4）；与 DEC-006 §A `问:` 菜单循环正交；Step 0.5 位置已从 bootstrap 区调整到 Step 0 之后（C1 修复）；纯 orchestrator 动作不动 5 agent / 2 skill / target CLAUDE.md
+
 ## review | reviewer-write-permission | 2026-04-21
 - 操作者: reviewer (subagent, fg; critical_modules 3/3 命中 → 必落盘；orchestrator relay due to subagent Write unavailable — Step 7 兜底 dogfood)
 - 影响文件: docs/reviews/2026-04-21-reviewer-write-permission.md (new, orchestrator relay)
@@ -257,6 +277,7 @@
 | `lint` | 健康检查发现的问题及处理 | `lint \| 3 issues found \| 2026-04-17` |
 | `fix` | 裁决冲突后的修复 | `fix \| DEC-xxx updated \| 2026-04-17` |
 | `fix-rootcause` | bug 根因结构化 entry（Tier 1/2，DEC-014） | `fix-rootcause \| some-bug \| 2026-04-20` |
+| `faq-sink` | orchestrator 自动沉淀机制类 Q&A 到 `{docs_root}/faq.md`（issue #27） | `faq-sink \| faq-sink \| 2026-04-21` |
 
 ## 条目格式
 

--- a/docs/reviews/2026-04-21-faq-sink-protocol.md
+++ b/docs/reviews/2026-04-21-faq-sink-protocol.md
@@ -1,0 +1,70 @@
+---
+slug: faq-sink-protocol
+source: issue #27 P2 bug fix
+reviewer: roundtable:reviewer (orchestrator relay due to subagent Write unavailable — Step 7 兜底)
+created: 2026-04-21
+judgment: Approve-with-caveats (after C1 inline fix)
+---
+
+# Review: FAQ Sink Protocol (issue #27)
+
+## Critical
+
+**C1（已 inline 修复）** — `commands/workflow.md` — **Step 0.2 位置与 `{docs_root}` 依赖序错位**
+
+原 Step 0.2 位于 Step -1 与 Step 0 之间（line 54 vs Step 0 line 106），但 semantics 引用 `{docs_root}` / `target_project`，这两项由 Step 0 populate。实际修复：
+- rename Step 0.2 → **Step 0.5**
+- 物理位置 move 到 Step 0 之后（已用 Python 重排 lines）
+- 在 Step 0.5 开头加"**位置说明**（C1 修复）"段明示 standing rule 语义 + "Step 0 完成前的提问延后 sink"
+- `commands/bugfix.md` ref 同步 → Step 0.5
+
+## Warning
+
+**W1（已修）** — `docs/design-docs/faq-sink-protocol.md:65` §2.4 "grep 用户原问关键词 + ≥70% 词重叠" stale → 改 Jaccard bag-of-words + ref `commands/workflow.md` Step 0.5 权威
+
+**W2（已修）** — `docs/design-docs/faq-sink-protocol.md:98` §3.1 draft `prefix: analyze` stale → 改 `prefix: faq-sink` + 加"正文以 commands/workflow.md Step 0.5 为权威"
+
+**W3（follow-up）** — 同义词去重盲区（`orchestrator` vs `编排器`）留 follow-up 扩词典
+
+**W4（已修）** — 强制 sink 命令 (`add to FAQ`) 需机制类前提；纯业务问题即使强制也拒绝 + 引导改写
+
+**W5（已修）** — `docs/log.md:26` 条目说明 `prefix analyze slug faq-sink` 笔误 → 改 `prefix: faq-sink slug: faq-sink`
+
+## Suggestion
+
+**S1（follow-up）** — Tokenization 对 `DEC-\d+` / `Step \d+(\.\d+)?` 预归一化为原子 token
+
+**S2（已修）** — `docs/faq.md:4` 绝对路径 ref `commands/workflow.md Step 0.2` → 改泛化 "roundtable FAQ Sink Protocol"
+
+**S3（follow-up）** — slug `faq-sink` reserve 注释加到 §前缀规范
+
+**S4（已修）** — bugfix.md ref 同步 Step 0.5
+
+## 决策一致性
+
+- **DEC-006 §A**: **一致** —— A 类 `问:` 菜单循环专属显式 `问:` 前缀，裸问走 global FAQ + 回 menu，双路径互补
+- **DEC-013**: **一致** —— 与 decision_mode 正交
+- **DEC-014**: **一致** —— `faq-sink` 新前缀独立
+- **DEC-015**: **一致** —— orchestrator 自动动作非决策点，auto/manual 同款
+- **DEC-002 / DEC-009**: **一致** —— escalation 正交；log batching 沿用 Step 8 union/append
+
+## 积极项
+
+- **自举 dogfood Step 7 兜底（第二次）**：本次 reviewer runtime 再次未暴露 Write → Step 7 兜底 contract 再次触发 relay；F4 修复稳定有效
+- **critical_modules 命中判定准确** + 必落盘
+- **白名单关键词 + 中文通用词共现约束** 有效避免业务语境误伤（F6 修复心智正确）
+- **A 类 menu 互补规则清晰** (`问:` 前缀走 menu / 裸问走 Step 0.5)
+- **`faq-sink` 独立前缀** 避免 `analyze` 语义过载
+
+## 总结
+
+**判定：Approve-with-caveats** 合并前 C1 + W1/W2/W4/W5 + S2/S4 已 inline 修复。W3/S1/S3 归 follow-up。
+
+合入后跟进：
+1. 同义词去重扩词典（W3）
+2. Tokenization 原子化 DEC/Step 编号（S1）
+3. slug `faq-sink` reserve 注释（S3）
+
+## 变更记录
+
+- 2026-04-21 initial（reviewer + orchestrator relay）

--- a/docs/testing/faq-sink-protocol.md
+++ b/docs/testing/faq-sink-protocol.md
@@ -1,0 +1,207 @@
+---
+slug: faq-sink-protocol
+source: docs/design-docs/faq-sink-protocol.md
+created: 2026-04-21
+reviewer: tester (adversarial)
+---
+
+# FAQ Sink Protocol 测试计划
+
+## 1. 当前覆盖现状
+
+- design-doc §5 列 7 场景（用户常见路径）
+- 无自动化测试（纯 orchestrator prompt 行为，靠 dogfood session 验证）
+- `lint_cmd` 已覆盖硬编码扫描（0 命中）
+
+## 2. 规格模糊点（发现的潜在问题）
+
+下列 F-n 编号即 findings，final message 统一呼应。
+
+### F1 [High]：70% 词重叠去重算法未指定
+
+**位置**：`commands/workflow.md` Step 0.2 "去重" / design-doc §2.4。
+
+**问题**：仅说 "≥70% 词重叠"，未指定：
+- tokenization（whitespace split / 语素切分 / n-gram？）
+- 中英混合处理（`orchestrator` vs `编排器` 视为同词？）
+- 是否去停用词（"是" / "什么" / "的"）
+- stemming / case-folding（`DEC-013` vs `dec013`）
+- 集合算子（Jaccard / containment / cosine）
+
+**风险**：不同 session orchestrator 实现漂移；两轮同问一次判重复一次判新增，FAQ 冗余或漏沉淀。
+
+**建议**：明文指定 "按 whitespace + 标点 split，lower-case，去中英停用词（最小白名单），Jaccard ≥0.7" 或直接降级为 "`Read` FAQ 后由 orchestrator LLM 判断近似问题"（不定阈值，但约定语义 dedupe）。后者更实际。
+
+### F2 [High]：`<project>` 填充规则未定义
+
+**位置**：Step 0.2 "`# <project> FAQ`" minimal header 模板 / design-doc §3.1。
+
+**问题**：不存在 faq.md 时 orchestrator 创建 header，`<project>` 由谁填？
+- `target_project` basename？（dogfood 下是 `roundtable`，填出 `# roundtable FAQ` 合理）
+- CLAUDE.md 首行 `# <name>`？（不稳定，名字不一定是 project name）
+- 未定义 → 字面留 `<project>` 字符串（已 dogfood faq.md 手写头部绕过，但协议本身未闭合）
+
+**风险**：orchestrator 首次创建时可能写字面 `# <project> FAQ`，后续轮次难以修正。
+
+**建议**：明文 "取 `target_project` basename 作为 `<project>`"。
+
+### F3 [Medium]：白名单关键词与 A 类 menu `问:` 边界漂移
+
+**位置**：Step 0.2 "与 A 类 `问:` 区别" 段 / design-doc §4。
+
+**问题**：用户在 A 类 producer-pause 菜单阶段**不**用 `问:` 前缀直接问机制类问题 —— 走 Step 0.2 还是走 menu 循环？
+- 现规则：Step 0.2 触发条件是"非 A 类菜单 `问:`"，言外之意 A 类 menu 阶段的直接提问 **也** 走 Step 0.2
+- 但 DEC-006 §A 明确"菜单穷举 + 禁止 silent default"—— 用户未用 `问:` 前缀时 orchestrator 应提示菜单而非直接答
+
+**冲突**：A 类 menu 下用户裸问"auto_mode 啥意思"，orchestrator 应：(a) 按菜单穷举原则回"请用 `问: ...`"，还是 (b) 按 Step 0.2 直接答 + sink？
+
+**建议**：在 Step 0.2 增加一句 "A 类 producer-pause 菜单激活期间裸问仍走 menu；`问:` 前缀触发 analyst slug 级 FAQ，Step 0.2 只覆盖菜单未激活的直接提问"，或明确 Step 0.2 覆盖一切非 `问:` 裸问（含 menu 内）。两条路都可接受，关键是消歧。
+
+### F4 [Medium]：`log_entries.prefix = analyze` 语义过载
+
+**位置**：Step 0.2 "`log_entries:` 上报" / design-doc §3.1。
+
+**问题**：`analyze` 前缀按 `docs/log.md` 前缀规范专指 analyst 产出的研究报告 / `docs/analyze/*.md` 条目。FAQ sink 挂 `analyze` prefix 导致：
+- `log.md` 扫描 `analyze` 前缀的读者会误以为存在 analyst session
+- slug `faq-sink` 与 analyst slug 共用命名空间，未来 analyst 也做 FAQ 研究时碰撞
+
+**建议**：二选一：
+- (a) 新增前缀 `faq-sink` 到 `docs/log.md` §前缀规范 白名单
+- (b) 复用 `decide` 前缀（orchestrator 自身动作，贴近"决策 / 元操作"语义，虽也过载但好于 analyze）
+
+推荐 (a)；workflow.md Step 8 YAML 契约列表里也要加。**当前实现未动 log.md §前缀规范**，会触发 lint 告警（若 lint 扫 prefix enum）。
+
+### F5 [Medium]：用户命令识别的中英 / 大小写 / 部分匹配
+
+**位置**：Step 0.2 "用户显式 `加入 FAQ` / `沉淀到 FAQ` / `add to FAQ`" / `别沉淀` / `skip FAQ` / `don't FAQ`。
+
+**问题**：
+- `add` 单字（如 "add that to the doc"）是否触发？现规则字面匹配 `add to FAQ` 短语应不触发，但 orchestrator LLM fuzzy 可能激进
+- 大小写（`Skip FAQ` / `SKIP FAQ`）未明示不敏感
+- 中英混排（`加入 faq`、`add 到 FAQ`、`沉淀一下 faq`）边界模糊
+- 反例："不要总是加入 FAQ" —— 同时含 `加入 FAQ` 和 `不要`，冲突时取哪个？
+
+**建议**：明文 "大小写不敏感；两类命令共存时 skip 优先（conservative safer default）；fuzzy 判断但不过激，短语级而非单词级匹配"。
+
+### F6 [Medium]：白名单关键词覆盖漂移
+
+**位置**：Step 0.2 "提问关键词命中" 列表。
+
+**问题**：列出 9 个英文术语 + 5 个中文词。边界 case：
+- `stage` / `阶段` 命中"阶段"一词，但"我这个阶段要做什么"（询问自己业务的阶段）会误触发
+- `DEC-xxx` 命中，但 "DEC-013 的 option schema 怎么写" 与 "请帮我决定 X" 都含 "决"字语义不等
+- 未列：`dispatch` / `Task` / `Monitor` / `subagent` / `Resource Access`（实际列了）/ `lint_cmd` / `test_cmd` / `docs_root` / `target_project` / `slug` / `exec-plan` / `artifact`
+- 中文"机制"太宽，"降低延迟的机制是什么"（业务问题）会误触
+
+**风险**：假阳（业务问题被沉淀污染 FAQ）+ 假阴（plugin 术语未在列表漏沉淀）。
+
+**建议**：规则改"白名单启发式 + LLM 语义判断兜底"，显式说"上下文是 roundtable plugin 机制 / workflow orchestration / DEC / Phase Matrix / agent-skill 架构 等，**target 项目业务语义不算**"；keyword 列表仅作 hint 非硬判。
+
+### F7 [Low]：`{docs_root}` 跨项目一致性
+
+**位置**：Step 0.2 路径引用 `{docs_root}/faq.md`。
+
+**问题**：target 项目 docs_root 可能是 `documentation/` 而非 `docs/`。Step 0 Context Detection 已归一化到 `{docs_root}` 变量，但 design-doc §3.3 落点清单写死 `docs/faq.md`，跨项目 dogfood 时矛盾。
+
+**建议**：design-doc §3.3 改 `{docs_root}/faq.md`。
+
+### F8 [Low]：去重 ref 锚点格式不稳
+
+**位置**：Step 0.2 "回复末尾标注" —— `📚 已有相关条目见 {docs_root}/faq.md § Q: <锚点>`。
+
+**问题**：Markdown 标题锚点是 GFM slug 算法（`Q: 什么是 orchestrator` → `q-什么是-orchestrator`）；但标注里写 `§ Q: <锚点>` 是人读格式。TG 前端点击 `docs/faq.md#q-xxx` 才能跳。
+
+**风险**：协议现状只够人读，程序/TG 跳不过去。
+
+**建议**：可选改进 —— 标注附 markdown link `[Q: <title>](./faq.md#<gfm-slug>)`。非阻断。
+
+### F9 [Low]：并发写 faq.md 的 race
+
+**位置**：Step 7 / Step 8 已处理 INDEX / log.md 的并发（orchestrator 代写），faq.md 同样是 orchestrator 唯一写入者故无 race。但**两轮不同 session** 并发修改（用户多个 Claude Code 实例）可能冲突。
+
+**建议**：不是本轮 scope，但 design-doc §4 "影响范围" 可加一句"多 session 并发 dogfood 靠 git 冲突解决，本协议不加锁"。
+
+### F10 [Low]：📚 emoji 在 TG markdownv2 未转义
+
+**位置**：Step 0.2 "回复末尾标注" —— `📚 已追加到 ...`。
+
+**问题**：TG forwarding（Step 5b 事件类 a-e）已定义格式，**但 FAQ sink 标注不在 5 类转发清单**内。故 active channel 下 FAQ 标注是否同步到 TG 未规定。
+
+**建议**：在 Step 5b 表格加第 6 行 "FAQ sink 标注 → `markdownv2` 单行"，或明确"不转发"（design-doc §4 可加注脚）。
+
+### F11 [Low]：软上限 / 大小控制
+
+**问题**：`docs/faq.md` 无条目数 / 文件大小上限。dogfood 数月后 faq.md 膨胀到几百 KB，新 session 加载成本 + orchestrator 每次 Read dedupe 成本线性增长。
+
+**建议**：非本轮阻断；可加 follow-up "达到 100 条时分 faq-archive.md 按 DEC-xxx / 年月归档"。
+
+## 3. 对抗性测试场景（人工执行）
+
+以下测试项靠 dogfood session 跑，记录期望 vs 实际。
+
+### 3.1 触发路径
+
+- [ ] **P1** 裸问 "orchestrator 是什么？" → 期望：回答 + sink + 📚 标注
+- [ ] **P1** 裸问 "我这段 Rust 代码 bug 在哪" → 期望：回答 + **不** sink
+- [ ] **P1** 裸问 "auto_mode 怎么用？" → 期望：sink（白名单命中 `auto_mode`）
+- [ ] **P1** 用户说 `加入 FAQ: 我今天心情如何` → 期望：强制 sink（命令覆盖）or orchestrator 拒绝（非机制类强制沉淀的边界，现规则未定义拒绝条件，可能被误用）
+- [ ] **P1** 用户说 `skip FAQ` 后紧接问 "DEC-013 是什么" → 期望：回答 + **不** sink
+- [ ] **P2** A 类 producer-pause 菜单激活中，裸问（非 `问:` 前缀）"phase matrix 状态是什么" → **F3 消歧待定**；测试观察实际 orchestrator 走哪条路
+- [ ] **P2** 用 `问:` 前缀问 "roundtable 机制" → 期望：走 DEC-006 §A menu 循环 + analyst slug 级 FAQ（**不**走 Step 0.2）
+
+### 3.2 去重路径
+
+- [ ] **P1** 首轮问 "orchestrator 是什么" sink 后，次轮问 "orchestrator 啥意思" → 期望：命中 70% 去重 → 不追加 + 回复指向已有 § 锚点（**F1 未定义阈值算法**，可能判重也可能判新增）
+- [ ] **P2** 问 "DEC-013 是什么" 首轮 sink 后，问 "decision mode 是什么" → 期望：不命中（中英不同词）但实际语义重复（**F1 风险**）
+- [ ] **P3** 同一轮 session 内两次问同一问题 → orchestrator 应记忆 session 态而非只靠 faq.md Read 判重
+
+### 3.3 边界 / 误判
+
+- [ ] **P2** 裸问 "我项目中的阶段怎么规划" → 期望：**不** sink（业务语义非 plugin `阶段`；**F6 风险**，实际可能误触）
+- [ ] **P2** 裸问 "降低延迟的机制有哪些" → 同上（业务 "机制" 不应触发）
+- [ ] **P2** 裸问 "add this feature to FAQ" → 期望：**不** 触发强制 sink（非命令而是功能讨论；**F5 风险**）
+- [ ] **P3** 用户说 "加入 FAQ 但别沉淀" → 冲突命令，期望：skip 优先（**F5 未定义**）
+
+### 3.4 创建路径
+
+- [ ] **P1** 首次 session `docs/faq.md` 不存在 → orchestrator 创建 minimal header → header 中 `<project>` 实际填成什么？（**F2 未定义**）
+- [ ] **P1** `{docs_root}` = `documentation/` 的 target 项目 → faq.md 创建在 `documentation/faq.md` 而非 `docs/faq.md`（**F7 design-doc §3.3 需修**）
+
+### 3.5 Bugfix session 继承
+
+- [ ] **P2** `/roundtable:bugfix <issue>` 期间裸问 "critical_modules 怎么判" → 期望：走 Step 0.2（bugfix.md Step -1 已 ref workflow Step 0.2）
+
+### 3.6 log_entries 正确性
+
+- [ ] **P1** FAQ sink 后 orchestrator 执行 Step 8 flush，log.md 追加 `## analyze | faq-sink | YYYY-MM-DD` 条目（**F4 语义过载**：若未来前缀规范严格 enum 校验，analyze + slug=faq-sink 合法但语义歧义）
+- [ ] **P2** 同 session 多次 sink 合并为一条 `log_entries`（`files: union` / `note: append`）还是分多条？Step 8 "合并规则" 讲同 agent 同轮合并 —— orchestrator 自己多次触发 FAQ sink 是否算同轮？
+
+### 3.7 Critical modules lint
+
+- [x] lint_cmd `grep -rnE "gleanforge|dex-sui|..."` 扫描 `commands/workflow.md` Step 0.2 新增段 —— **0 命中**（手工检查确认：示例串 `我这个 phase 要跑什么` / `加入 FAQ` 等皆不在禁词表）
+- [x] lint_cmd 扫描 `commands/bugfix.md` +1 行 ref —— 0 命中
+- [x] lint_cmd 扫描 `docs/design-docs/faq-sink-protocol.md` / `docs/faq.md` —— 0 命中
+
+## 4. Benchmark
+
+不适用（纯 prompt 协议，无性能 hot path；每次 sink 成本 = 1 Read faq.md + 1 Edit，延迟 ~1s 已在 design-doc §4 声明）。
+
+## 5. 反馈 developer / orchestrator 优先级列表
+
+| # | Severity | Finding | 是否阻断合并 |
+|---|---------|---------|------------|
+| F1 | High | 70% 词重叠算法未指定 | **是**（易行为漂移） |
+| F2 | High | `<project>` 填充规则未定义 | **是**（首次创建即暴露） |
+| F3 | Medium | A 类 menu 裸问 vs Step 0.2 边界 | 可合并但建议同轮澄清 |
+| F4 | Medium | `log_entries.prefix=analyze` 语义过载 | 可合并；follow-up 加 `faq-sink` 到前缀规范 |
+| F5 | Medium | 用户命令中英 / 大小写 / 冲突 | 可合并；加一句规则 |
+| F6 | Medium | 白名单关键词误触（业务 "机制" / "阶段"） | 可合并；加 "plugin 上下文" 限定语 |
+| F7 | Low | design-doc §3.3 写死 `docs/faq.md` | 小修 |
+| F8 | Low | 去重 ref 锚点 markdown link 化 | 非阻断 |
+| F9 | Low | 多 session 并发写 race | 非阻断 |
+| F10 | Low | FAQ 标注是否转发 TG 未规 | 非阻断，归 follow-up |
+| F11 | Low | faq.md 膨胀归档策略 | 非阻断 |
+
+## 6. 变更记录
+
+- 2026-04-21 初版对抗审查（tester subagent；F1-F11 11 finding；2 High / 4 Medium / 5 Low；建议 F1+F2 合并前修复，其余可 follow-up）


### PR DESCRIPTION
## Summary

P2 bug — user asks roundtable mechanism questions directly; orchestrator answers but doesn't persist to FAQ. Knowledge doesn't accumulate across sessions.

## Fix

**`commands/workflow.md` Step 0.5** (standing rule active after Step 0):
- Trigger: roundtable-specific term (orchestrator / phase matrix / DEC-\d+ / auto_mode / etc.) OR Chinese general word co-occurring with a specific term
- Dedupe: **Jaccard bag-of-words ≥0.7** on tokenized Q titles
- User commands: `加入 FAQ` / `add to FAQ` force (mechanism-class precondition enforced) vs `skip FAQ` force skip; `skip` wins in conflict
- Entry format: Q / 提问于 / 类别 / answer ≤500 codepoints
- Reply footer: `📚 已追加到 {docs_root}/faq.md § Q: ...`
- New `faq-sink` log prefix
- **A-class `问:` menu loop complementary** (not overlapping): `问:` prefix → analyst slug FAQ loop; bare mechanism Q → global faq.md + return to menu (DEC-006 §A)

**`commands/bugfix.md` Step -1**: +1 ref line

**`docs/faq.md`**: minimal header (`<project>` = `basename(target_project)`)

## Quality gates

- **tester**: 2 High + 4 Medium + 5 Low + 2 Positive; F1-F6 inline post-fix; F7-F11 follow-up
- **reviewer**: **Approve-with-caveats after C1 inline fix** (0 Critical remaining / 5 Warning all inline / 4 Suggestion / 5 Positive)
- **C1 fix**: Original "Step 0.2" sat before Step 0 creating {docs_root} dependency ordering conflict → renamed Step 0.5, physically moved to after Step 0, added 位置说明 standing-rule clarification
- **Self-dogfood of Step 7 fallback (2nd time)** — reviewer subagent runtime didn't expose Write; review .md relayed by orchestrator
- **lint**: 0 hits
- **critical_modules 3/3**: prompt body + Phase Matrix + Escalation Protocol

## Follow-ups (non-blocking)

1. W3: synonym dedupe dictionary (orchestrator vs 编排器)
2. S1: atomize `DEC-\d+` / `Step N.M` in tokenization
3. S3: reserve `faq-sink` slug note
4. F7-F11 low-severity

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)