### PR TITLE
fix(roundtable): batch follow-up for #84 dogfood findings (#97)

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -84,6 +84,8 @@ echo '{"ts":"<iso-utc>","role":"reviewer","dispatch_id":"{{dispatch_id}}","slug"
 
 ## 审查维度
 
+**门槛合规（DEC 专项）**：PR 新增 / 修改 `decision-log.md` DEC 条目时必检 —— 新 DEC 是否命中 `decision-log.md` §开立门槛 5 类必开 + 不踩 Red Flags 负例反模式。严重度按 reviewer judgement 归类（同下文 🔴/🟡/🔵 三级）。
+
 **🔴 Critical（必须修）**：
 - 资金/账户/权限等业务逻辑错误
 - 整数溢出/精度丢失

--- a/commands/lint.md
+++ b/commands/lint.md
@@ -66,6 +66,12 @@ argument-hint: [target project name or path, optional]
 
 **定位**：本节是 `decision-log.md` 元规则（门槛 + 铁律 + 状态机）的**执行层审查工具**。机械判定条款全进本节；门槛类 judgement（某 DEC 是否真属 5 类必开）留 architect / reviewer。
 
+**实施共性**（L6.1-L6.5 共用，各子节不再重述）：
+
+- **code-fence-aware 扫描**：skip 位于 ` ```markdown ` / ` ``` ` 围栏内的 `### DEC-` 行（含 template `### DEC-[编号] [标题]`）—— 避免模板 / 示例误报
+- **DEC 编号 regex**：`DEC-\d{3}`（非 `DEC-\w+`）—— 避免占位符 `DEC-xxx` / `DEC-MMM` 误报
+- **Grandfather DEC-001~020**：字面值 / 字符数 / 必填字段检查跳过 DEC-001 ≤ NNN ≤ DEC-020（含 DEC-017 Amendment）；影响范围 ≤10 行纪律单独走 L6.2 自有范围 DEC-013~020；L6.4 悬空引用**例外全量扫描**（引用语义不受 grandfather 影响）
+
 #### L6.1 状态流转
 
 - 长期 **Proposed** > 30 天未决 → 告警「长期 Proposed：建议评估 Accepted / Rejected」
@@ -79,13 +85,14 @@ argument-hint: [target project name or path, optional]
 - 段内行数（按字面换行符）> 10 → 告警「影响范围超 10 行，建议移 design-doc `## 影响文件清单`」
 - **不回溯** DEC-013~020（铁律 5 声明不回溯；lint 扫描跳过 DEC-013 ≤ NNN ≤ DEC-020）
 
-#### L6.3 状态行字面值 + ≤60 字符
+#### L6.3 状态行字面值 + ≤60 字符 + 新 DEC 必标 Provisional
 
 - 扫每条 DEC 的 `**状态**:` 行
 - 必须以 6 种字面值之一起首：`Proposed` / `Provisional` / `Accepted` / `Superseded by DEC-xxx` / `Rejected`（可并列附 `Refined by DEC-xxx`）
 - "起首" 判定字符终止于第一个全角/半角括号前（遇 `（` / `(` 即停）；括号内补语不计入字面值匹配
 - 状态行总字符 > 60 → 告警「状态行超 60 字符，建议附加上下文放正文」
-- **不回溯**（DEC-025 决定 10 扩用）：跳过 DEC-001 ≤ NNN ≤ DEC-020 的字符数与字面值检查（含 DEC-017 Amendment）。grandfather clause 仅适用字面值/字符数；悬空引用 L6.4 仍全量扫描
+- **新 DEC（落盘日 ≤ 7 天）状态行必须起首 `Provisional`**；否则告警「新 DEC 漏标 Provisional」
+  - 判定依据：DEC `**日期**` 字段 vs 当前日期差 ≤ 7 天
 
 #### L6.4 Refined by / Superseded by 引用完整性
 
@@ -98,8 +105,6 @@ argument-hint: [target project name or path, optional]
 - 每条 DEC 必含 `**日期**` / `**状态**` / `**上下文**` / `**决定**` / `**相关文档**` / `**影响范围**` **6 项**
 - 任一缺失 → 告警「DEC-NNN 缺字段：<清单>」
 - `**备选**` / `**理由**` 非强制（有则检，无则跳）
