### PR TITLE
chore: bump version to 0.0.4-rc3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "roundtable",
       "source": "./",
       "description": "Multi-role AI development workflow (analyst / architect / developer / tester / reviewer / dba) with plan-then-execute discipline.",
-      "version": "0.0.4-rc2"
+      "version": "0.0.4-rc3"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtable",
-  "version": "0.0.4-rc2",
+  "version": "0.0.4-rc3",
   "description": "Multi-role AI development workflow for Claude Code. Bring analyst, architect, developer, tester, reviewer, and DBA to the same table with plan-then-execute discipline, AskUserQuestion decision popups, and design-doc-driven collaboration. Zero-config install; per-project CLAUDE.md drives everything.",
   "author": {
     "name": "duktig666",


### PR DESCRIPTION
## Summary

- Bump `.claude-plugin/plugin.json` 和 `.claude-plugin/marketplace.json` 从 `0.0.4-rc2` → `0.0.4-rc3`
- 汇总 2026-04-20 合入的 10 个 PR（#44 #45 #47 #50 #51 #52 #53 #54 #55 #56），让本地 plugin cache 能拉到新版本

## Changes included (rc2 → rc3)
- #44 forward decision-needed to active MCP channel (DEC-013 §3.1a)
- #45 DEC-015 workflow --auto mode design
- #47 DEC-015 --auto mode impl
- #50 DEC-013 §3.1a TG forwarding: phase summaries / role digests / auto_mode audit (#48)
- #51 phase-end approval gate menu + architect exec-plan split (#30)
- #52 dedupe 产出 / created fields in final message (#29)
- #53 reviewer/tester/dba Write permission absolute precedence + orchestrator fallback (#23)
- #54 FAQ sink protocol (#27)
- #55 Stage 9 Closeout bundle spec (#26)
- #56 prune DEC-xxx / issue #N labels in runtime prompts (#22)

## Test plan
- [ ] merge 后 `/plugin update roundtable` 拉到 0.0.4-rc3
- [ ] `/reload-plugins` 后跑一次 `/roundtable:workflow` 实测 4 个点：#48 markdownv2 TG 转发 / #30 approval gate / #29 final message 去重 / #23 reviewer Write 权限

🤖 Generated with [Claude Code](https://claude.com/claude-code)