### PR TITLE
chore(gitignore): ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Thumbs.db
 .claude/settings.local.json
 .claude/agent-memory/
 .claude/agent-memory-local/
+.claude/worktrees/
 # .claude/rules/ 若未来使用，需团队共享，不忽略
 
 # 个人 CLAUDE.md 覆盖（不入库）


### PR DESCRIPTION
## Summary

Add `.claude/worktrees/` to `.gitignore` so orchestrator-spawned agent isolation worktrees (`.claude/worktrees/agent-<id>/` with embedded `.git/` dirs) don't get staged by `git add -A`.

Observed during #97 closeout: `git add -A` from this session silently staged 4 leftover agent worktrees as submodule entries, requiring manual unstage.

## Test plan

- [x] `git status` with existing untracked `.claude/worktrees/agent-*` dirs no longer shows them after this merges
- [x] Other `.claude/*` rules (settings.local.json / agent-memory / rules) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)