-- **实施硬约束**：扫描 code-fence 感知 —— skip 位于 ` ```markdown ` / ` ``` ` 围栏内的 `### DEC-` 行（含 template 模板 `### DEC-[编号] [标题]`）；regex 用 `DEC-\d{3}` 而非 `DEC-\w+`（避免占位符 `DEC-xxx` / `DEC-MMM` 误报，L6.4 同此规则）
-- **不回溯**（grandfather）：DEC-017 Amendment 缺 `**相关文档**` 属历史格式，跳过必填字段检查（同 L6.3 不回溯）；DEC-001 ≤ NNN ≤ DEC-020 全部 grandfather
 
 ### 7. exec-plans 过期审计
 - 扫描 `{docs_root}/exec-plans/active/` 下每个计划

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -174,7 +174,7 @@
 
 ### bugfixes
 
-（Tier 2 postmortem 暂无条目；DEC-014）
+- [batch-97-dogfood-findings.md](bugfixes/batch-97-dogfood-findings.md) — issue #97 batch follow-up for #84（DEC-025/026 落盘后 dogfood findings）：5 改动合并 1 PR（F1 lint L6.3 Provisional 首值 / F2 铁律 4 tradeoff 归属 / F3 DEC-011 锚点漂移 post-fix / F4 lint §6 preface 重构 / F5 reviewer §审查维度 加门槛合规）；Fixed；supersedes #91/92/93/95/96
 
 ## 主题 slug 约定
 

