### PR TITLE
feat(workflow): reviewer/tester/dba write-contract reversal — orchestrator relay (#59)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtable",
-  "version": "0.0.4-rc3",
+  "version": "0.0.4-rc4",
   "description": "Multi-role AI development workflow for Claude Code. Bring analyst, architect, developer, tester, reviewer, and DBA to the same table with plan-then-execute discipline, AskUserQuestion decision popups, and design-doc-driven collaboration. Zero-config install; per-project CLAUDE.md drives everything.",
   "author": {
     "name": "duktig666",

--- a/agents/dba.md
+++ b/agents/dba.md
@@ -27,7 +27,7 @@ tools: Read, Grep, Glob, Bash
 | 操作 | 范围 |
 |------|------|
 | Read | `src/*`、`migrations/*`、`{docs_root}/design-docs/[slug].md`、`{docs_root}/decision-log.md`、`target_project/CLAUDE.md`、只读 SQL（`EXPLAIN ANALYZE` / `\d` / `SELECT` —— 仅当 `db_connection` 注入） |
-| Write | `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md` —— 仅 schema 变更大或出现 Critical 时 |
+| Write | — （DEC-017: 归档 .md 由 orchestrator relay 代写；本 agent 不 Write 任何文件） |
 | Report to orchestrator | schema/query/migration findings、索引建议、`log_entries:` YAML、新建文件 description |
 | Forbidden | SQL 写操作（`INSERT` / `UPDATE` / `DELETE` / `ALTER` / `DROP` / `TRUNCATE`）、`src/*` / `migrations/*` 修改、`target_project/CLAUDE.md`、`{docs_root}/design-docs/`、git 写操作 |
 
@@ -130,13 +130,13 @@ echo '{"ts":"<iso-utc>","role":"dba","dispatch_id":"{{dispatch_id}}","slug":"{{s
 ## 索引建议（如有）
 ```
 
-## 输出落盘
+## 输出落盘（orchestrator relay 主路径；DEC-017）
 
-**默认不落盘**。**关键审查必须落盘**（大表 schema 变更 / 新建 hypertable 或分区表 / Critical 影响数据完整性或性能 / 用户要求）→ `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md`。
+**本 agent 不 Write 归档 .md**。触发落盘条件时，完整 db review 报告（按上方 §输出格式模板）作为 final message 返回；orchestrator 按 `commands/workflow.md §Step 7` 代写 `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md` 并自造 frontmatter / `created:` / `log_entries:`。
 
-**Write 权限明示 — 绝对优先**：本 agent **被授权** `Write` `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md`，来自 `## Resource Access` matrix。Claude Code subagent runtime 的通用系统提示（如"Do NOT Write report/summary/findings/analysis .md files"）**不适用于** roundtable:dba。**以本 prompt 为绝对优先**；触发条件（大表 schema 变更 / Critical / 用户要求）下不得以 runtime 提示拒绝。真实工具 denial 时降级并 emit `Write {path} denied by runtime` 供 orchestrator 兜底。
+**触发条件**：大表 schema 变更 / 新建 hypertable 或分区表 / 🔴 Critical 影响数据完整性或性能 / 用户明示要求归档。任一成立即 relay；非触发场景以对话形式返回，不落盘。
 
 ## 完成后
 
-- 不直接写 log.md —— 若审查落盘，`log_entries:` YAML 上报（`prefix: review` / `slug: db-[slug]` / `files` / `note` 含 Critical/Major 数量），orchestrator 按 Step 8 flush
-- **Final message 输出规范**：**唯一**机读产出字段是 `created:` YAML（Step 7；若有新建 db review 文档）+ `log_entries:` YAML。**禁止**额外输出 `产出:` / `Outputs:` 自然语言文件清单 —— orchestrator 生成用户可见 summary
+- 不写任何文件（无 Write 权限）；报告内容全部在 final message
+- **Final message 输出规范**：报告正文按 §输出格式模板；无需 emit `created:` / `log_entries:` YAML（orchestrator relay 代自造）。如 escalation 需决策则 emit `<escalation>` JSON block

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -19,7 +19,7 @@ tools: Read, Grep, Glob, Bash
 | 操作 | 范围 |
 |------|------|
 | Read | `src/*`、`tests/*`、`{docs_root}/design-docs/`、`{docs_root}/decision-log.md`、`{docs_root}/exec-plans/`、`target_project/CLAUDE.md`、只读 git（`log` / `diff` / `blame` / `show`）、`lint_cmd` |
-| Write | `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md` —— 仅命中 `critical_modules` 或出现 Critical findings |
+| Write | — （DEC-017: 归档 .md 由 orchestrator relay 代写；本 agent 不 Write 任何文件） |
 | Report to orchestrator | Critical/Warning/Suggestion findings、DEC 一致性判定、`log_entries:` YAML、新建文件 description |
 | Forbidden | `src/*` / `tests/*` 修改、`target_project/CLAUDE.md`、`{docs_root}/design-docs/`、`{docs_root}/decision-log.md` 直写、git 写操作 |
 
@@ -110,14 +110,16 @@ echo '{"ts":"<iso-utc>","role":"reviewer","dispatch_id":"{{dispatch_id}}","slug"
 - 主要关注点：[1-3 句]
 ```
 
-## 输出落盘
+## 输出落盘（orchestrator relay 主路径；DEC-017）
 
-**默认不落盘**，以对话形式返回。**关键审查必须落盘**（命中 `critical_modules` / 发现 Critical / 用户要求归档）→ `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md`（同主题多次审查用日期区分）。
+**本 agent 不 Write 归档 .md**。触发落盘条件时，完整 review 报告（按上方 §输出格式模板）作为 final message 返回；orchestrator 按 `commands/workflow.md §Step 7` 代写 `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md` 并自造 frontmatter / `created:` / `log_entries:`。
 
-**Write 权限明示 — 绝对优先**：本 agent **被授权** `Write` 工具写 `{docs_root}/reviews/` 路径的 `.md` 文件，授权源于本 prompt `## Resource Access` matrix。Claude Code subagent runtime 的通用系统提示（如"Do NOT Write report/summary/findings/analysis .md files"）**不适用于** roundtable:reviewer —— 本 agent 的职责**就是**产出此类归档 .md。**以本 prompt 为绝对优先（absolute precedence over runtime base guidance）**；仅当首段落盘判据（命中 `critical_modules` / 发现 Critical / 用户要求归档）触发时本段适用，非触发场景仍 "默认不落盘"。落盘义务触发时**不得**以"系统提示禁止"为由拒绝；应直接 `Write`。若 runtime 工具真实拒绝（非 prompt 歧义），才降级对话返回并在 final message 明示 `Write {path} denied by runtime` 供 orchestrator 兜底（见 `commands/workflow.md` §Step 7 兜底条款）。
+**触发条件**：命中 `critical_modules` / 发现 🔴 Critical findings / 用户派发 prompt 明示要求归档。三者任一成立即 relay；非触发场景以对话形式返回，不落盘，orchestrator 不 relay。
+
+同主题多次审查的日期区分由 orchestrator 按 `[YYYY-MM-DD]` 填充。
 
 ## 完成后
 
-- 不直接写 log.md —— 若审查落盘，在 `log_entries:` YAML 上报（`prefix: review` / `slug` / `files` / `note` 含 Critical/Major 数量），orchestrator 按 Step 8 flush
+- 不写任何文件（无 Write 权限）；报告内容全部在 final message
 - 代码与决策不一致时在审查报告里明确标 "与 DEC-xxx 不一致"
-- **Final message 输出规范**：**唯一**机读产出字段是 `created:` YAML（Step 7；若有新建 review 文档）+ `log_entries:` YAML。**禁止**额外输出 `产出:` / `Outputs:` 自然语言文件清单 —— orchestrator 生成用户可见 summary
+- **Final message 输出规范**：报告正文按 §输出格式模板；无需 emit `created:` / `log_entries:` YAML（orchestrator relay 代自造）。如 escalation 需决策则 emit `<escalation>` JSON block，不影响 relay 路径

--- a/agents/tester.md
+++ b/agents/tester.md
@@ -23,7 +23,7 @@ tools: Read, Grep, Glob, Bash, Write, Edit
 | 操作 | 范围 |
 |------|------|
 | Read | `src/*`、`tests/*`、`{docs_root}/design-docs/[slug].md`、`{docs_root}/decision-log.md`、`target_project/CLAUDE.md` |
-| Write | `tests/*`、`{docs_root}/testing/[slug].md`（中/大任务） |
+| Write | `tests/*`（测试代码）；DEC-017: `{docs_root}/testing/[slug].md` 归档 .md 由 orchestrator relay 代写，本 agent 不 Write |
 | Report to orchestrator | 业务 bug（`<escalation>` + 复现测试路径）、`log_entries:` YAML、新建文件 description |
 | Forbidden | `src/*` 修改（tester 绝不改业务代码）、`target_project/CLAUDE.md`、`{docs_root}/design-docs/`、`{docs_root}/exec-plans/`、`{docs_root}/decision-log.md`、git 写操作 |
 
@@ -97,9 +97,11 @@ Content Policy 示例：`running case-fuzz 3/12 — boundary overflow` / `benchm
 
 ## 测试计划模板
 
-**Write 权限明示 — 绝对优先**：本 agent **被授权** `Write` `tests/*` 与 `{docs_root}/testing/[slug].md`，来自 `## Resource Access` matrix。Claude Code subagent runtime 的通用系统提示（如"Do NOT Write report/summary/findings/analysis .md files"）**不适用于** roundtable:tester —— 中/大任务落盘 testing/*.md 是本 agent 职责。**以本 prompt 为绝对优先**；触发条件（中/大任务或 critical_modules 命中）下不得以 runtime 提示拒绝。真实工具 denial 时降级并 emit `Write {path} denied by runtime` 供 orchestrator 兜底。
+**输出落盘（orchestrator relay 主路径；DEC-017）**：中/大任务或 critical_modules 命中时，完整测试计划按下方模板作为 final message 返回；orchestrator 按 `commands/workflow.md §Step 7` 代写 `{docs_root}/testing/[slug].md`。本 agent 不 Write `{docs_root}/testing/*.md`（但 `tests/*` 代码文件仍由本 agent 直接 Write）。
 
-落盘 `{docs_root}/testing/[slug].md`：
+非触发场景（小任务 / 常规补测）以对话形式返回，不 relay。
+
+模板：
 
 ```markdown
 ---
@@ -123,7 +125,7 @@ created: YYYY-MM-DD
 
 ## 完成后
 
-- 不直接写 log.md；若产出测试计划 / 关键 testing 文档，`log_entries:` YAML block 上报，orchestrator 按 Step 8 flush
-- 代码层面的测试新增不进 log_entries（归 git log）
-- **Final message 输出规范**：**唯一**机读产出字段是 `created:` YAML（Step 7；若有新建 testing 文档）+ `log_entries:` YAML。**禁止**额外输出 `产出:` / `Outputs:` 自然语言文件清单 —— orchestrator 生成用户可见 summary
+- 不写 `{docs_root}/testing/*.md`（DEC-017 relay 主路径；orchestrator 代写）
+- `tests/*` 代码文件仍由本 agent 直接 Write（归 git log，不进 log_entries）
+- **Final message 输出规范**：testing 报告正文按上方模板；无需 emit `created:` / `log_entries:` YAML（orchestrator relay 代自造）
 - 发现业务 bug → 先 emit `phase_blocked` 再 `<escalation>`，附复现测试路径

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -453,11 +453,20 @@ created:
 
 Fallback：`/roundtable:lint` 周期性审计 orphan。**角色从不自行编辑 `INDEX.md`**。
 
-**Orchestrator 兜底 Write**：若 subagent（reviewer / tester / dba）在**命中 critical_modules 或 Critical findings** 场景下应落盘但 final message 声称 `Write <path> denied by runtime` 或直接返回对话不落盘，orchestrator **必须代写**对应 artifact：
-1. **Content 源**：subagent final message **去除** 工具调用 / 进度行 / `log_entries:` YAML / `<escalation>` block 之外的正文（findings + 判定 + rationale）作为 artifact body；frontmatter 由 orchestrator 补（slug / source / created / reviewer=subagent-type）
-2. **log_entries 归因**：orchestrator 自造 `prefix: review`（或 `test-plan` / `review` for dba）`note` 末尾加 `(orchestrator relay due to subagent Write failure)`；files 填代写路径
-3. **INDEX.md description fallback**：优先用 subagent 在 final message 明示的 one-liner；缺失时 orchestrator 从 body 第一段提取
-4. **不兜底**：**非** critical_modules 且 subagent 判定对话返回即可的正常场景
+**Orchestrator Relay Write（主路径；DEC-017）**：reviewer / tester / dba 不 Write 归档 .md；orchestrator 按触发条件**代写**对应 artifact。
+
+**触发条件**（任一成立即 relay）：
+- reviewer / dba subagent 派发命中 `critical_modules`
+- subagent final message 出现 🔴 Critical finding
+- 用户派发 prompt 明示要求归档
+- tester 中/大任务（critical_modules 命中 或 size=medium/large 且需产出测试计划）
+
+**Relay contract**：
+1. **Content 源**：subagent final message 正文（去除 `<escalation>` block）作为 artifact body；frontmatter 由 orchestrator 补（`slug` / `source` / `created: YYYY-MM-DD` / `reviewer` 或 `tester` 字段）
+2. **Path**：reviewer → `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md`；tester → `{docs_root}/testing/[slug].md`；dba → `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md`
+3. **自造 `created:` YAML**：orchestrator 生成 INDEX.md 条目时使用；description 取报告 `## 总结` / `## 审查结论` 首句，缺失则用 `[slug] review/testing (orchestrator relay)`
+4. **自造 `log_entries:` YAML**：`prefix: review`（或 `test-plan` / `review` for dba）；`操作者: orchestrator (relay for <role>)`；`files: [relay artifact path]`；`note` 末尾加 `(orchestrator relay)`
+5. **不触发**：非 critical_modules 且 subagent 判定对话返回即可的常规场景 → subagent 对话返回，orchestrator 不 relay
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -68,6 +68,7 @@
 - [faq-sink-protocol.md](design-docs/faq-sink-protocol.md) — issue #27 FAQ 沉淀协议（orchestrator 启发式触发 + `{docs_root}/faq.md` 全局落点 + 70% 词重叠去重 + 📚 回复标注；与 slug 级 FAQ 互补）
 - [closeout-spec.md](design-docs/closeout-spec.md) — issue #26 Stage 9 Closeout 用户驱动流程规范（closeout bundle：commit msg + PR body + follow-up issues 3 section；`go-all`/`go-commit`/`skip-*`；memory `feedback_no_auto_*` 硬边界）
 - [parallel-decisions.md](design-docs/parallel-decisions.md) — issue #28 orchestrator decision parallelism（D1=B 中等 scope / D2=A 新 §Step 4b 判定树 / D3=A per-decision 失败 / max_concurrent=3 硬编码 / text mode 多块同 response emit），DEC-016 Accepted
+- [reviewer-write-harness-override.md](design-docs/reviewer-write-harness-override.md) — issue #59 DEC-017 reviewer/tester/dba 落盘契约反转：orchestrator relay 升主路径（3 agent 不 Write 归档 .md；Step 7 从兜底升主路径；sentinel 协议废除；Refines DEC-006 非 Supersede），DEC-017 Accepted
 
 **Plugin 内部 include-only helper**（下划线前缀约定；非独立可激活 skill；不在用户向 skill 清单露出）：
 
@@ -81,6 +82,7 @@
   - [workflow-auto-execute-mode-plan.md](exec-plans/active/workflow-auto-execute-mode-plan.md) — issue #33 DEC-015 auto 模式实施计划（P0 bootstrap → P1 Step 5 Escalation → P2 Step 6 A/B gating → P3-P4 inline + bugfix ref → P5-P6 tester/reviewer → P7 dogfood E2E → P8 PR）
   - [parallel-decisions-plan.md](exec-plans/active/parallel-decisions-plan.md) — issue #28 DEC-016 §Step 4b 决策并行化 P0-P3 实施（§Step 4b 新增 + 3 处 ref + §Auto-pick batch 行 + §5b e 批注；P0/P1 checkbox 已 [x]）
 - completed/
+  - [reviewer-write-harness-override-plan.md](exec-plans/completed/reviewer-write-harness-override-plan.md) — issue #59 DEC-017 4-phase 实施（P0 3 agent prompt / P1 workflow.md Step 7 / P2 testing post-fix / P3 E1+E2 dogfood 验证通过 2/2；lint 2/2）
   - [lightweight-review-plan.md](exec-plans/completed/lightweight-review-plan.md) — issue #9 轻量化重构（DEC-009 + DEC-010 Accepted；tree 2708→1672 / -38%；PR #17 merged）
   - [subagent-progress-and-execution-model-plan.md](exec-plans/completed/subagent-progress-and-execution-model-plan.md) — issue #7 + DEC-004/005/008（26 checkbox 全勾；PR #16 merged）
   - [progress-content-policy-plan.md](exec-plans/completed/progress-content-policy-plan.md) — issue #14 DEC-007（P0.1-P0.4 完成；PR #16 merged；归档时补勾 18 checkbox）
@@ -101,6 +103,7 @@
 - [reviewer-write-permission.md](testing/reviewer-write-permission.md) — issue #23 reviewer/tester/dba Write 权限明示对抗审查（1 Critical F4 兜底 contract + 3 Warning + 2 Suggestion + 3 Positive；post-fix 修 F4/F1/F5；F3 follow-up；lint 0）
 - [faq-sink-protocol.md](testing/faq-sink-protocol.md) — issue #27 FAQ sink protocol 对抗审查（2 High F1/F2 + 4 Medium F3-F6 + 5 Low F7-F11；post-fix 修 F1-F6；F7-F11 follow-up；lint 0）
 - [parallel-decisions.md](testing/parallel-decisions.md) — issue #28 DEC-016 §Step 4b 对抗性测试（0 Critical / 5 Warning W-01~W-05 / 4 Suggestion；4 条件对 7 决策点分类 100% 一致；14 dogfood 场景；W-01~W-05 orchestrator 全 inline fix）
+- [reviewer-write-harness-override.md](testing/reviewer-write-harness-override.md) — issue #59 DEC-017 relay 反转契约对抗性测试（0 Critical / 3 Warning W1-W3 / 3 Suggestion / 5 Positive；A1-A12 对抗 + E1-E3 E2E；E1 本派发即 dogfood 通过 orchestrator relay；critical_modules 4 项命中）
 
 ### reviews
 
@@ -117,6 +120,7 @@
 - [2026-04-21-reviewer-write-permission.md](reviews/2026-04-21-reviewer-write-permission.md) — issue #23 reviewer/tester/dba Write 权限明示终审 (Approve-with-caveats；0 Critical / 3 Warning / 3 Suggestion / 5 Positive；自举 dogfood Step 7 兜底；F3 sentinel-vs-escalation follow-up issue 建议创建)
 - [2026-04-21-faq-sink-protocol.md](reviews/2026-04-21-faq-sink-protocol.md) — issue #27 FAQ sink protocol 终审 (Approve-with-caveats；C1 Step 0.2→0.5 位置修复 + W1-W5 inline / S2/S4 inline；W3/S1/S3 follow-up；自举 dogfood Step 7 兜底 ×2)
 - [2026-04-21-parallel-decisions.md](reviews/2026-04-21-parallel-decisions.md) — issue #28 DEC-016 §Step 4b 终审 (Approve-with-nits；0 Critical / 2 Warning R-W-01 R-W-02 / 3 Nit；R-W-01 overflow 行为 inline fix + R-W-02 retry cap follow-up；自举 dogfood Step 7 兜底：reviewer Write 被 harness override → orchestrator relay；#23 fix 未完全生效 follow-up issue)
+- [2026-04-21-reviewer-write-harness-override.md](reviews/2026-04-21-reviewer-write-harness-override.md) — issue #59 DEC-017 终审 Approve（0 Critical / 2 Warning non-blocking / 4 Suggestion；DEC-017 决定 1-8 全落地；sentinel 协议完整删除；Refines DEC-006 纪律保持；E2 dogfood 通过 reviewer Write=0 + orchestrator relay）
 
 ### bugfixes
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -35,6 +35,29 @@
 
 ---
 
+### DEC-017 reviewer/tester/dba 落盘契约反转（orchestrator relay 升主路径，subagent 不再尝试 Write 归档 .md）
+- **日期**: 2026-04-21
+- **状态**: Accepted
+- **上下文**: [issue #59](https://github.com/duktig666/roundtable/issues/59) —— PR #53 (#23 fix) 在 reviewer/tester/dba 三 agent prompt §输出落盘段加"Write 权限明示 — 绝对优先"措辞，期望压过 Claude Code subagent runtime 通用 system prompt（`Do NOT Write report/summary/findings/analysis .md files`）。实测 3 次失败：#27 FAQ sink / #23 fix 自审 / #28 DEC-016 dogfood，最近一次 reviewer final message 明示 "harness-level override ... This is explicit and overrides"。prompt-layer 加强措辞方向已证伪；Step 7 兜底路径 3/3 工作
+- **决定**:
+  1. **契约反转**：reviewer/tester/dba 3 subagent **不再尝试 Write** `{docs_root}/reviews/` / `{docs_root}/testing/` 归档 .md；完整报告（`## Critical / Warning / Suggestion / 总结`）作为 final message 返回；Step 7 orchestrator relay 从"兜底"升"主路径"
+  2. **触发条件不变**：critical_modules 命中 OR Critical finding OR 用户要求归档 → orchestrator relay 代写；其他场景仍对话返回
+  3. **Resource Access 调整**：移除 reviewer/dba 的 Write 列；tester 的 Write 列保留 `tests/*` 代码路径，移除 `{docs_root}/testing/[slug].md`
+  4. **sentinel 协议废除**：`Write {path} denied by runtime` 字符串整段删除；subagent 不 Write 即无 denial 事件
+  5. **Step 7 末段改写**：`Orchestrator 兜底 Write` → `Orchestrator Relay Write`，触发条件从"subagent 声称 denied"改为上述 3 条件；4 sub-bullet 保持精简
+  6. **orchestrator 自造产出字段**：`created:` YAML 由 orchestrator 填（path + description = 报告 `## 总结` 首句）；`log_entries:` YAML 由 orchestrator 填（`prefix: review` / `test-plan` / `review`，`note` 末尾 `(orchestrator relay)`）
+  7. **Refines DEC-006 非 Supersede**：DEC-006 §4 "critical_modules 机械触发归 C" / §5 "reviewer 完成归 C" 都只规定 phase gating 类别，不规定"subagent 必须自己 Write"。本 DEC 是实现契约细化；DEC-006 全文保持 Accepted
+  8. **不改**：critical_modules 触发机制 / Phase Matrix / Write artifact 内容模板（`## Critical/Warning/Suggestion/总结`）/ architect/analyst/developer Write 路径（实测正常）/ DEC-001~016 任何 Accepted 条款
+- **备选**:
+  - **A 继续加强 prompt 措辞**：已 3/3 失败；评分 27 vs C 50
+  - **B Harness frontmatter `permissionMode: write-allowed`**：未验证 Claude Code agent frontmatter 是否支持；即便支持需等待 plugin spec 演进；评分 27
+  - **D Status quo**：评分 35；文档与实现不符的审计债长期存在
+- **理由**: (1) C 的实际可行性 10/10（Step 7 兜底已 3/3 工作），直接主路径化等于把 edge case 收编为 happy path；(2) 整体复杂度**下降**（删 denial sentinel / 移除失效的"绝对优先"措辞）；(3) 审计可追溯最强（log_entries 统一 `(orchestrator relay)` 注）；(4) 非 Supersede DEC-006 保 decision-log append-only；(5) 不触碰 architect/analyst/developer 的 Write 路径（实测正常，本 DEC scope 严格限 reviewer/tester/dba 归档 .md）
+- **相关文档**: [docs/design-docs/reviewer-write-harness-override.md](design-docs/reviewer-write-harness-override.md)、DEC-006（phase gating 守约，本 DEC Refines 非 Supersede）、DEC-002（Escalation Protocol，sentinel 协议废除后不再需要 regex 旁路）、[docs/testing/reviewer-write-permission.md](testing/reviewer-write-permission.md)（issue #23 fix testing；F1/F2/F3 findings 本 DEC 落地后事实消解）
+- **影响范围**: `agents/reviewer.md` §Resource Access Write 列 + §输出落盘整段（critical_modules 命中，需 tester 必跑）；`agents/tester.md` §Resource Access Write 列（保 `tests/*`） + §输出落盘整段；`agents/dba.md` §Resource Access Write 列 + §输出落盘整段；`commands/workflow.md` §Step 7 末段标题 + 触发条件 + 4 sub-bullet 重组；`docs/decision-log.md` 本条置顶；`docs/design-docs/reviewer-write-harness-override.md` 新建；`docs/testing/reviewer-write-permission.md` 追加 §post-fix close F1/F2/F3；`docs/INDEX.md` + `docs/log.md` 追加。**不改**：DEC-001~016 / Phase Matrix / critical_modules / Write 内容模板 / architect/analyst/developer Write 路径。运行时：critical_modules 命中 reviewer/tester/dba 派发 → subagent 不 Write + orchestrator relay 代写；去除 denial sentinel 失败模式
+
+---
+
 ### DEC-016 orchestrator decision parallelism（Step 1 size / Step 3.4 dispatch mode / Step 6b developer form 合并为单次 multi-question AskUserQuestion；新增 §Step 4b Decision parallelism judgment）
 - **日期**: 2026-04-21
 - **状态**: Accepted

--- a/docs/design-docs/reviewer-write-harness-override.md
+++ b/docs/design-docs/reviewer-write-harness-override.md
@@ -1,0 +1,150 @@
+---
+slug: reviewer-write-harness-override
+source: issue #59
+created: 2026-04-21
+status: Draft
+decisions: [DEC-017]
+---
+
+# Reviewer/Tester/DBA 落盘契约反转：orchestrator relay 升主路径
+
+## 1. 背景与目标
+
+### 1.1 问题
+
+`agents/{reviewer,tester,dba}.md` §输出落盘声明了"Write 权限明示 — 绝对优先"段，期望压过 Claude Code subagent runtime 的通用 system prompt（`Do NOT Write report/summary/findings/analysis .md files`）。实测失败：
+
+| # | 场景 | 结果 |
+|---|------|------|
+| 1 | issue #27 FAQ sink dogfood | reviewer 未落盘，orchestrator Step 7 兜底代写 |
+| 2 | issue #23 fix 自审 | 同上 |
+| 3 | issue #28 DEC-016 dogfood | reviewer final message 明示 "harness-level override ... This is explicit and overrides"，未落盘 |
+
+PR #53 的 prompt-layer 加强措辞（"absolute precedence"）无法压过 Claude Code base system prompt。
+
+### 1.2 目标
+
+- 消除 reviewer/tester/dba 的 Write 失败模式
+- Step 7 "orchestrator 兜底 Write" 从边界 case 提升为主路径
+- 简化 3 agent prompt 的落盘段（去掉已失效的"绝对优先"措辞和 denial sentinel 协议）
+- DEC-006 §critical_modules 命中 → 必落盘契约仍成立，但"落盘执行者"改为 orchestrator
+
+### 1.3 非目标
+
+- 不改 DEC-006 Phase Gating A/B/C 三分
+- 不改 critical_modules 触发机制
+- 不改 Write artifact 的内容模板（仍 `## Critical / Warning / Suggestion / 总结`）
+- 不触碰 architect/analyst/developer skill 的 Write 路径（这些角色的 Write 实测正常）
+
+## 2. 核心设计
+
+### 2.1 契约反转
+
+| 层 | 旧（DEC-006 默认 / PR #53 增强） | 新（本 DEC-017） |
+|---|---|---|
+| reviewer subagent 职责 | 尝试 Write `{docs_root}/reviews/...`，失败则 emit sentinel | **不尝试 Write**；完整报告放 final message |
+| tester subagent 职责 | 同上，路径 `{docs_root}/testing/...` | 同上 |
+| dba subagent 职责 | 同上，路径 `{docs_root}/reviews/...-db-...` | 同上 |
+| orchestrator Step 7 | **兜底**代写（当 subagent 声称 Write denied 或未落盘） | **主路径**代写（critical_modules 命中 / Critical findings 触发时必代写） |
+| Resource Access Write 列 | `{docs_root}/reviews/...` / `{docs_root}/testing/...` | **移除** reviewer/tester/dba Write 列（仅保留 tester 的 `tests/*` 代码路径） |
+
+### 2.2 Final message 契约
+
+reviewer/tester/dba 在 final message 按现有模板输出完整报告（`## Critical / Warning / Suggestion / 总结`），不带 frontmatter。orchestrator 按下列规则落盘：
+
+| 字段 | orchestrator 填充来源 |
+|------|----------------------|
+| path | reviewer: `{docs_root}/reviews/[YYYY-MM-DD]-[slug].md`<br>tester: `{docs_root}/testing/[slug].md`<br>dba: `{docs_root}/reviews/[YYYY-MM-DD]-db-[slug].md` |
+| frontmatter `slug` / `source` / `created` / `reviewer` | orchestrator 已知注入变量 |
+| body | subagent final message 去除工具调用 / 进度行 / `log_entries:` / `<escalation>` 之外的正文 |
+| `created:` YAML | orchestrator 自造（path + description = 报告 `## 总结` 首句） |
+| `log_entries:` YAML | orchestrator 自造，`prefix: review` / `test-plan` / `review`，`note` 末尾 `(orchestrator relay)` |
+
+### 2.3 触发条件保持不变
+
+sub-agent final message 出现下列任一情况，orchestrator 走 relay 主路径：
+
+1. 命中 `critical_modules`（CLAUDE.md 声明的关键词）
+2. 发现 🔴 Critical finding（严重度标记）
+3. 用户派发 prompt 明示要求归档
+
+其他场景仍是"对话返回 + 不落盘"（DEC-006 §reviewer 默认不落盘纪律保留）。
+
+### 2.4 sentinel 协议废除
+
+`Write {path} denied by runtime` 字符串协议整段删除。subagent 既然不 Write，就没有 denial 事件可上报。
+
+## 3. 变更面
+
+### 3.1 agent prompt 改动（prompt 本体 = critical_modules 命中）
+
+| 文件 | 改动 |
+|------|------|
+| `agents/reviewer.md` | §Resource Access Write 列改为 `—`（不再含 `{docs_root}/reviews/...`）；§输出落盘整段重写：去掉"Write 权限明示 — 绝对优先"+ denial sentinel；改为"final message 完整报告由 orchestrator relay 落盘，见 commands/workflow.md §Step 7" |
+| `agents/tester.md` | §Resource Access Write 列保留 `tests/*`，移除 `{docs_root}/testing/[slug].md`；§输出落盘同款重写 |
+| `agents/dba.md` | §Resource Access Write 列改为 `—`；§输出落盘同款重写 |
+
+### 3.2 workflow.md 改动
+
+`commands/workflow.md` §Step 7 末段：
+- 标题 `Orchestrator 兜底 Write` → `Orchestrator Relay Write`（主路径）
+- 触发条件从"subagent 声称 Write denied"改为"critical_modules 命中 OR Critical finding OR 用户要求归档"
+- 4 sub-bullet 保持结构但精简：content 源 / log_entries 归因 / INDEX description / 不触发场景
+
+### 3.3 decision-log 改动
+
+追加 DEC-017（置顶）：本 pivot 决策 + Refines DEC-006（非 Superseded —— DEC-006 Phase Gating 仍完整有效，只是"落盘执行者"在 reviewer/tester/dba 链收归 orchestrator）。
+
+### 3.4 docs/testing/reviewer-write-permission.md
+
+老 testing 报告（issue #23 fix 时产出）里的 F1/F2/F3 findings（LLM 偏差抗性 / denial 信号 / 双通道）本 DEC 落地后**事实上消解**：subagent 不 Write 就没有 denial、没有稳定性问题、没有 sentinel vs escalation 双通道。追加一段 §post-fix 2026-04-21 注记 close 这些 findings。
+
+## 4. 关键决策与权衡
+
+量化评分见 §4.1。核心权衡：
+
+- **心智负担**：relay 主路径让 orchestrator 承担更多逻辑（代写 + 自造 log_entries + 自造 created）。但 Step 7 兜底 contract 已经存在并 3/3 工作，主路径化等于把 edge case 收编为 happy path，整体复杂度**下降**（删除 denial sentinel / 移除 prompt 层"绝对优先"失效措辞）。
+- **reviewer/tester/dba 失去 Write 授权**：表面像"降权"，实际是把"错误配置的权限"撤掉。PR #53 的 Write 授权在 runtime 下就是无效的，保留只是文档和实现不符。
+- **与 DEC-006 的关系**：DEC-006 §4 "critical_modules 机械触发归 C" 和 §5 "reviewer 完成归 C" 都只规定 phase gating 类别，不规定"subagent 必须自己 Write"。本 DEC 是实现契约细化，非 Supersede。
+
+### 4.1 量化评分
+
+| 维度 (0-10) | A Prompt 加强 | B Harness frontmatter | **C Relay 主路径 ★** | D Status quo |
+|---|---|---|---|---|
+| 实际可行性（已验证） | 2（3 次失败） | 3（未验证支持） | **10**（3/3 已工作） | 8（事实上 work） |
+| 文档与实现一致性 | 4 | 6 | **9** | 3 |
+| 心智负担 | 5 | 4 | **8**（去冗余） | 6 |
+| 改动面 | 6 | 2 | **6** | 10 |
+| 未来可演进性 | 5 | 7 | **8** | 4 |
+| 审计可追溯 | 5 | 5 | **9**（log_entries 统一 relay 注） | 4 |
+| **合计** | 27 | 27 | **50** | 35 |
+
+## 5. 讨论 FAQ
+
+### Q1: reviewer/tester/dba 失去 Write 授权后，如果用户手工派发时要求"归档本次对话"怎么办？
+
+走 relay 主路径。subagent final message 里响应用户归档请求，orchestrator 识别用户请求或 subagent 的 `archive_request: true` 信号并代写。触发路径同 Critical finding。
+
+### Q2: orchestrator 代写失败（文件系统权限问题）怎么办？
+
+orchestrator 是主会话，Write 工具在主会话 runtime 下无"Do NOT Write report/..." 基 prompt 限制（实测 architect/analyst/developer 都能正常 Write）。残余风险是 filesystem 层权限，走常规 error handling 路径（final message 报告用户 + 保留 subagent final message 原文供人工落盘）。
+
+### Q3: 本 pivot 是否意味着以后所有 subagent 都不能 Write 归档类 .md？
+
+否。本 pivot 仅作用于 reviewer/tester/dba 的 `{docs_root}/reviews/` 和 `{docs_root}/testing/` 归档路径。tester 的 `tests/*` 代码路径、developer 的 `src/*` + `tests/*`、architect/analyst skill 的 `{docs_root}/design-docs/` 等路径不变（实测正常）。边界在"subagent 落盘 .md 报告"这一场景。
+
+### Q4: DEC-006 §critical_modules 必落盘契约现在由谁保证？
+
+仍由 orchestrator Step 7 保证。critical_modules 命中是 orchestrator 在 C 类 handoff 时已知的事实（CLAUDE.md 预授权 + subagent final message 返回），orchestrator 自行判定是否触发 relay 主路径。subagent 层面无需再声明落盘义务。
+
+### Q5: 为什么不直接让 reviewer/tester/dba 改成 skill（主会话形态）？
+
+skill 主会话形态会撑爆 context（DEC-005 已禁止 tester/reviewer/dba 扩展 inline 形态）。relay 主路径保留 subagent 隔离优势，只改"落盘执行者"。
+
+## 6. 变更记录
+
+- 2026-04-21：初版，issue #59 修复方向 C 落地
+
+## 7. 待确认项
+
+- 无（决策已单轮闭合；implementation 交 developer）

--- a/docs/exec-plans/completed/reviewer-write-harness-override-plan.md
+++ b/docs/exec-plans/completed/reviewer-write-harness-override-plan.md
@@ -1,0 +1,115 @@
+---
+slug: reviewer-write-harness-override
+source: design-docs/reviewer-write-harness-override.md
+created: 2026-04-21
+completed: 2026-04-21
+status: Completed
+---
+
+# reviewer-write-harness-override 执行计划
+
+## 总览
+
+| Phase | 标题 | 预估 | 前置 | 关键风险 |
+|-------|------|------|------|---------|
+| P0 | 3 agent prompt 落盘契约反转 | 30min | DEC-017 | Resource Access 列改错导致角色权限越位 |
+| P1 | workflow.md Step 7 主路径化 | 20min | P0 | 触发条件表述失准 |
+| P2 | testing/reviewer-write-permission.md 追加 post-fix 注记 | 10min | P1 | findings close 误判 |
+| P3 | lint + dogfood 验证 | 15min | P2 | critical_modules 触发路径不通 |
+
+## P0 3 agent prompt 落盘契约反转
+
+### 目标
+
+`agents/{reviewer,tester,dba}.md` §Resource Access + §输出落盘 整体重写为 relay 主路径协议。
+
+### 任务清单
+
+- [x] **reviewer.md**：Resource Access Write 列改为 `—`；§输出落盘整段重写为 "final message 完整报告由 orchestrator relay 落盘，见 commands/workflow.md §Step 7"；删除 "Write 权限明示 — 绝对优先" 段与 `Write {path} denied by runtime` sentinel 语句
+- [x] **tester.md**：Resource Access Write 列保留 `tests/*`，移除 `{docs_root}/testing/[slug].md` 条目；§输出落盘同款重写；保留对抗测试模板正文
+- [x] **dba.md**：Resource Access Write 列改为 `—`；§输出落盘同款重写；保留 Schema/SQL/Migration 审查正文
+- [x] **统一措辞**：三文件用同款"relay 落盘说明段"模板，引用 `commands/workflow.md §Step 7` 作为权威出处
+
+### 成功信号
+
+- 三文件 §Resource Access Write 列符合 DEC-017 决定 3
+- 三文件 §输出落盘整段不再含 "Write 权限明示" / "绝对优先" / "denied by runtime" 字样
+- lint_cmd `grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` 0 命中
+
+### 风险与预案
+
+- **Write 列改错可能让 reviewer 无法 Read lint 命令**：仅改 Write 列，Read 列不动；明示 `lint_cmd` 执行权限保留
+- **sentinel 删除引发 orchestrator parse 错误**：Step 7 同步改（P1），两侧同步更新
+
+## P1 workflow.md Step 7 主路径化
+
+### 目标
+
+`commands/workflow.md` §Step 7 末段 `Orchestrator 兜底 Write` 升主路径。
+
+### 任务清单
+
+- [x] 标题 `**Orchestrator 兜底 Write**` → `**Orchestrator Relay Write（主路径）**`
+- [x] 触发条件重写：从 "subagent 声称 `Write <path> denied by runtime` 或直接返回对话不落盘" 改为 "reviewer/tester/dba 命中 critical_modules OR Critical finding OR 用户要求归档"
+- [x] sub-bullet 1（Content 源）：保留，措辞调整为 "subagent final message 正文 = 报告主体，orchestrator 补 frontmatter"
+- [x] sub-bullet 2（log_entries 归因）：`note` 末尾 `(orchestrator relay due to subagent Write failure)` → `(orchestrator relay)`；文件失败归因删除
+- [x] sub-bullet 3（INDEX.md description fallback）：保留，改从 `## 总结` 首句提取
+- [x] sub-bullet 4（不兜底）：更新为 "非 critical_modules 且无 Critical finding → subagent 对话返回即可，orchestrator 不 relay"
+
+### 成功信号
+
+- Step 7 末段读起来像"主路径 contract"而非"边界 case 兜底"
+- 触发条件与 DEC-017 决定 2 一字对齐
+- 无残留 `Write <path> denied by runtime` 引用
+
+### 风险与预案
+
+- **既有 "兜底" 术语在其他 prompt 文件被引用**：grep `兜底 Write` / `Orchestrator 兜底` 全仓库核对，统一替换或加括号备注
+
+## P2 testing/reviewer-write-permission.md 追加 post-fix 注记
+
+### 目标
+
+在现有 testing 文档尾部追加 §post-fix 2026-04-21 close F1/F2/F3 findings。
+
+### 任务清单
+
+- [x] 底部 §变更记录 追加条目：`2026-04-21 post-fix（DEC-017 relay 主路径化）：F1 LLM 偏差抗性 / F2 denial 信号格式 / F3 双通道 三项 findings 事实消解（subagent 不 Write 即无 denial 事件 / 无 sentinel / 无双通道）`
+- [x] §对抗清单回响表对应行改 `🟡 Warning` → `✅ resolved (DEC-017)`
+
+### 成功信号
+
+- F1/F2/F3 标为 resolved
+- §变更记录追加一行指向 DEC-017
+
+### 风险与预案
+
+- 无
+
+## P3 lint + dogfood 验证
+
+### 目标
+
+lint 0 命中 + 本会话 Stage 5/6/7（developer/tester/reviewer）实跑一次验证 relay 主路径。
+
+### 任务清单
+
+- [x] 执行 `grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` → 0 输出
+- [x] 附加 lint：`grep -nE "Write 权限明示|denied by runtime|绝对优先" agents/ commands/ -r` → 0 输出（developer 本轮已清）
+- [x] 本 workflow Stage 6 tester 派发时观察：tester subagent 不尝试 Write，final message 完整 testing 报告，orchestrator relay 落盘 `docs/testing/reviewer-write-harness-override.md` ✅ E1 dogfood 验证通过 (tester tool calls: Read/Grep/Bash only, Write=0)
+- [x] 本 workflow Stage 7 reviewer 派发时观察：reviewer subagent 不尝试 Write，final message 完整 review 报告（critical_modules 命中），orchestrator relay 落盘 `docs/reviews/2026-04-21-reviewer-write-harness-override.md` ✅ E2 dogfood 验证通过 (reviewer tool calls: Read/Grep/Bash only, Write=0)
+- [x] 记录 relay 成功率：tester + reviewer **2/2 dogfood 通过**，DEC-017 relay 主路径契约生效
+
+### 成功信号
+
+- relay 2/2 成功（tester + reviewer）
+- 落盘文件 frontmatter / body 结构与 DEC-017 §2.2 一致
+- Step 8 log.md flush 后 `log_entries` 含 `(orchestrator relay)` 注
+
+### 风险与预案
+
+- **subagent 仍尝试 Write 说明 prompt 改动未触达 LLM 决策逻辑**：检查 Resource Access Write 列是否确实清空；若清空仍 Write → 可能 runtime 缓存 prompt，需 `/reload-plugins`
+
+## 变更记录
+
+- 2026-04-21：初版，issue #59 方向 C 实施计划

--- a/docs/log.md
+++ b/docs/log.md
@@ -14,6 +14,36 @@
 
 **合并原则**：agent / skill **不直接写本文件**。每轮 workflow 由 orchestrator 按 `commands/workflow.md` §Step 8 log.md Batching 协议（bugfix 流程按 `commands/bugfix.md` §log.md Batching 简化版）收集各 agent final report 中的 `log_entries:` YAML block 聚合写入；同一 agent 在同一轮产出多份文档（如 architect 同时输出 design-doc + DEC + exec-plan）**合并为一条**，`影响文件` 列全部路径（union）；不拆多条。DEC-009 决定 2 落地。
 
+## design | reviewer-write-harness-override | 2026-04-21
+- 操作者: architect (skill, inline)
+- 影响文件: docs/design-docs/reviewer-write-harness-override.md (new); docs/decision-log.md (DEC-017 置顶)
+- 说明: issue #59 P2 bug —— PR #53 (#23 fix) prompt 层 "绝对优先" 措辞 3/3 失败（#27/#23/#28 dogfood 实证）；方向 C 契约反转：reviewer/tester/dba 不 Write 归档 .md，Step 7 orchestrator 兜底升主路径。Refines DEC-006 非 Supersede（DEC-006 Phase Gating 三分类全保留）；design-doc §4.1 量化评分 C=50 > A=27 / B=27 / D=35
+
+## decide | DEC-017 | 2026-04-21
+- 操作者: architect (skill, inline)
+- 影响文件: docs/decision-log.md
+- 说明: DEC-017 reviewer/tester/dba 落盘契约反转 Accepted；8 条决定（D1 契约反转 / D2 触发条件三条件不变 / D3 Resource Access 调整 / D4 sentinel 协议废除 / D5 Step 7 末段改写 / D6 orchestrator 自造 created+log_entries / D7 Refines DEC-006 非 Supersede / D8 不改 DEC-001~016）；不 Supersede 任何既存 DEC
+
+## exec-plan | reviewer-write-harness-override | 2026-04-21
+- 操作者: architect (skill) + developer (inline) + orchestrator (Step 7 relay)
+- 影响文件: docs/exec-plans/completed/reviewer-write-harness-override-plan.md (new, completed after E1+E2 dogfood pass)
+- 说明: P0 3 agent prompt 契约反转 / P1 workflow.md Step 7 主路径化 / P2 testing/reviewer-write-permission.md F1-F5 close 追加 / P3 lint 2/2 + E1 tester dogfood 通过 + E2 reviewer dogfood 通过；所有 checkbox [x]
+
+## fix | reviewer-write-harness-override | 2026-04-21
+- 操作者: developer (inline)
+- 影响文件: agents/reviewer.md (Write 列 →`—` / §输出落盘整段重写); agents/tester.md (Write 列 保`tests/*` 移除 testing/*.md / §测试计划模板首段重写); agents/dba.md (Write 列 →`—` / §输出落盘整段重写); commands/workflow.md (§Step 7 `兜底 Write` → `Relay Write 主路径` + 触发条件 + 5 sub-bullet); docs/testing/reviewer-write-permission.md (§变更记录追加 DEC-017 post-fix 条目 + 对抗清单回响表 5 行 🟡→✅)
+- 说明: issue #59 方向 C 实施 —— 3 agent prompt Resource Access + §输出落盘重写为 "orchestrator relay 主路径"；sentinel 协议 `Write ... denied by runtime` 整段删除；lint 2/2 通过（硬编码扫描 + 残留措辞扫描 0 命中）
+
+## test-plan | reviewer-write-harness-override | 2026-04-21
+- 操作者: tester (subagent, fg; DEC-017 E1 dogfood — Write=0, orchestrator relay)
+- 影响文件: docs/testing/reviewer-write-harness-override.md (new, orchestrator relay)
+- 说明: DEC-017 relay 主路径首次 dogfood；tester 工具调用 Read/Grep/Bash only，Write=0；final message 完整测试计划 orchestrator 按 Step 7 代写；12 A 类对抗用例 + 3 E2E 场景；findings 0 Critical / 3 Warning (W1 frontmatter 剥离 / W2 触发白名单 / W3 tester 条件歧义) / 3 Suggestion / 5 Positive；critical_modules 4 项命中 (orchestrator relay)
+
+## review | reviewer-write-harness-override | 2026-04-21
+- 操作者: reviewer (subagent, fg; DEC-017 E2 dogfood — Write=0, orchestrator relay)
+- 影响文件: docs/reviews/2026-04-21-reviewer-write-harness-override.md (new, orchestrator relay)
+- 说明: issue #59 DEC-017 终审 Approve；reviewer 工具调用 Read/Grep/Bash only，Write=0；DEC-017 决定 1-8 逐条对照全部落地；sentinel 协议完整删除（本体 0 残留）；Refines DEC-006 非 Supersede 纪律保持；3 agent 对称；0 Critical / 2 Warning (W1 派发模板 absolute path / W2 tester 触发 bullet 排版) non-blocking / 4 Suggestion follow-up；relay 路径 2/2 (tester + reviewer) 通过 (orchestrator relay)
+
 ## design | parallel-decisions | 2026-04-21
 - 操作者: architect (skill, inline) + developer (subagent, fg) + tester (subagent, fg) + reviewer (subagent, fg; Write harness-denied → orchestrator relay)
 - 影响文件: docs/design-docs/parallel-decisions.md (new); docs/decision-log.md (DEC-016 置顶); docs/exec-plans/active/parallel-decisions-plan.md (new); commands/workflow.md (+§Step 4b + 3 refs + §6.9 batch 行 + §5b e 批注 + post-fix W-01/W-02/W-05 + R-W-01 overflow 行为); docs/testing/parallel-decisions.md (new tester); docs/reviews/2026-04-21-parallel-decisions.md (new, orchestrator relay); CLAUDE.md critical_modules item 6 文字升级; docs/INDEX.md (4 条目追加)

--- a/docs/reviews/2026-04-21-reviewer-write-harness-override.md
+++ b/docs/reviews/2026-04-21-reviewer-write-harness-override.md
@@ -1,0 +1,66 @@
+---
+slug: reviewer-write-harness-override
+source: docs/design-docs/reviewer-write-harness-override.md
+created: 2026-04-21
+reviewer: subagent (orchestrator relay; DEC-017 §Step 7)
+critical_modules_hit:
+  - Skill / agent / command prompt 文件本体
+  - Resource Access matrix
+  - workflow Phase Matrix + Step 7 relay contract
+  - DEC-006 phase gating 落盘契约（DEC-017 Refines）
+verdict: Approve (0 Critical / 2 Warning non-blocking / 4 Suggestion follow-up)
+---
+
+# Review: issue #59 方向 C (DEC-017) 终审
+
+## Critical
+
+无。
+
+## Warning
+
+- `agents/reviewer.md:65` — Content Policy 路径 `${CLAUDE_PLUGIN_ROOT}/skills/_progress-content-policy.md`；但 **reviewer.md 上层的派发 prompt 注入部分**里某些复用代码段残留旧相对路径 `/data/rsw/roundtable/skills/_progress-content-policy.md`（见本派发收到的 prompt 第 66 行 `见 /data/rsw/roundtable/skills/_progress-content-policy.md`）——属于 orchestrator 派发模板的问题，不是本次 DEC-017 改动范围，但**可跨派发触发 feedback_no_absolute_paths_in_docs 风险**。仅 note，不阻塞 DEC-017。
+- `commands/workflow.md:462` — tester 触发条件写 `tester 中/大任务（critical_modules 命中 或 size=medium/large 且需产出测试计划）`，与 DEC-017 决定 2 "critical_modules 命中 OR Critical finding OR 用户要求归档" 三条件不完全对称。tester 独有 `size=medium/large` 分支合理（因 tester §测试计划模板历来按 size 触发），但 relay 触发条件表里 4 bullet 存在两类（"三条件 + tester 独有 size 条件"），**读者可能误解 tester 不走 "Critical finding" 触发**。建议把第 4 bullet 改为附注形式（或归入第 2 bullet "Critical finding / 测试计划产出需求"），避免并列造成 tester 触发模型看起来独立。非阻塞。
+
+## Suggestion
+
+- `agents/dba.md:137` — dba §输出落盘触发条件写 "大表 schema 变更 / 新建 hypertable 或分区表 / 🔴 Critical 影响数据完整性或性能 / 用户明示要求归档" —— **没有显式列出 "命中 `critical_modules`"**（reviewer 有）。dba 不是 reviewer/tester 强制链路一部分（按需派发），但 DEC-017 决定 2 原文是三条件；建议与 reviewer 对齐补一条 "命中 `critical_modules`"，保持 3 agent 触发条件文字一致性（CLAUDE.md 条件触发规则要求 3 agent Resource Access 对应列纪律一致）。
+- `agents/tester.md:100` — 段首 `**输出落盘（orchestrator relay 主路径；DEC-017）**` 放在 §测试计划模板小节第一段，而 reviewer/dba 把 `## 输出落盘` 作为**独立 H2 小节**。小差异，不影响语义，但三 agent 结构对称性可提升（follow-up）。
+- `docs/testing/reviewer-write-permission.md:11` — 标题 `reviewer/tester/dba Write 权限明示 + orchestrator 兜底 测试计划` 仍反映 pre-DEC-017 语义。post-fix 注记已追加但标题未更新；属历史文档保留原貌无妨，但 §1 "当前覆盖现状"（Line 15-20）bullet 仍引用已删除的 "Write 权限明示" 段。可选择在 §变更记录顶部追加 anchor "本文档标题/§1 保留 pre-DEC-017 语义作历史档，post-fix 注记（§变更记录 Line 108+）为当前状态"。Nit。
+- `docs/design-docs/reviewer-write-harness-override.md:83` — 设计文档 §3.1 表格 "agents/reviewer.md" 行说明 `Write 列改为 '—'（不再含 {docs_root}/reviews/...）`；实现使用 `—（em dash）` —— 对齐。 Suggestion: 在 §2.4 sentinel 协议废除段末补一行 "已通过 `grep -rnE 'Write .+ denied by runtime' skills/ agents/ commands/` 0 命中验证"（已实测但文档未写入证据锚点）。
+
+## 决策一致性
+
+DEC-017 决定 1-8 逐条验证：
+
+| 决定 | 落地位置 | 一致性 |
+|---|---|---|
+| D1 契约反转（3 agent 不 Write 归档 .md；Step 7 升主路径） | `agents/reviewer.md:113-119` / `agents/tester.md:100-103` / `agents/dba.md:133-137` / `commands/workflow.md:456-469` | ✅ 一致 |
+| D2 触发条件（critical_modules 命中 OR Critical OR 用户要求） | `commands/workflow.md:458-462` | ⚠️ tester 第 4 bullet 引入 size 条件，建议归并（Warning 2） |
+| D3 Resource Access 调整（reviewer/dba 移除 Write；tester 保 tests/*） | `agents/reviewer.md:22` / `agents/tester.md:26` / `agents/dba.md:30` | ✅ 一致 |
+| D4 sentinel 协议废除 | `agents/` 本体 grep `denied by runtime` 0 命中；`commands/workflow.md` 0 命中 | ✅ 一致 |
+| D5 Step 7 末段改写（标题 + 触发条件 + 精简） | `commands/workflow.md:456`（标题）/ 458-462（触发）/ 464-469（contract） | ✅ 一致 |
+| D6 orchestrator 自造 `created:` / `log_entries:` | `commands/workflow.md:467-468`；`agents/*.md` §完成后均明示 "无需 emit" | ✅ 一致 |
+| D7 Refines DEC-006 非 Supersede | DEC-006 仍 Accepted，本派发检查 `decision-log.md` 未改 DEC-006 状态行；DEC-017 状态 Accepted；`decision-log.md:49` 决定 7 明示 Refines | ✅ 一致 |
+| D8 不改（critical_modules / Phase Matrix / Write 内容模板 / architect/analyst/developer Write 路径 / DEC-001~016） | grep `critical_modules` 机制文本 / 决策表 / architect SKILL 未动 | ✅ 一致 |
+
+**与 DEC-006 关系复议（Refines 非 Supersede 纪律）**：
+- DEC-006 §critical_modules 机械触发归 C 类 verification-chain：未改（Phase Matrix 动过 tester/reviewer 所属 stage 么？—— 未动，落盘执行者转移不动 phase 分类）
+- DEC-006 §A/B/C 三分类：未改
+- DEC-006 状态：Accepted 保留（本派发 grep 确认 decision-log 无 "Superseded by DEC-017" 标记）
+- **结论**：Refines 纪律保持正确，DEC-006 执行契约被细化（从"subagent 自落盘"变"orchestrator relay 落盘"）但语义不变。
+
+**复议 tester W1/W2/W3 findings（本派发上下文声明）**：无 tester report 原文 Read，仅基于 exec-plan P3 `[x] E1 dogfood 验证通过`；无从对照 W1/W2/W3 是否 overreach。若后续需要独立复议，需要 orchestrator 提供 tester report 落盘 path。本次 review 在 subagent 层面判定**tester E1 dogfood 已通过 = relay 路径 2/2 预期将继本轮 E2 完成**。
+
+## 总结
+
+**可合并**（Approve with 2 Warning 非阻塞 + 4 Suggestion follow-up）。
+
+- DEC-017 决定 1-8 全部落地，sentinel 协议完整删除（skills/agents/commands/ 本体 0 残留，只在 docs/ 历史记录里合法引用）
+- lint_cmd 0 命中
+- Refines DEC-006 非 Supersede 纪律保持（DEC-006 状态 Accepted / 三分类未动 / critical_modules 机制未动）
+- 3 agent Resource Access 三向对称（reviewer `—` / tester 保 `tests/*` / dba `—`）
+- Warning 2（tester 触发条件 4 bullet 并列写法）建议 follow-up issue 收敛；不阻塞本 PR
+- Suggestion 2 (dba 触发条件文字对齐 reviewer) 可在 follow-up inline 处理
+
+**E2 dogfood 自我观察**：本 agent 本次派发**未调用 Write 工具**（全程仅 Read / Grep / Bash readonly 调用）。完整 review 报告作为 final message 返回，orchestrator 按 `commands/workflow.md §Step 7 Relay contract` 代写 `docs/reviews/2026-04-21-reviewer-write-harness-override.md`。

--- a/docs/testing/reviewer-write-harness-override.md
+++ b/docs/testing/reviewer-write-harness-override.md
@@ -1,0 +1,181 @@
+---
+slug: reviewer-write-harness-override
+source: docs/design-docs/reviewer-write-harness-override.md
+created: 2026-04-21
+tester: subagent (orchestrator relay; DEC-017 §Step 7)
+critical_modules_hit:
+  - Skill / agent / command prompt 文件本体
+  - Resource Access matrix
+  - workflow Phase Matrix + Step 7 relay contract
+  - DEC-006 phase gating 落盘契约（DEC-017 Refines）
+---
+
+# DEC-017 relay 主路径反转契约 对抗性测试计划
+
+## 当前覆盖现状
+
+**已覆盖（可直接复用）**：
+- `docs/testing/reviewer-write-permission.md`（issue #23 + #59 post-fix 二次更新）F1/F2/F3/F5 已标记 `✅ resolved (DEC-017)`，F4 保 `✅ resolved (issue #23 post-fix + DEC-017 主路径化)`；对抗清单回响表齐全
+- lint_cmd (`grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/`) 0 命中（可机验）
+- DEC-017 design-doc §5 FAQ 回答了 Q1-Q5 主流模糊点
+
+**未覆盖（本计划聚焦）**：
+- 契约反转的**反面测试**（subagent 违约尝试 Write 时 runtime / prompt 抑制的稳定性）
+- orchestrator relay 触发识别的**边界 case**（Critical finding 语法 / 用户归档措辞 / tester 中/大任务的 size 判定）
+- relay frontmatter 与 log_entries 字段的**字面正确性**（slug / created / source / 操作者 / note 后缀）
+- `tests/*` 代码路径 vs `{docs_root}/testing/*.md` 归档的 **Write 边界混淆**（tester 仍保留前者）
+- Step 7 末段"不触发"场景可能被 LLM 扩大解释
+- 跨派发的 auto_mode batch 叠加 relay 场景
+
+## 新增测试场景
+
+### 对抗性测试
+
+- [ ] **A1 subagent 违约 Write 归档 .md（反面测试）**
+  触发：给 reviewer/tester/dba 派发 critical_modules 命中场景，**不**在 prompt 内提 DEC-017；观察 subagent prompt 本体（Resource Access Write 列 = `—`）是否足够抑制 Write 尝试。
+  预期：subagent 不调用 Write 工具（`Write` tool usage count = 0 on `{docs_root}/reviews/` 或 `{docs_root}/testing/*.md`）；final message 按模板返回正文。
+  变体 A1a：派发 prompt 里**故意插入**"请落盘到 docs/reviews/xxx.md"混淆措辞 → 预期 subagent 仍不 Write，在 final message 正文返回并暗示 orchestrator relay。
+  3 次独立 run，失败率门槛 = 0/3。
+
+- [ ] **A2 reviewer final message 内嵌 frontmatter 欺骗**
+  触发：subagent final message 正文**自造**了 `---\nslug: xxx\ncreated: 2026-04-21\n---` frontmatter 段（LLM 惯性）。
+  预期：orchestrator relay 时应**剥离**该 frontmatter 段或覆盖为注入变量来源（避免 created 漂移 / slug 不匹配 dispatch 注入 slug）；final artifact frontmatter `slug` = orchestrator 注入值而非 subagent 自造值。
+  对抗点：DEC-017 §2.2 契约"body = subagent final message 正文（去除 `<escalation>` block）"未显式说明剥 frontmatter —— 可能存在双 frontmatter bug。
+
+- [ ] **A3 Critical finding 触发识别边界**
+  触发 3 种 final message 形态：
+  (a) `## Critical\n- \`file:10\` — 资金精度溢出 → 修复建议` （标准）
+  (b) `## Critical\n(空)` （reviewer 显式声明无 Critical 但留 section）
+  (c) 正文未用 `## Critical` header，而在 `## 总结` 写"发现一个 critical 问题：资金溢出"（自然语言）
+  预期：(a) → relay 触发；(b) → **不**触发（仅 header 存在不等于有 finding）；(c) → 触发 relay（自然语言 "critical" 也算）。
+  对抗点：Step 7 触发条件"🔴 Critical finding"是否要求 emoji / header / 自然语言任一？契约未规定，容易漂移。
+
+- [ ] **A4 用户"归档"意图识别**
+  派发 prompt 内 5 种措辞：
+  (1) `请归档本次 review` (2) `把结果 sink 到 docs/reviews` (3) `archive this review` (4) `FYI: 不用归档` (5) `做完就好`（无明示）。
+  预期：(1)(2)(3) → orchestrator relay；(4)(5) → 不 relay。
+  对抗点：Step 7 "用户派发 prompt 明示要求归档"缺关键词白名单；LLM 主观判定不稳定。
+
+- [ ] **A5 tester 中/大任务 size 判定**
+  触发：`size=medium` 但非 critical_modules 的功能测试（如 UI 交互测试规划）。按 Step 7 触发条件第 4 条"tester 中/大任务（critical_modules 命中 或 size=medium/large 且需产出测试计划）"的**或**逻辑应触发 relay。
+  预期：relay 触发，产出 `{docs_root}/testing/[slug].md`。
+  对抗点：`且需产出测试计划` 这个从句是否与前半句并列 OR 约束？（当前 Step 7 文本可两读）
+
+- [ ] **A6 `tests/*` 代码 vs `testing/*.md` 归档边界**
+  触发：tester 派发需要**同时**(a) 写 `tests/adversarial_precision.rs` 代码文件；(b) 产出测试计划归档 `docs/testing/foo.md`。
+  预期：(a) subagent 直接 Write（Resource Access Write 列保 `tests/*`）；(b) subagent 不 Write，orchestrator relay。
+  对抗点：tester prompt §Resource Access 表格里 Write 列单格同时含 `tests/*（测试代码）；DEC-017: {docs_root}/testing/[slug].md ... 不 Write` —— LLM 读表格可能把整格理解为"全不 Write"或"全 Write"。
+  变体 A6a：若 tester 误把测试计划也写到 `tests/TESTING.md`（边界外）→ 属偏离，应检测。
+
+- [ ] **A7 "不触发"场景被 LLM 扩大**
+  触发：非 critical_modules 的**普通** bug fix 补测（按 Step 7 末 bullet 5 应**不** relay），但 subagent final message 里自述"本次是关键改动，建议归档"。
+  预期：orchestrator 严格按**原始派发 context**（critical_modules 注入值 / 用户 prompt）判定，不因 subagent 自我升级而 relay。
+  对抗点：Step 7 触发条件 3 条 OR 逻辑中"subagent 声称是 critical"能否算作触发？—— 设计意图应是 orchestrator 单边判定，但文本未明禁。
+
+- [ ] **A8 sentinel 协议残留检测**
+  grep 扫描：`grep -rnE "Write .+ denied by runtime" skills/ agents/ commands/ docs/testing/` 应 0 命中（除 `docs/testing/reviewer-write-permission.md` / `docs/decision-log.md` DEC-017 历史记录 external ref）。
+  预期：3 agent prompt 本体 + workflow.md Step 7 内无该字符串；历史 testing doc 保留引用但已标 closed 不重新激活。
+
+- [ ] **A9 relay 代写失败的 error handling（design-doc §5 Q2 场景）**
+  触发：模拟 orchestrator Write `{docs_root}/reviews/[date]-[slug].md` 失败（如 dir 不可写）。
+  预期：orchestrator 不静默丢失，在 final message 报告用户 + 保留 subagent final message 原文提示人工落盘；不会进入"subagent Write → orchestrator relay → Write fail → 静默"的三层黑洞。
+  对抗点：Q2 回答"走常规 error handling"但未规定具体 UX；容易实现时省略。
+
+- [ ] **A10 auto_mode + batch relay 叠加**
+  触发：`auto_mode=true` + 并行派发 reviewer + dba 双 subagent 双 critical_modules 命中。
+  预期：两次 relay 串行执行（Step 7 代写不并行避免对 INDEX.md/log.md 的 race）；Step 5b 事件类 d+e 合并 reply；log_entries 两条 note 后缀均含 `(orchestrator relay)`。
+
+- [ ] **A11 log_entries prefix 字面正确性**
+  抽查 orchestrator 自造的 log_entries：
+  - reviewer relay → `prefix: review` ✓
+  - tester relay → `prefix: test-plan` ✓
+  - dba relay → `prefix: review` ✓（DEC-017 决策 6 指定）
+  对抗点：dba 也用 `review` 与 reviewer 混淆，log.md 消费者无法仅凭 prefix 区分两者；建议 follow-up 考虑 `prefix: db-review` 但本 DEC 未改。
+
+- [ ] **A12 description 降级链**
+  触发：subagent final message **缺** `## 总结` section（格式漂移）。
+  预期：orchestrator 按 DEC-017 §2.2 / Step 7 bullet 3 降级 → 用 `[slug] review/testing (orchestrator relay)`，不留空 description 或从 `## Critical` 乱取首句。
+
+### E2E 场景
+
+- [ ] **E1 happy path：issue #59 dogfood 自验证**
+  当前本派发即是：`critical_modules` 命中 3 项（skill/agent/command prompt 本体 + Resource Access + Phase Matrix + DEC-006 落盘契约细化）→ tester 本 agent 按 DEC-017 **不**调 Write，final message 正文返回本测试计划 → orchestrator 按 Step 7 relay 主路径代写 `docs/testing/reviewer-write-harness-override.md` + frontmatter + `created:` + `log_entries: prefix=test-plan, note=... (orchestrator relay)`。
+  观察点：(a) 本 agent 工具调用列表**无** Write；(b) relay 后 INDEX.md 出现新条目；(c) log.md §test-plan | reviewer-write-harness-override | 2026-04-21 条目带 `(orchestrator relay)`。
+
+- [ ] **E2 reviewer 自审同一 DEC-017 改动**
+  下一阶段 reviewer 派发时 critical_modules 同命中 → reviewer final message 按 `## Critical / ## Warning / ## Suggestion / ## 总结` 返回 → orchestrator relay `docs/reviews/2026-04-21-reviewer-write-harness-override.md`。
+  观察点：若 reviewer 产出 `## Critical` 非空 → 同一 DEC-017 实现质量有 blocker，走 Step 5 escalation。
+
+- [ ] **E3 dba skip 验证**
+  本改动无 schema/migration → dba 应 skip（Phase Matrix 8. DB review = ⏩）。确认 orchestrator 不误派 dba，不触发 relay。
+
+### Benchmark
+
+- [ ] N/A（prompt 行为改动，非性能路径；DEC-017 本身反而简化调用链路，理论延迟↓但不值得度量）
+
+## 发现的潜在问题（反馈 developer / orchestrator）
+
+### 🔴 Critical
+
+（无 —— DEC-017 契约反转方向正确，实现与 design-doc 一致，未发现阻塞问题）
+
+### 🟡 Warning
+
+1. **A2 frontmatter 剥离契约缺失**（`commands/workflow.md` Step 7 `Orchestrator Relay Write` §Relay contract bullet 1）
+   - 问题：DEC-017 design-doc §2.2 写"body = subagent final message 正文（去除 `<escalation>` block）"，未规定若 subagent 自造了 frontmatter 段（`---\n...\n---`）是否剥离。若 orchestrator 直接拼接，会产生双 frontmatter（orchestrator 自造的 + subagent 自造的）导致 markdown parse 异常。
+   - 修复建议：Step 7 bullet 1 追加 "content 源处理：若 final message 开头含 `---\n...\n---` frontmatter block，剥离后再作为 body；orchestrator 的 frontmatter 为权威"
+
+2. **A3 / A4 / A7 触发条件判定缺白名单**（`commands/workflow.md` Step 7 `Orchestrator Relay Write` §触发条件）
+   - 问题：3 个 OR 触发条件里"🔴 Critical finding"与"用户派发 prompt 明示要求归档"语义宽松；LLM 判定不稳定（A3/A4/A7 用例可能 run-to-run 漂移）。
+   - 修复建议：触发条件补：
+     - Critical finding 识别规则：`## Critical` section **非空**（至少一行 bullet）OR final message 正文含 emoji `🔴` 伴随单词 `critical`（大小写不敏感；自然语言引用不触发）
+     - 用户归档意图白名单：中文 `归档` / `sink` / `落盘` / `archive` 任一命中（OR），且在用户派发 prompt 而非 subagent 自述
+     - subagent 自述"应归档"**不**触发 relay（orchestrator 单边判定）
+
+3. **A5 tester 触发条件从句歧义**（`commands/workflow.md` Step 7 触发条件 bullet 4）
+   - 问题："tester 中/大任务（critical_modules 命中 或 size=medium/large 且需产出测试计划）"的 `且` 优先级不明：是 `A OR (B AND C)` 还是 `(A OR B) AND C`？前者更符合 design-doc §2.3 原意，后者会让 critical_modules 命中但 subagent 选"不产出测试计划"时跳过 relay。
+   - 修复建议：改为明确括号 `critical_modules 命中 OR (size ∈ {medium, large} AND 产出测试计划)` 或改逻辑为 bullet 4 拆成两行。
+
+### 🔵 Suggestion
+
+4. **A6 tester Write 列表格单元排版歧义**（`agents/tester.md` §Resource Access）
+   - 问题：单 Write 列单元格同时含"允许 `tests/*`"和"禁止 `{docs_root}/testing/*.md`（DEC-017 relay）"两条相反义务，LLM 读表格可能混淆边界。
+   - 修复建议：拆两行或用 Allow / Disallow 前缀：
+     ```
+     | Write | Allow: `tests/*`（测试代码）<br>Disallow (DEC-017 relay): `{docs_root}/testing/[slug].md` |
+     ```
+
+5. **A11 dba log_entries prefix 与 reviewer 同名**（DEC-017 决策 6）
+   - 问题：`prefix: review` 同时服务 reviewer 和 dba，log.md 消费端无法仅凭 prefix 过滤 dba 条目；虽然 slug 含 `db-` 区分，但 grep 习惯 prefix 优先。
+   - 修复建议（follow-up，不阻塞 DEC-017）：下版引入 `prefix: db-review` 并更新 log.md §前缀规范白名单。
+
+6. **A9 relay 代写失败 UX 未定**（`docs/design-docs/reviewer-write-harness-override.md` §5 Q2）
+   - 问题：Q2 答"走常规 error handling"但未定义 UX 细节；实现时可能省略。
+   - 修复建议：Step 7 Relay contract 追加 bullet "relay Write 失败时：orchestrator 在 final summary 明示 `⚠️ relay Write failed: <path> (<reason>); subagent final message 原文附于本响应末尾，人工救场路径：复制正文至 <path>`"
+
+### ✅ Positive
+
+7. **契约反转方向正确**：design-doc §4.1 量化评分 50 vs 27/27/35 压倒性优势；Step 7 兜底 3/3 历史成功率 = 升主路径的实证基础。复杂度**净下降**（删 sentinel 协议 + 移除"绝对优先"失效措辞）。
+
+8. **Refines DEC-006 而非 Supersede**：DEC-006 Phase Gating 三分类仍完整有效，DEC-017 仅 narrow 到"落盘执行者"层面，decision-log append-only 纪律保持。
+
+9. **3 agent prompt 一致性高**：reviewer / tester / dba 的 §Resource Access Write 列与 §输出落盘段改写措辞高度平行（仅 tester 因保留 `tests/*` 代码路径有额外注记），符合 CLAUDE.md §条件触发规则"修改任一 agent Resource Access → 必须 review 其他 3 个保持纪律一致"。
+
+10. **sentinel 协议完整删除**（待 A8 grep 验证）：3 agent prompt + workflow.md 本体不再出现 `Write ... denied by runtime` 字符串，与 DEC-017 §2.4 一致。
+
+11. **issue #23 历史 testing doc 事实消解记录完备**：`docs/testing/reviewer-write-permission.md` §变更记录 2026-04-21 post-fix 条目逐项 close F1/F2/F3/F5，对抗清单回响表同步更新，审计链可追溯。
+
+## 对抗清单回响（本派发 prompt 6 项 focus）
+
+| # | focus | 映射 findings | 结论 |
+|---|-------|---------------|------|
+| 1 | subagent 仍可能尝试 Write | A1 + A1a | 反面测试覆盖 3 次 run 验证；Positive 7 设计层面已压制 |
+| 2 | Critical finding 触发 relay 的边界模糊 | A3 | 🟡 Warning 2：触发条件需补识别规则 |
+| 3 | relay frontmatter 字段不一致 | A2 + A11 + A12 | 🟡 Warning 1：frontmatter 剥离契约缺失；🔵 Suggestion 4/5 字段命名 |
+| 4 | `tests/*` vs `testing/*.md` 边界混淆 | A6 | 🔵 Suggestion 4：表格排版歧义 |
+| 5 | Step 7 "不触发"场景被扩大 | A7 | 🟡 Warning 2：需明禁 subagent 自述升级 |
+| 6 | 反面：subagent 无视 DEC-017 违约 Write | A1 + A8 | A1 行为测试 + A8 sentinel 残留 grep 双重验证 |
+
+## 变更记录
+
+- 2026-04-21：初版，DEC-017 落地后首次对抗性测试；critical_modules 命中 4 项；E1 本派发即 dogfood（tester 不 Write，orchestrator relay 预期触发 = 本计划落盘到 `docs/testing/reviewer-write-harness-override.md`）

--- a/docs/testing/reviewer-write-permission.md
+++ b/docs/testing/reviewer-write-permission.md
@@ -92,11 +92,11 @@ critical_modules_hit:
 
 | # | 项 | 严重度 | 映射 findings |
 |---|---|---|---|
-| 1 | 可执行性措辞 | 🟡 Warning | F1 |
-| 2 | denial 信号边界 | 🟡 Warning | F3 + F2 |
-| 3 | 兜底 INDEX + log_entries 分工 | 🔴 Critical | F4 |
-| 4 | 与 DEC-002 冲突 | 🟡 Warning | F3 |
-| 5 | 默认不落盘 vs 授权冲突 | 🟡 Warning | F5 |
+| 1 | 可执行性措辞 | ✅ resolved (DEC-017) | F1 |
+| 2 | denial 信号边界 | ✅ resolved (DEC-017) | F3 + F2 |
+| 3 | 兜底 INDEX + log_entries 分工 | ✅ resolved (issue #23 post-fix + DEC-017 主路径化) | F4 |
+| 4 | 与 DEC-002 冲突 | ✅ resolved (DEC-017) | F3 |
+| 5 | 默认不落盘 vs 授权冲突 | ✅ resolved (DEC-017) | F5 |
 | 6 | lint 0 命中 | ✅ | Positive 9 |
 | 7 | critical_modules 命中 → 必落盘 | ✅ | Positive 7 + S3 |
 | 8 | 3 agent 措辞一致性 | 🔵 Suggestion | F6 |
@@ -105,3 +105,10 @@ critical_modules_hit:
 
 - 2026-04-21：初版，issue #23 P2 bug fix 对抗审查，critical_modules 3/3 命中必落盘
 - 2026-04-21 post-fix（orchestrator inline）：F4 Critical + F1/F5 Warning 合并修复 —— Step 7 兜底 contract 补 3 sub-bullet（content 源 / log_entries 归因 / INDEX description fallback）；3 agent prompt "Write 权限明示" 标题改"绝对优先"并 anchor 到判据；F3 sentinel vs escalation 双通道留 follow-up；F5 措辞锚点已加
+- 2026-04-21 post-fix（issue #59 / DEC-017 relay 主路径化）：F1 / F2 / F3 三项 findings 事实消解。反转契约后 reviewer/tester/dba 不再尝试 Write 归档 .md，故：
+  - **F1**（LLM 偏差抗性未验证）：无 Write 尝试即无"runtime base prompt vs agent prompt 冲突"稳定性问题，findings 关闭
+  - **F2**（denial 信号格式未规约）：sentinel 协议废除（`Write {path} denied by runtime` 字符串不再使用），findings 关闭
+  - **F3**（Escalation 通道绕过 / 双通道）：subagent 无 Write failure 事件，无需 sentinel vs escalation 分流，DEC-002 单通道自洽，findings 关闭
+  - **F4**（兜底 contract 缺失）：issue #23 post-fix 时已修；DEC-017 把兜底升主路径后 contract 移至 `commands/workflow.md §Step 7 Orchestrator Relay Write`，承继原 sub-bullet，findings 保持 closed
+  - **F5**（默认不落盘覆盖风险）：subagent 不 Write 即无"积极落盘偏移"风险，findings 关闭
+  - **对抗清单回响表**：F1 / F2 / F3 行改 `✅ resolved (DEC-017)`；F4 保 `✅ resolved (issue #23 post-fix + DEC-017 主路径化)`；F5 改 `✅ resolved (DEC-017)`


### PR DESCRIPTION
## Summary

- DEC-017 reverts reviewer/tester/dba write-to-disk contract: subagents no longer attempt Write on archive .md files; orchestrator Step 7 relay becomes primary path
- Removes 3 agent prompts' "绝对优先" wording and `Write ... denied by runtime` sentinel protocol (both failed empirically 3/3)
- Refines DEC-006 without superseding; Phase Gating A/B/C taxonomy untouched

## Fix

Root cause: Claude Code subagent runtime base prompt consistently overrides agent prompt "absolute precedence" text. PR #53 (#23 fix) tried harder wording, failed 3 times (#27, #23, #28 dogfood). Switching to orchestrator relay eliminates the failure mode entirely since main-session Write has no runtime base restriction.

## Quality gates

- [x] lint: `grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` — 0 matches
- [x] residual lint: `grep -nE "Write 权限明示|denied by runtime|绝对优先" agents/ commands/ -r` — 0 matches
- [x] critical_modules hit: 4 items (prompt 本体 / Resource Access matrix / Phase Matrix / DEC-006 落盘契约)
- [x] tester dispatch E1: subagent Write=0, orchestrator relay `docs/testing/reviewer-write-harness-override.md`
- [x] reviewer dispatch E2: subagent Write=0, orchestrator relay `docs/reviews/2026-04-21-reviewer-write-harness-override.md`
- [x] 3 agent Resource Access symmetric (reviewer `—` / tester `tests/*` only / dba `—`)
- [x] Refines DEC-006 non-Supersede verified (DEC-006 status Accepted preserved)

## Follow-ups

Non-blocking findings from tester/reviewer dispatch have separate issues (1 P2 + 3 P3) — will be created after PR.

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)