### PR TITLE
fix: make TG broadcast checklist explicit in workflow + bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to **roundtable** will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- `commands/workflow.md` Step 2: replaced the abstract "every phase transition must be posted" sentence with an explicit checklist of broadcast points (workflow start / phase 1·2·4·6·7·8·9 completion / user gates 3·5 / closeout). The v0.0.6 rule was too easy to miss at runtime — observed in practice: workflow start posted to TG, phase 1 completion did not.
+- `commands/bugfix.md` Step 1: added a one-line reference to the workflow.md broadcast rule so bugfix runs don't go silent on TG either.
+
 ## [0.0.6] - 2026-05-11
 
 Post-rewrite polish: channel-aware user prompts and phase broadcast, looser doc templates, leftover DEC-numbering cleanup.

--- a/commands/bugfix.md
+++ b/commands/bugfix.md
@@ -13,6 +13,8 @@ Fast path for fixing a bug. Skip analyst, design-doc, and user gates around desi
 
 SessionStart hook injects `docs_root` + `project_id`. Pick a slug.
 
+**Channel broadcast**: same rule as `/roundtable:workflow` Step 2 — if telegram MCP is loaded, post a new `reply` at workflow start, each phase completion (Step 4 developer / Step 5 reviewer or dba / Step 6 postmortem), and closeout. Terminal-only output is a bug.
+
 ## Step 2: Locate the bug
 
 - If the input is an issue # (`#123`, `gh issue view 123`, GitLab / Jira / URL), fetch the body

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -17,7 +17,14 @@ The SessionStart hook injects roundtable context (`Roundtable context:` block). 
 
 Render before each phase transition and every user pause. Status: ⏳ todo · 🔄 doing · ✅ done · ⏩ skipped.
 
-**Channel broadcast**: if the telegram MCP server is loaded (check system-reminders for `plugin:telegram:telegram`), every phase transition and every user gate must also be posted via `mcp__plugin_telegram_telegram__reply` — terminal-only output leaves TG users blind. Use `edit_message` for in-phase progress; use a new `reply` when a phase completes (edits don't push-notify).
+**Channel broadcast**: if the telegram MCP server is loaded (check system-reminders for `plugin:telegram:telegram`), the orchestrator must post a new `mcp__plugin_telegram_telegram__reply` at each of these points — terminal-only output is a bug:
+
+- workflow start (matrix + config)
+- each phase completion (1 / 2 / 4 / 6 / 7 / 8 / 9): one-line summary + output path + next phase
+- each user gate (3 / 5): the `accept / modify / reject / ask` prompt
+- workflow closeout (commit / PR bundle)
+
+Use `edit_message` only for in-phase progress updates; phase *completion* must always be a new `reply` (edits don't push-notify). Skills own their own in-phase decision prompts; the orchestrator owns transition broadcasts — never assume a skill posted the completion message.
 
 | # | Role             | Output                                              | Optional? |
 |---|------------------|-----------------------------------------------------|-----------|


### PR DESCRIPTION
## Summary

- `commands/workflow.md` Step 2: abstract rule → explicit checklist of broadcast points (workflow start / phase 1·2·4·6·7·8·9 completion / user gates 3·5 / closeout)
- `commands/bugfix.md` Step 1: add one-line reference to the same rule so the short path doesn't go silent on TG either

## Why

Observed in practice (botB run on M14 admin UI restructure, 2026-05-11): orchestrator posted workflow start to TG, but Phase 1 analyst completion only printed to terminal. The v0.0.6 rule "every phase transition must be posted" lived in one prose sentence and got lost between Step 2 and Step 4 at runtime.

This PR keeps the change minimal — just makes the existing intent runnable by spelling out the points. No new behaviour.

## Test plan

- [ ] Dogfood: run `/roundtable:workflow` on a small task with telegram MCP loaded; verify TG receives reply at each phase completion + user gate + closeout
- [ ] Dogfood: run `/roundtable:bugfix` likewise

🤖 Generated with [Claude Code](https://claude.com/claude-code)