--- a/docs/bugfixes/batch-97-dogfood-findings.md
+++ b/docs/bugfixes/batch-97-dogfood-findings.md
@@ -1,0 +1,68 @@
+---
+slug: batch-97-dogfood-findings
+created: 2026-04-22
+status: Fixed
+severity: minor
+related_issue: #97
+related_dec: DEC-011 / DEC-025 / DEC-026
+---
+
+# #84 DEC-025/026 落盘后 dogfood findings batch follow-up Postmortem
+
+## 1. 现象
+
+`/roundtable:workflow` 对 issue #84（DEC-025 / DEC-026 sustainability umbrella）的 Stage 6/7 产出 9 Warning + 6 Suggestion；其中 6 条属可机械落实的 follow-up（原拟拆 #91~#96 六条 issue，按用户 #717 指示合并为 #97 batch）。发现项未阻塞落盘但留下 5 处"弱声明 / 漏字段 / 引用漂移"，若不补会在下一轮 dogfood 时回放。
+
+## 2. 根因
+
+DEC-025 落盘同时触发了多处耦合，导致以下五类残留：
+
+| 编号 | 根因 | 位置 |
+|------|------|------|
+| F1 | L6.3 字面值检查没涵盖"新 DEC 必带 Provisional 首值" —— DEC-025 决定 5 引入 Provisional 状态但 lint 侧未加时间窗判定 | `commands/lint.md` L6.3 |
+| F2 | 铁律 4 对 "新 tradeoff 才开新 DEC" 没说 tradeoff 的判定 / 升级路径，architect 与 reviewer 分歧时无默认裁决人 | `docs/decision-log.md` §铁律 4 |
+| F3 | DEC-025 决定 8 在 `skills/architect/SKILL.md` §阶段 2 第 8 步前插入自问句，使 DEC-011 正文 "§阶段 2 第 8 步" 字面指代变化（原指追加 decision-log，现指门槛自问句） | `docs/decision-log.md` DEC-011 |
+| F4 | L6.1-L6.5 有重复的 code-fence 感知 / regex 约束 / grandfather 声明，编辑成本高且易漂移 | `commands/lint.md` §6 |
+| F5 | reviewer `§审查维度` 只有 Critical/Warning/Suggestion 三级严重度，无 DEC-025 §开立门槛的专项检查维度 | `agents/reviewer.md` §审查维度 |
+
+均非实现缺陷，而是元规则落盘时的信息完整性 / 一致性漏洞 —— 属 DEC-014 §Tier 2 的"critical_modules 命中"分类（F5 动 `agents/reviewer.md` 本体）。
+
+## 3. 修复
+
+5 项改动，单 PR：
+
+- **F1**：`commands/lint.md` L6.3 补 "新 DEC（落盘日 ≤ 7 天）状态行必须起首 `Provisional`" 告警项，判定依据 DEC `**日期**` vs 当前日期差 ≤ 7 天
+- **F2**：`docs/decision-log.md` §铁律 4 后追加 `**post-fix 2026-04-22（issue #97 F2）**` 段，明确 tradeoff 判定归属（architect 主张 / reviewer 终审 / 分歧升用户 AskUserQuestion）
+- **F3**：`docs/decision-log.md` DEC-011 正文末追加 `**post-fix 2026-04-22**` 段，说明 §阶段 2 第 8 步字面漂移到 step 9，语义锚点不变
+- **F4**：`commands/lint.md` §6 提取 `**实施共性**（L6.1-L6.5 共用）` preface 段含 3 共用条款（code-fence 扫描 / `DEC-\d{3}` regex / grandfather DEC-001~020），各子节去掉重复条款。L6.2 自有 DEC-013~020 范围 + L6.4 悬空引用例外在 preface 显式保留
+- **F5**：`agents/reviewer.md` §审查维度 在 🔴/🟡/🔵 三级严重度前追加 "门槛合规（DEC 专项）" 检查 —— 新 DEC 是否命中 §开立门槛 5 类必开 + 不踩 Red Flags；严重度由 reviewer judgement 归类
+
+## 4. 复现步骤
+
+无独立回归测试（纯文档元规则改动）。等价复现：
+
+1. 下一轮任意 roundtable 自身 `/roundtable:workflow` 写新 DEC 时，`commands/lint.md` §6 L6.3 会自动扫 Provisional 首值
+2. DEC-011 正文读者从 "§阶段 2 第 8 步" 跳转时，post-fix 指示按 step 9 理解
+3. reviewer 遇 PR 改 `decision-log.md` 新 DEC 段时，按新增 §审查维度 "门槛合规" 检查
+
+lint_cmd 硬编码扫描 0 命中验证：`grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` → 0 match
+
+## 5. 验证
+
+- **lint_cmd**：0 match（roundtable 自家 lint，纯硬编码扫描）
+- **diff 规模**：3 files changed, 14 insertions(+), 5 deletions(-)（initial） → 含 F5/F2 advisor 反馈后调整
+- **critical_modules 命中**：F5 `agents/reviewer.md` 本体 → reviewer 自审（inline 形态，见 §6 后续动作）
+- **advisor 审查**：对 F5 初版"严重度映射（Red Flags→Critical / 5 类不命中→Warning）"指出为 scope creep，已删；F2 格式对齐 DEC-011 post-fix 样式
+
+## 6. 后续动作
+
+- **观察项 #94**（issue #97 保留的独立观察）：Refined by first-use validation —— 等下个 Refines 类 DEC 落盘时验证 Provisional + 父 DEC 状态行加 `Refined by` + lint L6.4 不悬空三者链路
+- **follow-up**：本 batch 合并 `#91 / #92 / #93 / #95 / #96`，闭 #97；`#94` 保留独立观察
+- **DEC 候选**：无；本批纯 clarification 走铁律 4 inline post-fix，不新开 DEC
+
+## 7. 变更记录
+
+| 日期 | 改动 | 操作者 |
+|------|------|--------|
+| 2026-04-22 | F1-F5 初版落盘（3 files） | orchestrator (inline developer) |
+| 2026-04-22 | advisor 反馈：F5 scope 收敛；F2 格式与 DEC-011 post-fix 对齐 | orchestrator |

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -37,6 +37,8 @@
 2. **冲突报 diff**：新决策与旧决策冲突时，必须在新条目中引用旧条目编号
 3. **编号递增**：DEC 编号只增不减，不复用
 4. **clarification 不开新 DEC**（自 2026-04-22 起）：落盘后发现的 tester/reviewer findings / 文本补丁 / 边角场景 id 格式等细化 → **inline append 父 DEC 末尾**并注日期（形如 `**post-fix YYYY-MM-DD（issue #N）**：...`），不新开 DEC 也不另立 Amendment 小节。仅当改动引入新 tradeoff / 新备选评估 / 跨 DEC 语义重构时才开新 DEC
