### PR TITLE
fix(prompts): replace absolute path residues in runtime prompts (#68)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ roundtable plugin：多角色 AI 开发工作流 Claude Code plugin。将 analys
 - **lint_cmd**: `grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/`（target-project 名 / 外部路径硬编码扫描，应 0 命中。**DEC-00X 引用本就合法**，不再扫 —— 过去误把 DEC-003/004/005 当"未完成 DEC 泄漏"是规则 bug）
 - **test_cmd**: dogfood run —— `/roundtable:workflow` 在 target 项目跑一轮做 E2E 验证（见 `docs/testing/p4-self-consumption.md` 样例）
 - **build_cmd**: N/A
-- **dev_cmd**: `claude --plugin-dir /data/rsw/roundtable`（本地测试 plugin）
+- **dev_cmd**: `claude --plugin-dir <path-to-roundtable-clone>`（本地测试 plugin；将 `<path-to-roundtable-clone>` 替换为本地仓库绝对路径）
 
 ## 条件触发规则
 

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -68,7 +68,7 @@ argument-hint: <task description>
 
 > **位置说明**（C1 修复）：本 step 虽按编号紧随 Step 0，但语义上是 **session 生命期常驻规则**，而非"执行一次"的 bootstrap。`{docs_root}` / `target_project` 必须由 Step 0 先填充，本 step 在**首次用户机制提问**到达时才激活；Step 0 完成前的任何提问**延后 sink**（先回答，等 Step 0 完成后再追加）。
 
-用户**直接提问**（非 `<escalation>` / 非 A 类菜单 `问:` / 非 skill 阶段调研）涉及 roundtable 机制时，orchestrator 回答后**自动追加** Q&A 到 `{docs_root}/faq.md`（不存在则创建 minimal header；`<project>` 字面值 = `basename(target_project)`，例如 `/data/rsw/roundtable` → `roundtable`）：
+用户**直接提问**（非 `<escalation>` / 非 A 类菜单 `问:` / 非 skill 阶段调研）涉及 roundtable 机制时，orchestrator 回答后**自动追加** Q&A 到 `{docs_root}/faq.md`（不存在则创建 minimal header；`<project>` 字面值 = `basename(target_project)`，例如 `target_project=/path/to/myapp` → `myapp`）：
 
 ```
 # <project> FAQ

--- a/docs/testing/abspath-residue-68.md
+++ b/docs/testing/abspath-residue-68.md
@@ -1,0 +1,62 @@
+# 测试报告：issue #68 绝对路径残留修复回归
+
+> 测试范围：`commands/workflow.md` Step 0.5 FAQ Sink example；`CLAUDE.md` §工具链覆盖 dev_cmd。
+>
+> 关联：issue #68（P3 bug）；源自 `docs/reviews/2026-04-21-reviewer-write-harness-override.md` W1。
+
+## 背景
+
+Reviewer W1 flag：派发 prompt 中出现 `/data/rsw/roundtable/skills/_progress-content-policy.md` 绝对路径，
+在其他用户机器上 plugin 无法解析。违反 `feedback_no_absolute_paths_in_docs`。
+
+实际定位：
+
+- `skills/_progress-content-policy.md` 的引用（`agents/{developer,tester,reviewer,dba}.md`）**已**使用 `${CLAUDE_PLUGIN_ROOT}`（PR #64 DEC-017 完成），无需修改。
+- 残留在两处**非引用**语境：
+  1. `commands/workflow.md:71` — FAQ Sink Protocol 示例用 `/data/rsw/roundtable` 说明 `basename(target_project)`。
+     这是 **runtime prompt** 的一部分，会随 orchestrator dispatch 下发到 subagent；虽是"example 字面值"
+     而非路径引用，但派发时被 reviewer 模式扫描直接识别为绝对路径命中。
+  2. `CLAUDE.md:38` — `dev_cmd` 示例含 `--plugin-dir /data/rsw/roundtable`，泄漏本地克隆路径。
+
+## 修复
+
+| 文件 | 修改 |
+|---|---|
+| `commands/workflow.md:71` | 示例 `/data/rsw/roundtable` → `target_project=/path/to/myapp` → `myapp` |
+| `CLAUDE.md:38` | `/data/rsw/roundtable` → `<path-to-roundtable-clone>` 占位符 + 替换说明 |
+
+注：`docs/**/*.md` 下的 dogfood trace / exec-plan / analyze / review 历史档保留绝对路径 —— 属于**内部
+贡献者溯源**语境，非 runtime prompt 组合，不会被 dispatch 注入到 subagent prompt。
+
+## 回归测试
+
+**R-01**：runtime prompt 文件无绝对路径残留
+
+```bash
+grep -rn '/data/rsw/roundtable' commands/ agents/ skills/ CLAUDE.md
+# 预期：0 命中
+```
+
+**R-02**：lint_cmd 无新增命中
+
+```bash
+grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/
+# 预期：0 命中（与 CLAUDE.md §工具链覆盖 lint_cmd 一致）
+```
+
+**R-03**：`_progress-content-policy.md` 4 处引用仍用 `${CLAUDE_PLUGIN_ROOT}`
+
+```bash
+grep -rn '_progress-content-policy' agents/ | grep -v CLAUDE_PLUGIN_ROOT
+# 预期：0 命中（所有引用必须 envvar 形式）
+```
+
+## 决策一致性
+
+无新 DEC；属 bugfix 范畴。与 `feedback_no_absolute_paths_in_docs` 一致性恢复。
+
+## 未修范围
+
+- `docs/exec-plans/` / `docs/analyze/` / `docs/reviews/` 历史档中的绝对路径：保留（历史档不随 dispatch 下发，
+  属内部贡献者读物）。若未来需要全局清洗可另开 issue。
+- `docs/decision-log.md:117` / `:337` 等条目中的绝对路径：同上，保留。


### PR DESCRIPTION
Closes #68.

## Summary

- `commands/workflow.md:71` — FAQ Sink Protocol example used `/data/rsw/roundtable` as a literal; replaced with `/path/to/myapp` → `myapp` generic placeholder. Runtime prompt, will be injected into subagent dispatch.
- `CLAUDE.md:38` — `dev_cmd` leaked local clone path; replaced with `<path-to-roundtable-clone>` placeholder + inline note.
- `_progress-content-policy.md` references in `agents/{developer,tester,reviewer,dba}.md` were already using `${CLAUDE_PLUGIN_ROOT}` (DEC-017 / PR #64). The reviewer W1 flag in `docs/reviews/2026-04-21-reviewer-write-harness-override.md` was triggered by the two collateral residues above.

Historical docs under `docs/exec-plans/`, `docs/analyze/`, `docs/reviews/`, `docs/decision-log.md` retain absolute paths — internal contributor dogfood trace, not injected into dispatch prompts.

## Test plan

- [x] `grep -rn '/data/rsw/roundtable' commands/ agents/ skills/ CLAUDE.md` → 0 hits
- [x] `grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` (lint_cmd) → 0 hits
- [x] `_progress-content-policy` references in agents/*.md all use `${CLAUDE_PLUGIN_ROOT}` envvar form
- [ ] Next `/roundtable:workflow` dispatch: confirm reviewer's dispatched prompt no longer contains `/data/...` literal

Regression note: `docs/testing/abspath-residue-68.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)