+
+   **post-fix 2026-04-22（issue #97 F2）tradeoff 判定归属**：由 architect 主张、reviewer 终审；architect 与 reviewer 分歧 → 升级给用户 `AskUserQuestion`
 5. **影响范围 ≤10 行**（自 DEC-009 决定 10 立，本纪律不回溯 DEC-013~020）：超出移到关联 design-doc；运行时行为变化与"不改"清单例外项放正文末段即可
 6. **默认不改清单**（自 2026-04-22 起）：以下为 roundtable 架构稳定边界，新 DEC 默认不改，**仅在破例时显式声明**「改 X」，无需每条重复"不改"声明：
    - DEC-001 D1-D9（plugin 分发 / 双形态 / 零 userConfig / scope=user / 目标项目识别）
@@ -565,6 +567,8 @@
 - **理由**: (1) Minimal header 成本最低，直接解决 issue #18 根因 3（目标项目 decision-log 无约定 header）；(2) "第一个 `### DEC-` 行"通用锚点对所有状态单一规则定位，无边界情况；(3) 约定通过文件自身 header 固化，比纯靠 SKILL.md 规则约束更 robust（非 architect 路径手改也能看到约定）；(4) architect 是 decision-log 唯一 Writer，规则落点单一 —— 改 SKILL.md 即完全覆盖；(5) 与 log.md 的"顶部最新"表述对称，用户心智一致
 - **相关文档**: docs/design-docs/decision-log-entry-order.md（设计主文档 + 决策量化评分）、issue #18、DEC-002（Resource Access 权限声明上游 —— architect 是 decision-log 唯一 Writer）
 - **影响范围**: `skills/architect/SKILL.md` 补 +12 行（L19 / L59 / L165 各补一句，§完成后 新增 ### decision-log 条目顺序约定 小节）；`docs/claude-md-template.md` L46 改 1 行；`docs/decision-log.md` 新增本条目（置顶）；`docs/design-docs/decision-log-entry-order.md` 新建。不改 DEC-001 ~ DEC-010；不改 5 个 agent prompt；不改 `commands/workflow.md` / `commands/bugfix.md`；不改 target CLAUDE.md 业务规则边界。运行时：下次 `/roundtable:workflow` 在目标项目写新 DEC 时置顶（最新在前），首次创建则先写 Minimal header
+
+**post-fix 2026-04-22（DEC-025 副作用，issue #97 F3）**：DEC-025 决定 8 在 `skills/architect/SKILL.md` §阶段 2 第 8 步前插入"开立前自问 §开立门槛"后，本 DEC 决定 1 所引 "§阶段 2 第 8 步" 字面已指向该自问句；原"新决策 → 追加 `decision-log.md`（置顶 / 最新在前）"内容下移为 step 9。语义按 step 9 理解，锚点规则不变。
 
 ---
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -14,6 +14,12 @@
 
 **合并原则**：agent / skill **不直接写本文件**。每轮 workflow 由 orchestrator 按 `commands/workflow.md` §Step 8 log.md Batching 协议（bugfix 流程按 `commands/bugfix.md` §log.md Batching 简化版）收集各 agent final report 中的 `log_entries:` YAML block 聚合写入；同一 agent 在同一轮产出多份文档（如 architect 同时输出 design-doc + DEC + exec-plan）**合并为一条**，`影响文件` 列全部路径（union）；不拆多条。DEC-009 决定 2 落地。
 
+## fix-rootcause | batch-97-dogfood-findings | 2026-04-22
+- 操作者: developer (inline, orchestrator)
+- 影响文件: commands/lint.md, docs/decision-log.md, agents/reviewer.md, docs/bugfixes/batch-97-dogfood-findings.md (new), docs/INDEX.md
+- 说明: issue #97 batch follow-up for #84 dogfood findings；Tier 2（critical_modules 命中 agents/reviewer.md）；5 改动合并 1 PR：F1 lint L6.3 加"新 DEC ≤7 天必带 Provisional 首值" / F2 铁律 4 inline post-fix tradeoff 归属（architect 主张 / reviewer 终审 / 分歧升 AskUserQuestion）/ F3 DEC-011 post-fix 说明 §阶段 2 第 8 步 漂移到 step 9 / F4 lint §6 提取 **实施共性** preface（code-fence / DEC-\d{3} regex / grandfather DEC-001~020）/ F5 reviewer §审查维度 加"门槛合规（DEC 专项）"；advisor 反馈 F5 scope 收敛（剥离 Red Flags→Critical 映射）、F2 格式对齐 DEC-011 post-fix 样式；supersedes #91/92/93/95/96；#94 保留独立观察
+- 关联 postmortem: docs/bugfixes/batch-97-dogfood-findings.md
+
 ## design | decision-log-sustainability | 2026-04-22
 - 操作者: architect (skill, inline)
 - 影响文件: docs/design-docs/decision-log-sustainability.md (new 313 行); docs/exec-plans/active/decision-log-sustainability-plan.md (new); docs/decision-log.md (+DEC-025 + DEC-026 Provisional 置顶); docs/INDEX.md (design-docs + exec-plans/active 条目追)


### PR DESCRIPTION
## Summary

5 changes merged into 1 PR per user direction (supersedes #91 / #92 / #93 / #95 / #96; closes #97). Pure documentation / meta-rule cleanup triggered by #84 DEC-025/026 dogfood findings.

- **F1** `commands/lint.md` L6.3 — add "new DEC (≤7 days) must start with `Provisional`" check; criterion = DEC `**日期**` vs current date diff
- **F2** `docs/decision-log.md` 铁律 4 — inline post-fix clarifying tradeoff judgement ownership (architect proposes, reviewer arbitrates, disagreement escalates via `AskUserQuestion`)
- **F3** `docs/decision-log.md` DEC-011 — inline post-fix noting DEC-025 决定 8 insertion shifted "§阶段 2 第 8 步" anchor to step 9 semantically
- **F4** `commands/lint.md` §6 — extract common `**实施共性**` preface (code-fence scan / `DEC-\d{3}` regex / grandfather DEC-001~020). L6.2 DEC-013~020 scope + L6.4 dangling-reference full-scan exception preserved in preface
- **F5** `agents/reviewer.md` §审查维度 — add "门槛合规（DEC 专项）" check; severity judged per reviewer (no forced mapping to 🔴/🟡)

`#94` "Refined by first-use validation" kept as standalone observation (no code change required; needs next Refines-class DEC to land before validating the chain).

## Tier 2 postmortem

`critical_modules` hit on `agents/reviewer.md` → Tier 2. Postmortem at `docs/bugfixes/batch-97-dogfood-findings.md`.

## Test plan

- [x] `grep -rnE "gleanforge|dex-sui|dex-ui|\bvault/|\bllm/" skills/ agents/ commands/` → 0 match (roundtable lint_cmd)
- [x] `git diff --numstat` = 90 insertions / 5 deletions (under 铁律 5 影响范围 ≤10 行 for the rule-level diff; postmortem + INDEX expansion are separate artifacts)
- [x] reviewer inline self-review: 0 Critical / 0 Warning / 2 Suggestion (verbose L6.3 subheading + bullet-indentation on 铁律 4 post-fix; acceptable)
- [x] advisor review before commit: corrected F5 scope creep (dropped Red Flags→Critical / 5 类不命中→Warning forced mapping) + F2 format alignment with DEC-011 post-fix style
- [x] 门槛合规 self-check: 3 changes = inline post-fix (铁律 4 route) + 2 changes = non-DEC prompt edits; no new DEC, correct landing point per DEC-025 §开立门槛

## Closeout

- closes #97
- supersedes #91 / #92 / #93 / #95 / #96
- `#94` remains open for independent observation

🤖 Generated with [Claude Code](https://claude.com/claude-code)