### PR TITLE
fix(codex): align runtime compatibility

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "roundtable",
       "source": "./",
       "description": "Multi-role AI development workflow (analyst / architect / developer / tester / reviewer / dba) with plan-then-execute discipline.",
-      "version": "0.0.7-rc1"
+      "version": "0.0.7-rc2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtable",
-  "version": "0.0.7-rc1",
+  "version": "0.0.7-rc2",
   "description": "Multi-role AI development workflow for Claude Code. Bring analyst, architect, developer, tester, reviewer, and DBA to the same table. Minimal-by-design: 4 subagents, 2 skills, 3 commands, one SessionStart hook. Per-project CLAUDE.md (optional) drives toolchain + critical_modules.",
   "author": {
     "name": "duktig666",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -20,16 +20,6 @@
     "codex"
   ],
   "skills": "./skills/",
-  "hooks": {
-    "SessionStart": [{
-      "matcher": "*",
-      "hooks": [{
-        "type": "command",
-        "command": "${PLUGIN_ROOT}/hooks/session-start",
-        "async": false
-      }]
-    }]
-  },
   "interface": {
     "displayName": "Roundtable",
     "shortDescription": "Multi-role AI development workflow: analyst, architect, developer, tester, reviewer, DBA",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roundtable",
-  "version": "0.0.7-rc1",
+  "version": "0.0.7-rc2",
   "description": "Multi-role AI development workflow. Bring analyst, architect, developer, tester, reviewer, and DBA to the same table. Minimal-by-design: 4 subagents, 2 skills, 3 commands, one SessionStart hook. Per-project CLAUDE.md (optional) drives toolchain + critical_modules.",
   "author": {
     "name": "duktig666",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to **roundtable** will be documented in this file.
 
 ### Changed
 
+- Codex SessionStart hooks now use a root-level `hooks.json`, matching current Codex plugin discovery. `.codex-plugin/plugin.json` no longer carries an inline `hooks` field, so it passes Codex manifest validation while Claude Code keeps using `hooks/hooks.json`.
+- Codex docs now treat SessionStart `additionalContext` as an optimization with a `docs_root` prompt fallback; Codex CLI v0.133 `codex exec` did not reliably surface hook context to the model in nonce testing.
+- Codex subagent instructions now use the current `spawn_agent(agent_type=..., message=...)` / `wait_agent(targets=[id])` / `close_agent(target=id)` shape and explicitly embed `agents/<role>.md` in worker messages.
+- User decision prompts are described as runtime-specific (`AskUserQuestion` in Claude Code, `request_user_input` in Codex when available, or normal chat fallback) instead of assuming one modal tool exists everywhere.
 - `commands/workflow.md` Step 2: replaced the abstract "every phase transition must be posted" sentence with an explicit checklist of broadcast points (workflow start / phase 1·2·4·6·7·8·9 completion / user gates 3·5 / closeout). The v0.0.6 rule was too easy to miss at runtime — observed in practice: workflow start posted to TG, phase 1 completion did not.
 - `commands/bugfix.md` Step 1: added a one-line reference to the workflow.md broadcast rule so bugfix runs don't go silent on TG either.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **roundtable** will be documented in this file.
 
 ## [Unreleased]
 
+## [0.0.7-rc2] - 2026-05-22
+
+Release candidate refresh after Claude review and Codex CLI v0.133 retest. Claude Code behaviour is unchanged; Codex install/runtime guidance is tightened while SessionStart hook context remains a runtime caveat with fallback.
+
 ### Changed
 
 - Codex SessionStart hooks now use a root-level `hooks.json`, matching current Codex plugin discovery. `.codex-plugin/plugin.json` no longer carries an inline `hooks` field, so it passes Codex manifest validation while Claude Code keeps using `hooks/hooks.json`.

--- a/README-zh.md
+++ b/README-zh.md
@@ -4,7 +4,7 @@
 
 > **让 analyst、architect、developer、tester、reviewer、DBA 同坐一桌，用 plan-then-execute 纪律推进复杂工作。**
 
-`roundtable` 是多 runtime plugin（Claude Code + Codex CLI + Codex App），把多角色 AI 开发工作流封装成一行安装。**极简设计**：4 subagent + 2 skill + 3 command + 1 SessionStart hook，全部 prompt+config 约 760 行。
+`roundtable` 是多 runtime plugin（Claude Code + Codex CLI + Codex App），把多角色 AI 开发工作流封装成一行安装。**极简设计**：4 subagent + 2 skill + 3 command + 1 SessionStart hook，prompt+config 保持紧凑。
 
 ## 安装
 
@@ -47,7 +47,7 @@ codex plugin add github.com/duktig666/roundtable
 ### Codex troubleshooting
 
 - **`spawn_agent` 报 unknown tool** —— 检查 `~/.codex/config.toml` 含 `[features] multi_agent = true`（当前 Codex 默认值为 `true`）。
-- **SessionStart 注入的 `Roundtable context:` block 不见** —— 检查 `~/.codex/config.toml` 含 `[features] plugin_hooks = true`，并确认 `hooks/session-start` 有执行权限。
+- **SessionStart 注入的 `Roundtable context:` block 不见** —— 检查 `~/.codex/config.toml` 含 `[features] plugin_hooks = true`、plugin 根目录含 `hooks.json`，并确认 `hooks/session-start` 有执行权限。部分 Codex CLI build 可能不会在 `codex exec` 中暴露 hook 的 `additionalContext`；这种情况下 workflow 会 fallback 询问 `docs_root`。
 - **TG MCP 在 Codex 下可选** —— 无 TG MCP 时 phase 广播自动降级到终端模式。如需启用：`codex mcp add telegram -- <你的 telegram MCP 命令>`，channel-aware 逻辑会自动路由到 Codex 侧 TG MCP 工具名（见 `codex /mcp` 输出）。
 
 ## 在任何项目里用
@@ -67,7 +67,7 @@ Claude Code 下用上面的 slash command。Codex CLI / App 下描述意图或�
 这就是这个 plugin 的模型：
 
 - **Analyst** 跑六问框架（失败模式 / 6 个月评价 + 4 个按需问题），只产**事实**——不做推荐
-- **Architect** 消费 analyst 的事实；每个架构决策点都通过 `AskUserQuestion` 让你拍板；medium/large 任务先产 **design-doc**（讨论态），用户确认后再产 exec-plan（执行态）
+- **Architect** 消费 analyst 的事实；每个架构决策点都通过当前 runtime 的用户提问机制让你拍板；medium/large 任务先产 **design-doc**（讨论态），用户确认后再产 exec-plan（执行态）
 - **Developer** 只在 exec-plan 锁定后才动代码；非平凡行为先写失败测试
 - **Tester** 写对抗性 / E2E / Playwright 测试；发现业务 bug 只写复现测试不改业务码
 - **Reviewer / DBA** 只读；reviewer 标 Critical / Warning / Suggestion；DBA 禁所有 SQL 写（不允许 INSERT/UPDATE/ALTER/DROP）
@@ -76,10 +76,10 @@ Claude Code 下用上面的 slash command。Codex CLI / App 下描述意图或�
 
 1. **零配置安装** —— `plugin.json` 无 userConfig 弹窗；工具链按项目根文件 auto-detect
 2. **architect 双轨产出** —— design-doc（讨论态，频繁迭代）和 exec-plan（执行态，稳定）拆成两份文件用于 medium/large 任务；small 任务合并
-3. **逐决策弹窗** —— architect 每个关键决策当场调 `AskUserQuestion`，不积压成文字列表
-4. **交互角色 → skill / 自主角色 → subagent** —— analyst/architect 主会话执行（需要 `AskUserQuestion`）；developer/tester/reviewer/dba 独立 subagent 上下文
-5. **`[NEED-DECISION]` 模式** —— subagent 不能弹窗，在返回文本印一行，orchestrator grep 后调 `AskUserQuestion` 续派
-6. **SessionStart hook 注入 `docs_root`** —— bash 在 session 开始时检测 docs_root + project_id（env > 向上找 `docs/` > `needs-init` 兜底），所有角色从注入上下文读，不再 inline 检测
+3. **逐决策提问** —— architect 每个关键决策当场提问，不积压成文字列表
+4. **交互角色 → skill / 自主角色 → subagent** —— analyst/architect 主会话执行（需要用户决策）；developer/tester/reviewer/dba 独立 subagent 上下文
+5. **`[NEED-DECISION]` 模式** —— subagent 不能弹窗，在返回文本印一行，orchestrator grep 后通过当前 runtime 的用户提问机制续派
+6. **SessionStart hook 注入 `docs_root`** —— bash 在 session 开始时检测 docs_root + project_id（env > 向上找 `docs/` > `needs-init` 兜底）；runtime 暴露上下文时角色直接读取，否则 skill 会询问一次
 7. **plugin 语言无关** —— prompt 全英文；输出语言由项目自己的 CLAUDE.md 决定（声明 `文档中文` 后所有产出自动中文）
 8. **无机制堆叠** —— 没有 decision-log / log.md / faq.md / progress JSONL / Monitor / `<escalation>` JSON。决策直接写进 exec-plan 的 `## Key Decisions`；FAQ 追加到对应 analyze/design-doc；INDEX.md 由 `/roundtable:lint` 重建
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **Sit the analyst, architect, developer, tester, reviewer, and DBA at the same session, and push complex work forward with plan-then-execute discipline.**
 
-`roundtable` is a multi-runtime plugin (Claude Code + Codex CLI + Codex App) that packages a multi-role AI development workflow into a one-line install. **Minimal-by-design**: 4 subagents + 2 skills + 3 commands + 1 SessionStart hook, ~760 lines of prompt+config total.
+`roundtable` is a multi-runtime plugin (Claude Code + Codex CLI + Codex App) that packages a multi-role AI development workflow into a one-line install. **Minimal-by-design**: 4 subagents + 2 skills + 3 commands + 1 SessionStart hook, with compact prompt+config files.
 
 ## Install
 
@@ -47,7 +47,7 @@ In the Codex App plugin UI, add `github.com/duktig666/roundtable`. The App handl
 ### Codex troubleshooting
 
 - **`spawn_agent` reports unknown tool** — verify `~/.codex/config.toml` has `[features] multi_agent = true` (default `true` on current builds).
-- **SessionStart `Roundtable context:` block missing** — verify `~/.codex/config.toml` has `[features] plugin_hooks = true`, and that `hooks/session-start` is executable.
+- **SessionStart `Roundtable context:` block missing** — verify `~/.codex/config.toml` has `[features] plugin_hooks = true`, the plugin root contains `hooks.json`, and `hooks/session-start` is executable. Some Codex CLI builds may not surface hook `additionalContext` in `codex exec`; in that case the workflow asks for `docs_root` as a fallback.
 - **TG MCP is optional under Codex** — phase broadcasts automatically degrade to terminal mode when no TG MCP server is configured. To enable: `codex mcp add telegram -- <your-telegram-mcp-command>`; channel-aware logic then routes via the Codex-side TG MCP tool name (visible in `codex /mcp`).
 
 ## Use it in any project
@@ -67,7 +67,7 @@ Under Claude Code use the slash commands above. Under Codex CLI / App, describe 
 That's the model:
 
 - **Analyst** runs the six-question framework (failure mode / 6-month review + 4 conditional questions) and emits **facts only** — no recommendations
-- **Architect** consumes the analyst's facts; surfaces every architectural decision via `AskUserQuestion`; produces a **design-doc** for medium/large tasks (then a separate exec-plan after design confirm)
+- **Architect** consumes the analyst's facts; surfaces every architectural decision via the runtime's user-question mechanism; produces a **design-doc** for medium/large tasks (then a separate exec-plan after design confirm)
 - **Developer** only touches code after the exec-plan is locked; writes failing tests first when behavior is non-trivial
 - **Tester** writes adversarial / E2E / Playwright tests; finds business bugs without modifying business code
 - **Reviewer / DBA** are read-only; reviewer flags Critical / Warning / Suggestion; DBA bans all SQL writes (no INSERT/UPDATE/ALTER/DROP)
@@ -76,10 +76,10 @@ That's the model:
 
 1. **Zero-config install** — `plugin.json` has no userConfig prompts; toolchain auto-detected from project root files
 2. **Two-track architect output** — design-doc (discussion-state, churns) and exec-plan (execution-state, stable) are separate files for medium/large tasks; small tasks combine both
-3. **Decision-by-decision popups** — architect fires `AskUserQuestion` at every key decision point, never piles them up at the end
-4. **Interactive roles → skills, autonomous roles → subagents** — analyst/architect run in main session (need `AskUserQuestion`); developer/tester/reviewer/dba run as isolated subagents (clean context)
+3. **Decision-by-decision prompts** — architect asks at every key decision point, never piles them up at the end
+4. **Interactive roles → skills, autonomous roles → subagents** — analyst/architect run in main session (need user decisions); developer/tester/reviewer/dba run as isolated subagents (clean context)
 5. **`[NEED-DECISION]` pattern** — subagents can't pop dialogs; they print one line in their return text, the orchestrator parses it and asks the user, then re-dispatches
-6. **SessionStart hook for `docs_root`** — bash detects `docs_root` + `project_id` once at session start (env override → walk-up tree → `needs-init` fallback); all roles read from injected context, no inline detection
+6. **SessionStart hook for `docs_root`** — bash detects `docs_root` + `project_id` once at session start (env override → walk-up tree → `needs-init` fallback); roles read the injected context when the runtime exposes it, otherwise the skill asks once
 7. **Language-neutral plugin** — prompts in English; output language follows your project's CLAUDE.md (e.g. declare `文档中文` and all docs come out in Chinese)
 8. **No mechanism bloat** — no decision-log / log.md / faq.md / progress JSONL / Monitor / `<escalation>` JSON. Decisions live inside exec-plan `## Key Decisions`; FAQ appends to the relevant analyze/design-doc; INDEX.md is rebuilt by `/roundtable:lint`
 

--- a/docs/testing/codex-compatibility.md
+++ b/docs/testing/codex-compatibility.md
@@ -332,4 +332,4 @@ git log --oneline -5   # 不应有 reviewer / dba 名义的 commit
 
 当前分支的 Codex manifest、root `hooks.json`、Claude `hooks/hooks.json`、skill references、README / CHANGELOG 文档已按当前 Codex tool schema 修正，静态验证通过。最重要的设计调整是：Codex manifest 不再内联 `hooks`；Codex subagent 文档不再假设 `task_name` 或自动注册 `agents/*.md`；所有用户决策都描述为 runtime-specific prompt with fallback。
 
-仍不能把 SessionStart 注入声明为“已完全跑通”：Codex CLI v0.133 的 `codex exec` nonce smoke test 未看到 `additionalContext` 进入模型上下文。因此 v0.0.7-rc1 的合理发布口径应是：hook 脚本和 discovery 文件合法，Claude 路径保持兼容，Codex 路径有 `docs_root` fallback；还需要在交互式 Codex CLI / Codex App 里继续确认 hooks、`/skills`、workflow subagent 编排和 App handoff。
+仍不能把 SessionStart 注入声明为“已完全跑通”：Codex CLI v0.133 的 `codex exec` nonce smoke test 未看到 `additionalContext` 进入模型上下文。因此 v0.0.7-rc2 的合理发布口径应是：hook 脚本和 discovery 文件合法，Claude 路径保持兼容，Codex 路径有 `docs_root` fallback；还需要在交互式 Codex CLI / Codex App 里继续确认 hooks、`/skills`、workflow subagent 编排和 App handoff。

--- a/docs/testing/codex-compatibility.md
+++ b/docs/testing/codex-compatibility.md
@@ -9,7 +9,7 @@ status: tester-report
 
 ## Scope
 
-本次验收 developer 完成的 20 个 step 改造（P1-P6），P0 全段（P0.1/P0.2/P0.3）+ P1.3 标 ⏩ deferred。
+原报告验收 developer 完成的 20 个 step 改造（P1-P6），并把 P0 全段（P0.1/P0.2/P0.3）+ P1.3 标为 ⏩ deferred。2026-05-22 的 Codex CLI retest 补跑了部分 P0.2，但 Codex App 与完整交互链路仍 deferred。
 
 **本会话能做**：
 
@@ -24,7 +24,17 @@ status: tester-report
 **本会话不能做**（→ deferred）：
 
 - 重启 Claude Code session 实测 `/roundtable:workflow <task>` 触发语法
-- 装 Codex CLI / Codex App 实测 `spawn_agent` / `request_user_input` / hooks 注入 / Path A handoff
+- Codex App 实测 Path A handoff
+
+## 2026-05-22 Codex 0.133 Retest
+
+本节覆盖原报告里 P0.2 的关键假设，基于分支 `fix/codex-runtime-compat` 在 Codex CLI v0.133.0 下重跑：
+
+- `python3 /home/ubuntu/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .` 通过；`.codex-plugin/plugin.json` 不再内联 `hooks`，Codex hook discovery 改用仓库根目录 `hooks.json`。
+- 临时 `CODEX_HOME` 本地安装能完成，plugin cache 中能看到 root `hooks.json` 与 `hooks/session-start`。
+- `hooks/session-start` 单独运行会输出合法 `{"additionalContext":"Roundtable context:..."}`；设置 `CLAUDE_PLUGIN_ROOT` 时仍输出 Claude Code 的 `hookSpecificOutput.additionalContext`。
+- 严格 nonce smoke test 显示：在 `codex exec --ephemeral --dangerously-bypass-hook-trust` 路径里，SessionStart hook 的 `additionalContext` 没有可靠进入模型上下文。当前设计必须把 hook 当优化项，并保留询问 `docs_root` 的 fallback。
+- Codex subagent 文档已更新为当前工具 schema：`spawn_agent(agent_type="worker", message=...)` 返回 agent id，后续用 `wait_agent(targets=[id])` 与 `close_agent(target=id)`；Codex 不会自动把 `agents/*.md` 注册成自定义 subagent，orchestrator 需要读取并嵌入 role prompt。
 
 ## Results
 
@@ -32,11 +42,11 @@ status: tester-report
 
 | 项 | 状态 | 说明 |
 |----|------|------|
-| A1 `.codex-plugin/plugin.json` JSON valid + 字段齐全 | ✅ | python3 json.load 通过；含 name/version/description/skills/hooks/interface；interface 含 displayName/shortDescription/longDescription/developerName/category/capabilities/defaultPrompt/brandColor/composerIcon/logo/screenshots |
+| A1 `.codex-plugin/plugin.json` JSON valid + 字段齐全 | ✅ | python3 json.load 通过；含 name/version/description/author/homepage/repository/license/keywords/skills/interface；interface 含 displayName/shortDescription/longDescription/developerName/category/capabilities/defaultPrompt/brandColor/screenshots；不含 Codex validator 不接受的 inline `hooks` |
 | A2 `.claude-plugin/plugin.json` JSON valid + version 0.0.7 | ✅ | json.load OK；version = "0.0.7" |
 | A3 `.claude-plugin/marketplace.json` JSON valid + version 0.0.7 | ✅ | json.load OK；plugins[0].version = "0.0.7" |
 | A4 defaultPrompt 每条 ≤128 字符 | ✅ | 实测 len 分别为 40 / 30 / 24 字符 |
-| A5 skills/composerIcon/logo 路径以 `./` 开头 | ✅ | `./skills/` / `./assets/icon.svg` / `./assets/logo.png` |
+| A5 skills 路径以 `./` 开头 | ✅ | `skills` = `./skills/`；未声明 unsupported `composerIcon` / `logo` 字段 |
 
 ### B. skill / agent / command frontmatter
 
@@ -65,9 +75,9 @@ status: tester-report
 | 项 | 状态 | 说明 |
 |----|------|------|
 | D1 bash 脚本可执行 | ✅ | `bash hooks/session-start </dev/null` 退出码 0，输出合法 JSON |
-| D2 stdout 含 `additionalContext` 字段 | ✅ | fallback 分支输出 `{"additionalContext":"Roundtable context:\\ndocs_root: ...\\nproject_id: ...\\nstatus: ok"}` — 命中 design-doc §C.5 Codex 期望 schema |
-| D3 `hooks/hooks.json` schema 未破坏 | ✅ | JSON valid；`SessionStart` matcher 仍在；command 仍用 `${CLAUDE_PLUGIN_ROOT}` |
-| D4 `.codex-plugin/plugin.json` `hooks` 字段 schema | ✅ | 用 `hooks.sessionStart` 数组形态，含 matcher `*` + hooks[].type=`command` + hooks[].command=`${PLUGIN_ROOT}/hooks/session-start` + async=false。属 analyst §C.5 4 种合法形态之一 |
+| D2 stdout 含 `additionalContext` 字段 | ✅ | fallback 分支输出 `{"additionalContext":"Roundtable context:\\ndocs_root: ...\\nproject_id: ...\\nstatus: ok"}`；脚本输出合法，但 Codex CLI `exec` 是否注入模型上下文需 runtime 实测 |
+| D3 `hooks/hooks.json` schema 未破坏 | ✅ | Claude Code 用的 `hooks/hooks.json` JSON valid；`SessionStart` matcher 仍在；command 仍用 `${CLAUDE_PLUGIN_ROOT}` |
+| D4 Codex root `hooks.json` schema | ✅ / ⚠️ | 仓库根 `hooks.json` JSON valid，`SessionStart` command 用 `${PLUGIN_ROOT}/hooks/session-start`；`.codex-plugin/plugin.json` 不再含 inline `hooks`，避免 Codex manifest validation 失败。Codex CLI v0.133 `exec` nonce test 未看到 `additionalContext` 进模型，因此 hook 注入仍按 runtime caveat 处理 |
 
 ### E. workflow skill Step 0 + Path A handoff
 
@@ -93,7 +103,7 @@ status: tester-report
 | G1 5 份 references 含工具映射表 | ✅ | 每份都有 `\| Claude Code \| Codex \| Notes \|` 三列表格 |
 | G2 workflow + bugfix references 含 `multi_agent` troubleshooting 段 | ✅ | workflow:80-88 + bugfix:37-39 |
 | G3 workflow + analyst + architect references 含 TG MCP 章节（Codex 可选 + 终端降级）| ✅ | workflow:62-75 详写；analyst:18 引用；architect:18 引用，都明确 `TG MCP optional under Codex` + 终端降级语义 |
-| G4 references 无明显事实错误 | ✅ | `spawn_agent` / `wait_agent` / `close_agent` / `request_user_input` / `update_plan` 拼写都对；Codex 工具名未与 Claude 工具名串错 |
+| G4 references 无明显事实错误 | ✅ | 已按当前 Codex tool schema 更新：`spawn_agent(agent_type=..., message=...)`、`wait_agent(targets=[id])`、`close_agent(target=id)`、`request_user_input(questions=[...])`；并注明 Codex 需读取并嵌入 `agents/<role>.md` |
 
 ### H. DEC 逐条核验
 
@@ -115,10 +125,10 @@ status: tester-report
 | 项 | 状态 | 说明 |
 |----|------|------|
 | I1 Claude Code 重启后 `/roundtable:workflow <task>` 触发 | ⏩ | P0.1 真验证；本会话不能重启 Claude；safe default（commands 薄壳）已应用，最差只剩薄壳被解析为 Slash Command 后 Skill 调用是否生效 |
-| I2 Codex CLI 装 plugin 后 `/skills` 列出 5 个 skill | ⏩ | 本会话无 Codex 安装 |
-| I3 Codex CLI 描述意图启动 workflow，spawn_agent 派 4 个 subagent | ⏩ | 本会话无 Codex 安装 |
-| I4 Codex 下 request_user_input 弹结构化选项 | ⏩ | 本会话无 Codex 安装 |
-| I5 Codex 下 hooks/session-start 注入 context 被 skill 读到 | ⏩ | 静态验证 D2 通过；P0.2 真验证未做 |
+| I2 Codex CLI 装 plugin 后 `/skills` 列出 5 个 skill | ✅ / partial | 临时 `CODEX_HOME` 本地安装成功，plugin cache 中 skill 文件与 root `hooks.json` 可见；交互式 `/skills` UI 未在本报告中截图 |
+| I3 Codex CLI 描述意图启动 workflow，spawn_agent 派 4 个 subagent | ⏩ | subagent 编排未跑全链路；文档已改为当前 `spawn_agent`/`wait_agent`/`close_agent` schema |
+| I4 Codex 下 request_user_input 弹结构化选项 | ⏩ | 当前会话有 `request_user_input` 工具 schema，但未在 plugin workflow 中跑交互式 gate |
+| I5 Codex 下 hooks/session-start 注入 context 被 skill 读到 | ⚠️ | standalone hook 输出合法；Codex CLI v0.133 `exec` nonce test 未看到 `additionalContext` 进入模型上下文，必须保留 `docs_root` fallback |
 | I6 Codex App detached HEAD 下 closeout 走 Path A | ⏩ | 静态验证 E3 通过；运行时未验 |
 | I7 Claude TG MCP 加载时 phase 广播 + decision prompt 走 TG reply | ⏩ | 静态 prose 未变；运行时未验 |
 | I8 Codex 无 TG MCP 时 channel-aware 自动走终端 | ⏩ | 静态 references 明示；运行时未验 |
@@ -134,7 +144,8 @@ status: tester-report
 python3 -c "import json; print('codex:', json.load(open('.codex-plugin/plugin.json'))['version'])"
 python3 -c "import json; print('claude:', json.load(open('.claude-plugin/plugin.json'))['version'])"
 python3 -c "import json; print('marketplace:', json.load(open('.claude-plugin/marketplace.json'))['plugins'][0]['version'])"
-python3 -c "import json; print('hooks.json valid:', bool(json.load(open('hooks/hooks.json'))))"
+python3 -c "import json; print('codex hooks.json valid:', bool(json.load(open('hooks.json'))))"
+python3 -c "import json; print('claude hooks.json valid:', bool(json.load(open('hooks/hooks.json'))))"
 ```
 
 输出：
@@ -143,7 +154,8 @@ python3 -c "import json; print('hooks.json valid:', bool(json.load(open('hooks/h
 codex: 0.0.7
 claude: 0.0.7
 marketplace: 0.0.7
-hooks.json valid: True
+codex hooks.json valid: True
+claude hooks.json valid: True
 ```
 
 ### .codex-plugin/plugin.json 字段 / prompt 长度 / 路径
@@ -151,10 +163,10 @@ hooks.json valid: True
 ```python
 import json
 m = json.load(open('.codex-plugin/plugin.json'))
-required = ['name','version','description','skills','hooks','interface']
+required = ['name','version','description','author','homepage','repository','license','keywords','skills','interface']
 print("A1:", all(k in m for k in required))
 for p in m['interface']['defaultPrompt']: print(f"  len={len(p)}")
-print("A5:", repr(m['skills']), repr(m['interface']['composerIcon']), repr(m['interface']['logo']))
+print("A5:", repr(m['skills']))
 ```
 
 输出：
@@ -164,7 +176,7 @@ A1: True
   len=40
   len=30
   len=24
-A5: './skills/' './assets/icon.svg' './assets/logo.png'
+A5: './skills/'
 ```
 
 ### session-start hook 跑
@@ -177,11 +189,11 @@ CLAUDE_PLUGIN_ROOT=/tmp bash hooks/session-start </dev/null
 输出：
 
 ```
-{"additionalContext":"Roundtable context:\ndocs_root: /data/rsw/roundtable/docs\nproject_id: roundtable\nstatus: ok"}
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"Roundtable context:\ndocs_root: /data/rsw/roundtable/docs\nproject_id: roundtable\nstatus: ok"}}
+{"additionalContext":"Roundtable context:\ndocs_root: /home/ubuntu/rsw/pm/roundtable/docs\nproject_id: roundtable\nstatus: ok"}
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"Roundtable context:\ndocs_root: /home/ubuntu/rsw/pm/roundtable/docs\nproject_id: roundtable\nstatus: ok"}}
 ```
 
-Fallback 分支命中 Codex 期望的 `{"additionalContext": "..."}`，含 `CLAUDE_PLUGIN_ROOT` 时命中 Claude `{"hookSpecificOutput": ...}`，两 runtime 都对。
+Fallback 分支输出 Codex 期望的 `{"additionalContext": "..."}`，含 `CLAUDE_PLUGIN_ROOT` 时输出 Claude `{"hookSpecificOutput": ...}`。脚本 schema 对齐；Codex CLI 是否把该字段注入模型上下文仍以 runtime 实测为准，本次 v0.133 `codex exec` nonce test 未通过。
 
 ### AGENTS.md 字节级检查
 
@@ -207,21 +219,21 @@ ls scripts/ .cursor-plugin/ .opencode/ gemini-extension.json GEMINI.md 2>&1
 
 ### Warning
 
-无 — design-doc §Architecture 描述的 `commands/` 目录「删除」状态被 developer 修订为「保留薄壳 safe default」，但此修订已在 exec-plan P2.5 Change Log 显式记录（2026-05-21 entry），并在 CHANGELOG v0.0.7 Changed 节 + design-doc R1 mitigation 中先行覆盖；属合规偏差，不算 warning。
+1. **Codex SessionStart 注入未可靠证实** —— root `hooks.json` + `hooks/session-start` 的静态 schema 已通过，但 Codex CLI v0.133 `codex exec` nonce test 未看到 `additionalContext` 进模型上下文。当前实现已把 hook 降级为优化项：workflow / bugfix 在 context 缺失时询问 `docs_root`。
+
+design-doc §Architecture 描述的 `commands/` 目录「删除」状态被 developer 修订为「保留薄壳 safe default」，但此修订已在 exec-plan P2.5 Change Log 显式记录（2026-05-21 entry），并在 CHANGELOG v0.0.7 Changed 节 + design-doc R1 mitigation 中先行覆盖；属合规偏差，不算 warning。
 
 ### Suggestion
 
 1. **AGENTS.md 尾换行**（C5 ⚠️）—— 当前 10 字节含 LF。若想严格对齐 superpowers 实证形态（superpowers 同样含尾换行），保持不动；若想严格匹配 design-doc DEC-0004「内容仅一行字面字符串 `CLAUDE.md`」字面，可去掉尾换行。**建议保持不动** —— POSIX 文本文件惯例 + 大部分编辑器自动加尾换行，去掉反而是反惯例。
 
-2. **`.codex-plugin/plugin.json` hooks 字段 schema** —— developer 选了 `hooks.sessionStart` 数组形态（matcher + hooks[].type=command），与 `.claude-plugin/plugin.json` 的 Claude `hooks` schema 完全同构。若 Codex 实际接受的是其他 3 种形态（如 `hooks.session_start` 蛇形 / 顶层 `sessionStart` / `hooks: { sessionStart: {command: "..."} }` 单对象），需 P0.2 实测时再调。**建议 P0.2 时优先验此项**。
+2. **Codex hook discovery 位置** —— 当前分支使用 root `hooks.json`，`.codex-plugin/plugin.json` 不再声明 inline `hooks`。这是为了通过当前 Codex manifest validator，并与官方 plugin 形态对齐。后续需要在 Codex App / 交互式 Codex CLI 里继续验 SessionStart 是否真的触发。
 
-3. **README.md 第 7 行 `~760 lines`** —— v0.0.7 prompts/config 总行数随 references/*5 + workflow Step 0 + agent Codex Runtime Note 增加；目测应在 1000 行附近。可在下一次 lint 时校准数字。**suggestion，非阻塞**。
-
-4. **commands 薄壳一行 `Skill(...)`** —— developer 在 P2.5 选了「保留薄壳」safe default；这是 DEC-0002 的「不破坏 Claude Code 用户路径」的稳妥做法。若 P0.1 实测发现 Claude `/<plugin>:<skill>` 直接触发 skill 而无需 commands 薄壳，可在 v0.0.8 删 commands/ 目录。当前形态最稳。
+3. **commands 薄壳一行 `Skill(...)`** —— developer 在 P2.5 选了「保留薄壳」safe default；这是 DEC-0002 的「不破坏 Claude Code 用户路径」的稳妥做法。若 P0.1 实测发现 Claude `/<plugin>:<skill>` 直接触发 skill 而无需 commands 薄壳，可在 v0.0.8 删 commands/ 目录。当前形态最稳。
 
 ## Deferred to User
 
-以下 9 项必须用户在装有 Claude Code / Codex CLI / Codex App 的环境里手动跑：
+以下项目仍需要在真实 Claude Code / Codex CLI / Codex App 交互环境里补跑；I2 已做临时本地安装 smoke test，但还缺交互式 `/skills` 截图或日志：
 
 ### I1 — Claude Code `/roundtable:workflow <task>` 触发验证
 
@@ -255,21 +267,21 @@ codex
 "run the multi-role workflow on this task: 实现一个 hello world function"
 ```
 
-期望：触发 workflow skill → analyst → architect (user gate) → exec-plan → developer subagent (spawn_agent) → tester → reviewer。subagent 派发用 `spawn_agent(task_name="developer", message="...")` + `wait_agent` + `close_agent`。
+期望：触发 workflow skill → analyst → architect (user gate) → exec-plan → developer subagent (spawn_agent) → tester → reviewer。Codex 下 subagent 派发应先读取 `agents/<role>.md`，再用 `spawn_agent(agent_type="worker", message="...")`，并用返回的 agent id 调 `wait_agent(targets=[id])` + `close_agent(target=id)`。
 
 ### I4 — Codex request_user_input
 
 在 I3 流程的 design-doc / exec-plan 用户确认点观察。
 
-期望：弹结构化 options（不是 plain prompt），含 A / B / accept / modify 等 label + 每条 description。
+期望：`request_user_input` 可用时弹结构化 options（不是 plain prompt），含 A / B / accept / modify 等 label + 每条 description；不可用时用普通聊天列出同等选项并等待用户回复。
 
 ### I5 — Codex SessionStart hook 注入
 
 在 I3 启动 session 时，让 workflow skill 在 Step 1 输出读到的 `Roundtable context:` 内容。
 
-期望：skill 报告 `docs_root` + `project_id` + `status` 与本会话静态验证一致（fallback 分支输出格式 `{"additionalContext": "Roundtable context:\\n..."}`）。
+期望：如果当前 Codex build 暴露 hook context，skill 报告 `docs_root` + `project_id` + `status` 与 standalone hook 输出一致（fallback 分支输出格式 `{"additionalContext": "Roundtable context:\\n..."}`）。如果 context 不可见，workflow 不应失败，而应询问一次 `docs_root`。
 
-如果 skill 报「context not visible」：检查 `~/.codex/config.toml` 含 `[features] plugin_hooks = true`。
+如果 skill 报「context not visible」：检查 `~/.codex/config.toml` 含 `[features] plugin_hooks = true`、plugin 根目录含 `hooks.json`，并确认 `hooks/session-start` 可执行。注意：本次 Codex CLI v0.133 `codex exec` nonce test 未看到 hook context 进模型，因此这一路径当前按 caveat 处理。
 
 ### I6 — Codex App Path A handoff
 
@@ -296,7 +308,7 @@ claude --plugin-dir /data/rsw/roundtable
 
 I3 流程默认无 TG MCP。
 
-期望：channel-aware 检测无 `plugin:telegram:telegram` → 自动走 `request_user_input` 决策路径；不报错；不调任何 TG 工具。
+期望：channel-aware 检测无 `plugin:telegram:telegram` → 走 `request_user_input`（可用时）或普通聊天 fallback；不报错；不调任何 TG 工具。
 
 ### I9 — Reviewer / DBA 在 Codex 下不动文件
 
@@ -316,10 +328,8 @@ git log --oneline -5   # 不应有 reviewer / dba 名义的 commit
 
 ## Conclusion
 
-**Overall status: pass with caveats**
+**Overall status: static pass; runtime hook caveat remains**
 
-静态验收 9 大类（A/B/C/D/E/F/G/H + 报告结构 I 列表）逐项核完，已落地的 20 个 step（P1.1, P1.2, P2.1-P2.6, P3.1-P3.3, P4.1, P4.2, P5.1+P5.2 折入 P2.1, P6.1-P6.3）全部 ✅ pass，1 项 ⚠️ warning 是 AGENTS.md 尾换行（行业惯例，建议保持不动）。
+当前分支的 Codex manifest、root `hooks.json`、Claude `hooks/hooks.json`、skill references、README / CHANGELOG 文档已按当前 Codex tool schema 修正，静态验证通过。最重要的设计调整是：Codex manifest 不再内联 `hooks`；Codex subagent 文档不再假设 `task_name` 或自动注册 `agents/*.md`；所有用户决策都描述为 runtime-specific prompt with fallback。
 
-P0.1 / P0.2 / P0.3 / P1.3 共 4 项标 ⏩ deferred-to-user 的真验证项目，**必须在装有 Claude Code / Codex CLI / Codex App 的环境跑过**才能 ship v0.0.7。建议用户先跑 I5（SessionStart hook 实际注入）和 I2-I3（Codex 触发 + subagent），这两项是最易撞 issue 的；I1（Claude `/roundtable:workflow` 触发）和 I7（TG 广播）可用现有 Claude 会话直接验。I6（Codex App Path A）需要 App 装好；I9（reviewer/dba 安全 prose 生效）建议第一次 Codex review 跑完后 audit `git status`。
-
-design-doc 10 个 DEC + §Architecture 目标文件树与实际实施一一对照通过，无偏差。代码质量、文档完整性、CHANGELOG / README / CONTRIBUTING 三处用户面文档都到位。可进入 reviewer phase（或直接走 closeout 用户确认 → v0.0.7 release tag）。
+仍不能把 SessionStart 注入声明为“已完全跑通”：Codex CLI v0.133 的 `codex exec` nonce smoke test 未看到 `additionalContext` 进入模型上下文。因此 v0.0.7-rc1 的合理发布口径应是：hook 脚本和 discovery 文件合法，Claude 路径保持兼容，Codex 路径有 `docs_root` fallback；还需要在交互式 Codex CLI / Codex App 里继续确认 hooks、`/skills`、workflow subagent 编排和 App handoff。

--- a/hooks.json
+++ b/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${PLUGIN_ROOT}/hooks/session-start\"",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # SessionStart hook for roundtable plugin.
 #
-# Detects docs_root + project_id and injects them into Claude Code session
-# context via the standard SessionStart hook JSON protocol. Skills, agents, and
-# commands read this context at runtime — no inline 4-step detection needed.
+# Detects docs_root + project_id and emits SessionStart JSON. Runtimes that
+# expose hook additionalContext make this visible to skills, agents, and commands.
 
 set -euo pipefail
 
@@ -37,7 +36,7 @@ docs_root: ${docs_root:-<none>}
 project_id: ${project_id}
 status: ${status}"
 [ "$status" = "needs-init" ] && context="${context}
-note: docs_root not found; commands should AskUserQuestion to set one."
+note: docs_root not found; commands should ask the user to set one."
 
 escape_for_json() {
     local s="$1"

--- a/skills/analyst/SKILL.md
+++ b/skills/analyst/SKILL.md
@@ -46,7 +46,7 @@ Always cover the two mandatory; cover conditionals only when relevant — skip s
 
 ## Asking the user
 
-When **research scope or depth** is ambiguous, ask once. **Channel-aware**: if telegram MCP server is loaded, post options via TG `reply` (`a) … b) …`) and wait for text reply; otherwise `AskUserQuestion`. Pack each option as `"Fact: <fact w/ source URL or file:line>. Tradeoff: <objective cost>."`. **Never** mark `★ recommended` — that's the architect's job.
+When **research scope or depth** is ambiguous, ask once. **Channel-aware**: if telegram MCP server is loaded, post options via TG `reply` (`a) … b) …`) and wait for text reply; otherwise use the runtime's user-question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex when available, or normal chat if not). Pack each option as `"Fact: <fact w/ source URL or file:line>. Tradeoff: <objective cost>."`. **Never** mark `★ recommended` — that's the architect's job.
 
 Architecture decisions are out of scope — surface them in `## Open Questions`.
 

--- a/skills/analyst/references/codex-tools.md
+++ b/skills/analyst/references/codex-tools.md
@@ -1,6 +1,6 @@
 # Codex tool mapping — analyst skill
 
-This skill is read-only by design. Under Codex the mapping is small; behaviour is identical.
+This skill is read-only by design. Under Codex the mapping is small; keep the same analyst semantics.
 
 ## Tool equivalents
 
@@ -14,14 +14,15 @@ This skill is read-only by design. Under Codex the mapping is small; behaviour i
 | `WebSearch(query=...)` | `web.run` (Codex web tool) | Use the same query; analyst still produces facts only |
 | `Write(file_path=..., content=...)` | `apply_patch` with `*** Add File:` | Used to create `<docs_root>/analyze/<slug>.md` |
 | `Edit(file_path=..., old=..., new=...)` | `apply_patch` with `*** Update File:` | Used to append to `## FAQ` on follow-up |
-| `AskUserQuestion(...)` | `request_user_input(prompt=..., options=[...])` | When research scope is ambiguous |
+| `AskUserQuestion(...)` | `request_user_input(questions=[...])` when available; otherwise ask in normal chat and wait | When research scope is ambiguous |
 | `mcp__plugin_telegram_telegram__reply` | TG MCP optional under Codex | See workflow `references/codex-tools.md` TG section |
 
 ## Channel-aware decision prompt
 
 Under Claude Code with TG MCP loaded, the analyst posts `a) … b) …` options via TG `reply` and waits for a text reply. Under Codex:
 
-- If no TG MCP server is configured, use `request_user_input` with structured options. Each option label packs the fact + source URL/file:line + objective tradeoff (per SKILL.md "Asking the user").
+- If no TG MCP server is configured and `request_user_input` is available, use `request_user_input(questions=[...])` with structured options. Each option label packs the fact + source URL/file:line + objective tradeoff (per SKILL.md "Asking the user").
+- If `request_user_input` is not available in the current Codex mode, ask the same options in normal chat and stop until the user replies.
 - If a TG MCP server is configured (see workflow `references/codex-tools.md` TG section), the same channel-aware logic applies; use the Codex-side TG MCP tool name visible in `codex /mcp`.
 
 Never mark `★ recommended` regardless of runtime — that is the architect's job.

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architect
-description: System design + execution planning. Activate to design a feature, plan architecture, choose between alternatives, or draft an exec-plan. Calls AskUserQuestion at every architectural decision point.
+description: System design + execution planning. Activate to design a feature, plan architecture, choose between alternatives, or draft an exec-plan. Asks the user at every architectural decision point.
 ---
 
 # Architect
@@ -69,7 +69,7 @@ status: active
 1. Read session-start context, analyst report (if any), prior exec-plans / design-docs (skim for collisions or constraints).
 2. Determine size. Ask user if unclear.
 3. **Optional research fan-out**: if 2–4 candidates need non-trivial external research, dispatch up to 3 general-purpose `Agent` subagents in parallel (one assistant message, multiple tool calls).
-4. For each architectural decision point, ask the user. **Channel-aware**: if the session has the telegram MCP server loaded (check system-reminders), post the question as a TG `reply` with labeled options (`a) … b) … c) …`) and wait for a text reply — do **not** call `AskUserQuestion` (it blocks TG). Otherwise call `AskUserQuestion`. One decision per call; batch only **independent** decisions.
+4. For each architectural decision point, ask the user. **Channel-aware**: if the session has the telegram MCP server loaded (check system-reminders), post the question as a TG `reply` with labeled options (`a) … b) … c) …`) and wait for a text reply — do **not** call the modal question tool (it blocks TG). Otherwise use the runtime's user-question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex when available, or normal chat if not). One decision per call; batch only **independent** decisions.
 5. **Medium / large**: write design-doc → tell user the path → wait for `accept / modify / reject`. On `accept`, write exec-plan → tell user → wait for second `accept / modify / reject`. On `modify`, edit the relevant file and re-prompt.
 6. **Small**: write a single exec-plan with `## Solution` section → wait for `accept / modify / reject`.
 7. On final accept, hand off to the orchestrator (which dispatches developer).
@@ -78,7 +78,7 @@ status: active
 
 2–4 mutually exclusive options. Each option: `<label> — <rationale + tradeoff>`. At most one marked `★ Recommended`. If no preference, recommend nothing.
 
-- Terminal: `AskUserQuestion` (pack rationale into `description`).
+- Terminal: use the runtime's user-question tool (pack rationale into `description`).
 - TG: reply text `<question>\na) <label> — <rationale>\nb) …`, wait for `a/b/c` reply.
 
 ## Boundaries

--- a/skills/architect/references/codex-tools.md
+++ b/skills/architect/references/codex-tools.md
@@ -1,14 +1,14 @@
 # Codex tool mapping — architect skill
 
-This skill orchestrates research, decisions, and emits the design-doc + exec-plan. Under Codex, equivalent tools are used; behaviour is identical.
+This skill orchestrates research, decisions, and emits the design-doc + exec-plan. Under Codex, keep the same architecture workflow while using Codex tool wiring.
 
 ## Tool equivalents
 
 | Claude Code | Codex | Notes |
 |---|---|---|
 | `Skill(skill: "roundtable:analyst")` | Call the `analyst` skill via `/skills` or describe intent | Both runtimes execute `skills/analyst/SKILL.md` |
-| `Agent(...)` for general-purpose research fan-out | `spawn_agent(task_name=..., message=...)` + `wait_agent` + `close_agent` | Up to 3 parallel spawns per Workflow Step 3 |
-| `AskUserQuestion(...)` | `request_user_input(prompt=..., options=[...])` | Used at every architectural decision point — one per call |
+| `Agent(...)` for general-purpose research fan-out | `spawn_agent(agent_type="explorer", message=...)` + `wait_agent(targets=[id])` + `close_agent(target=id)` | Up to 3 parallel spawns per Workflow Step 3 |
+| `AskUserQuestion(...)` | `request_user_input(questions=[...])` when available; otherwise ask in normal chat and wait | Used at every architectural decision point — one per call |
 | `Read(file_path=...)` | `shell` → `cat`/`head`/`tail` | Read prior design-docs, exec-plans, analyst report |
 | `Grep(pattern=..., path=...)` | `shell` → `rg <pattern> <path>` | Slug-collision check, prior decision check |
 | `Glob(pattern=...)` | `shell` → `find` / `rg --files` | — |
@@ -30,16 +30,14 @@ Agent(subagent_type: "general-purpose", prompt: "<research topic 3>")
 Codex:
 ```
 # In a single assistant message, multiple spawn_agent calls in parallel:
-spawn_agent(task_name="research-a", message="<topic 1>")
-spawn_agent(task_name="research-b", message="<topic 2>")
-spawn_agent(task_name="research-c", message="<topic 3>")
+a = spawn_agent(agent_type="explorer", message="<topic 1>")
+b = spawn_agent(agent_type="explorer", message="<topic 2>")
+c = spawn_agent(agent_type="explorer", message="<topic 3>")
 # Then collect:
-wait_agent(task_name="research-a")
-wait_agent(task_name="research-b")
-wait_agent(task_name="research-c")
-close_agent(task_name="research-a")
-close_agent(task_name="research-b")
-close_agent(task_name="research-c")
+wait_agent(targets=[a.id, b.id, c.id])
+close_agent(target=a.id)
+close_agent(target=b.id)
+close_agent(target=c.id)
 ```
 
 Limit: at most 3 parallel research agents (per Workflow Step 3).
@@ -50,7 +48,8 @@ The architect asks the user at every architectural decision point. Under Claude 
 
 Under Codex:
 
-- If no TG MCP server is configured: use `request_user_input` with structured options. Pack rationale + tradeoff into each option's `description`. At most one option marked `★ Recommended`. If no preference, recommend nothing.
+- If no TG MCP server is configured and `request_user_input` is available: call `request_user_input(questions=[...])` with structured options. Pack rationale + tradeoff into each option's `description`. At most one option marked `★ Recommended`. If no preference, recommend nothing.
+- If `request_user_input` is not available in the current Codex mode: ask the same options in normal chat and stop until the user replies.
 - If a TG MCP server is configured (see workflow `references/codex-tools.md`): use the channel-aware TG branch; do not call `request_user_input` (it would block the TG flow).
 
 One decision per call. Batch only **independent** decisions into a single call.

--- a/skills/bugfix/SKILL.md
+++ b/skills/bugfix/SKILL.md
@@ -12,7 +12,7 @@ Fast path for fixing a bug. Skip analyst, design-doc, and user gates around desi
 
 ## Step 1: Read context
 
-SessionStart hook injects `docs_root` + `project_id`. Pick a slug.
+SessionStart hook may inject `docs_root` + `project_id`. Pick a slug. If context is missing, ask for `docs_root` using the runtime's user-question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex when available, or normal chat if not).
 
 **Channel broadcast**: same rule as `/roundtable:workflow` Step 2 — if telegram MCP is loaded, post a new `reply` at workflow start, each phase completion (Step 4 developer / Step 5 reviewer or dba / Step 6 postmortem), and closeout. Terminal-only output is a bug.
 
@@ -34,12 +34,16 @@ LOC = `git diff --numstat` insertions + deletions. If unclear, ask the user.
 
 ## Step 4: Dispatch developer
 
-`Agent(subagent_type: "roundtable:developer", ...)` with:
+Dispatch developer:
+
+- Claude Code: `Agent(subagent_type: "roundtable:developer", ...)`
+- Codex: read `agents/developer.md`, then call `spawn_agent` with `agent_type: "worker"` and a `message` containing that role prompt plus:
+
 - bug description + root-cause analysis
 - tier (0 / 1 / 2)
 - explicit instruction: **must add a regression test**; do not refactor unrelated code
 
-If developer returns `[NEED-DECISION]`, call `AskUserQuestion` and re-dispatch.
+If developer returns `[NEED-DECISION]`, ask with the runtime's user-question tool and re-dispatch.
 
 ## Step 5: Verify + optional review
 

--- a/skills/bugfix/references/codex-tools.md
+++ b/skills/bugfix/references/codex-tools.md
@@ -1,13 +1,13 @@
 # Codex tool mapping — bugfix skill
 
-This skill uses Claude Code idiom. Under Codex, invoke the equivalent tool — behaviour is identical.
+This skill uses Claude Code idiom. Under Codex, keep the same bugfix workflow while using Codex tool wiring.
 
 ## Tool equivalents
 
 | Claude Code | Codex | Notes |
 |---|---|---|
-| `Agent(subagent_type: "roundtable:developer", ...)` | `spawn_agent(task_name="developer", message=...)` + `wait_agent` + `close_agent` | Pass bug description, tier, exec-plan path, slug |
-| `AskUserQuestion(...)` | `request_user_input(prompt=..., options=[...])` | Used for tier disambiguation + `[NEED-DECISION]` relay |
+| `Agent(subagent_type: "roundtable:developer", ...)` | `spawn_agent(agent_type="worker", message=...)` + `wait_agent(targets=[id])` + `close_agent(target=id)` | Read `agents/developer.md` first and embed it in the `message` |
+| `AskUserQuestion(...)` | `request_user_input(questions=[...])` when available; otherwise ask in normal chat and wait | Used for tier disambiguation + `[NEED-DECISION]` relay |
 | `Read(file_path=...)` | `shell` → `cat`/`head`/`tail` | — |
 | `Grep(pattern=..., path=...)` | `shell` → `rg <pattern> <path>` | Used in Step 2 to locate the bug |
 | `Glob(pattern=...)` | `shell` → `find` / `rg --files` | — |
@@ -20,17 +20,17 @@ This skill uses Claude Code idiom. Under Codex, invoke the equivalent tool — b
 
 Codex:
 ```
-spawn_agent(
-  task_name="developer",
-  message="bug: <description>\ntier: <0|1|2>\nslug: <slug>\ndocs_root: <path>\n\nMust add a regression test. Do not refactor unrelated code."
+result = spawn_agent(
+  agent_type="worker",
+  message="<contents of agents/developer.md>\n\nbug: <description>\ntier: <0|1|2>\nslug: <slug>\ndocs_root: <path>\n\nMust add a regression test. Do not refactor unrelated code.\nYou are not alone in the codebase; do not revert edits made by others."
 )
-wait_agent(task_name="developer")
-close_agent(task_name="developer")
+wait_agent(targets=[result.id])
+close_agent(target=result.id)
 ```
 
 ## `[NEED-DECISION]` relay
 
-Identical to workflow skill. Under Codex use `request_user_input`. See `skills/workflow/references/codex-tools.md` for the full pattern.
+Identical to workflow skill. Under Codex use `request_user_input(questions=[...])` when available; otherwise ask the user in normal chat and stop until they reply. See `skills/workflow/references/codex-tools.md` for the full pattern.
 
 ## Troubleshooting
 

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -12,7 +12,7 @@ Orchestrate the workflow. Don't design or code — dispatch each substantive ste
 
 ## Step 1: Read context
 
-The SessionStart hook injects roundtable context (`Roundtable context:` block). Extract `docs_root`, `project_id`, `status`. If `status: needs-init`, call `AskUserQuestion` to confirm where to put `docs/`. Pick a kebab-case `slug` for this task (or ask).
+The SessionStart hook may inject roundtable context (`Roundtable context:` block). Extract `docs_root`, `project_id`, `status` when present. If the block is missing or `status: needs-init`, ask the user where to put `docs/` using the runtime's user-question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex when available, or normal chat if not). Pick a kebab-case `slug` for this task (or ask).
 
 ## Step 2: Phase Matrix
 
@@ -51,9 +51,15 @@ Trigger phase 9 (dba) iff the task touches schema, migrations, or hot SQL.
 
 ## Step 4: Run phases
 
-Phase 1, 2, 4 are skills (run in main session via `Skill` tool):
+Phase 1, 2, 4 are skills (run in main session):
+
+Claude Code:
 - `Skill(skill: "roundtable:analyst", args: "<task summary + slug>")`
 - `Skill(skill: "roundtable:architect", args: "<task summary + slug + analyst report path if any>")` — architect handles both phase 2 (design-doc) and phase 4 (exec-plan) internally; it pauses for user confirm between them.
+
+Codex:
+- Open `skills/analyst/SKILL.md` / `skills/architect/SKILL.md` and execute their instructions directly in the main session.
+- If the skill needs runtime-specific tool syntax, read the matching `references/codex-tools.md` file first.
 
 Phase 3 and 5 are user gates. After architect produces design-doc (medium / large), render a 3-line summary + matrix and stop:
 
@@ -65,10 +71,11 @@ reply: `accept` / `modify: <…>` / `reject` / `ask: <…>`
 
 On `accept`, architect proceeds to write the exec-plan, then pauses again for the second confirmation.
 
-Phase 6–9 are subagents. Dispatch via `Agent` tool, one role per call:
-- Pass: exec-plan path, `docs_root`, slug, optional design-doc path
+Phase 6–9 are subagents. Dispatch one role per call:
+- Claude Code: use `Agent(subagent_type: "roundtable:<role>", prompt: ...)`.
+- Codex: first read `agents/<role>.md`, then call `spawn_agent` with `agent_type: "worker"` and a `message` containing that role prompt plus exec-plan path, `docs_root`, slug, optional design-doc path, and "You are not alone in the codebase; do not revert edits made by others." Keep the returned agent id for `wait_agent(targets: [id])` and `close_agent(target: id)`.
 - Read return text. Tick matrix status.
-- **If return text contains `[NEED-DECISION]`**: parse the line, ask the user (TG `reply` with `a/b` options if telegram MCP is loaded; else `AskUserQuestion`), append answer to the exec-plan's `## Change Log`, then re-dispatch the same role with the answer.
+- **If return text contains `[NEED-DECISION]`**: parse the line, ask the user (TG `reply` with `a/b` options if telegram MCP is loaded; else the runtime's user-question tool, falling back to normal chat when needed), append answer to the exec-plan's `## Change Log`, then re-dispatch the same role with the answer.
 - After phase 6 (developer), if the project's CLAUDE.md declares `critical_modules` and the diff hits one, phases 7 and 8 are mandatory; otherwise ask the user.
 
 ## Step 5: Closeout

--- a/skills/workflow/references/codex-tools.md
+++ b/skills/workflow/references/codex-tools.md
@@ -1,6 +1,6 @@
 # Codex tool mapping — workflow skill
 
-This skill is written in Claude Code idiom (`Skill`, `Agent`, `AskUserQuestion`, `TodoWrite`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Bash`). Under Codex, invoke the equivalent Codex tool — behaviour is identical, only the tool name changes.
+This skill is written in Claude Code idiom (`Skill`, `Agent`, `AskUserQuestion`, `TodoWrite`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, `Bash`). Under Codex, keep the same workflow semantics but use the Codex tool wiring below.
 
 ## Tool equivalents
 
@@ -8,8 +8,8 @@ This skill is written in Claude Code idiom (`Skill`, `Agent`, `AskUserQuestion`,
 |---|---|---|
 | `Skill(skill: "roundtable:analyst", args: ...)` | Call the `analyst` skill via `/skills` or describe intent — Codex loads `skills/analyst/SKILL.md` directly | Both runtimes execute the same SKILL.md body |
 | `Skill(skill: "roundtable:architect", args: ...)` | Same as analyst — `skills/architect/SKILL.md` | — |
-| `Agent(subagent_type: "roundtable:developer", ...)` | `spawn_agent(task_name="developer", message=...)` + `wait_agent` + `close_agent` | One spawn per role; pass exec-plan path, `docs_root`, slug, optional design-doc path in the `message` |
-| `AskUserQuestion(...)` | `request_user_input(prompt=..., options=[...])` | Schema is near 1:1; pack rationale into option labels |
+| `Agent(subagent_type: "roundtable:developer", ...)` | `spawn_agent(agent_type="worker", message=...)` + `wait_agent(targets=[id])` + `close_agent(target=id)` | One spawn per role; read `agents/<role>.md` first and embed that role prompt in the `message` |
+| `AskUserQuestion(...)` | `request_user_input(questions=[...])` when available; otherwise ask in normal chat and wait | One question object with `header`, `id`, `question`, and 2-3 `options` |
 | `TodoWrite(...)` | `update_plan(plan=[...])` | Codex schema is simpler; use it for matrix-style tracking |
 | `Read(file_path=...)` | `shell` → `cat <path>` / `head -n N <path>` / `tail -n N <path>` | No dedicated Read tool in Codex |
 | `Grep(pattern=..., path=...)` | `shell` → `rg <pattern> <path>` | `rg` is preferred over `grep` for speed |
@@ -28,16 +28,16 @@ Agent(subagent_type: "roundtable:developer", prompt: "<exec-plan path> ...")
 
 Codex:
 ```
-spawn_agent(
-  task_name="developer",
-  message="exec-plan: <path>\ndocs_root: <path>\nslug: <slug>\ndesign-doc (optional): <path>"
+result = spawn_agent(
+  agent_type="worker",
+  message="<contents of agents/developer.md>\n\nexec-plan: <path>\ndocs_root: <path>\nslug: <slug>\ndesign-doc (optional): <path>\n\nYou are not alone in the codebase; do not revert edits made by others."
 )
 # … other work in parallel if needed …
-wait_agent(task_name="developer")
-close_agent(task_name="developer")
+wait_agent(targets=[result.id])
+close_agent(target=result.id)
 ```
 
-The four subagent files (`agents/developer.md`, `tester.md`, `reviewer.md`, `dba.md`) work in both runtimes. Under Codex the frontmatter `tools:` field is not enforced; each agent's prose now contains the equivalent restrictions (see `agents/reviewer.md` and `agents/dba.md` Forbidden sections).
+The four subagent files (`agents/developer.md`, `tester.md`, `reviewer.md`, `dba.md`) are not auto-registered as Codex agent types. Under Codex, the orchestrator must read the target role file and embed it in the spawned worker's `message`. The frontmatter `tools:` field is not enforced; each agent's prose contains the equivalent restrictions (see `agents/reviewer.md` and `agents/dba.md` Forbidden sections).
 
 ## `[NEED-DECISION]` relay
 
@@ -47,14 +47,20 @@ When a subagent's return text contains:
 [NEED-DECISION] <topic> | options: A) <…> B) <…>
 ```
 
-Parse one line; ask the user; append answer to exec-plan `## Change Log`; re-dispatch the same role. The mechanism is identical across runtimes. Under Codex use `request_user_input` instead of `AskUserQuestion`:
+Parse one line; ask the user; append answer to exec-plan `## Change Log`; re-dispatch the same role. The mechanism is identical across runtimes. Under Codex use `request_user_input` when available, otherwise ask in normal chat and wait:
 
 ```
 request_user_input(
-  prompt="<topic>",
-  options=[
-    {"label": "A", "description": "<rationale + tradeoff>"},
-    {"label": "B", "description": "<rationale + tradeoff>"}
+  questions=[
+    {
+      "header": "Decision",
+      "id": "decision",
+      "question": "<topic>",
+      "options": [
+        {"label": "A", "description": "<rationale + tradeoff>"},
+        {"label": "B", "description": "<rationale + tradeoff>"}
+      ]
+    }
   ]
 )
 ```
@@ -72,7 +78,7 @@ Under Codex, TG is optional. If you want phase broadcasts to TG:
 2. Confirm the server is loaded: `codex /mcp`
 3. The channel-aware check will then post via the Codex-side TG MCP tool name (visible in `/mcp` output).
 
-If no TG MCP is loaded, the workflow degrades to terminal mode automatically — `request_user_input` for gates, plain stdout for phase summaries. This is the default Codex experience and is fully functional.
+If no TG MCP is loaded, the workflow degrades to terminal mode automatically — `request_user_input` for gates when available, or normal chat prompts otherwise, plus plain stdout for phase summaries. This is the default Codex experience.
 
 ## Troubleshooting
 
@@ -89,16 +95,20 @@ Restart the Codex session after editing config.
 
 ### SessionStart hook context missing
 
+Continue the workflow by asking the user for `docs_root`; the hook is an optimization, not a hard dependency.
+
 If the `Roundtable context:` block is not visible to the workflow skill, check:
 
 1. `~/.codex/config.toml` has `[features] plugin_hooks = true`
-2. `.codex-plugin/plugin.json` `hooks.sessionStart` block is well-formed JSON
+2. The plugin root contains `hooks.json` with a `SessionStart` hook
 3. `${PLUGIN_ROOT}/hooks/session-start` is executable: `chmod +x hooks/session-start`
 4. Run the hook standalone to verify output:
    ```
    bash hooks/session-start <<< '{}'
    ```
    Expected: a JSON object with `additionalContext` (or `additional_context` / `hookSpecificOutput.additionalContext` depending on env vars).
+
+5. On Codex CLI builds where `codex exec` does not surface hook `additionalContext` to the model, use the fallback prompt path and ask once for `docs_root`.
 
 ### `apply_patch` rejects an edit
 


### PR DESCRIPTION
## Summary

This PR tightens the v0.0.7-rc1 Codex compatibility layer after testing it with Codex CLI v0.133.0.

Changes:
- Move Codex SessionStart hook discovery to root-level `hooks.json` and remove unsupported inline `hooks` from `.codex-plugin/plugin.json`.
- Keep Claude Code compatibility via existing `hooks/hooks.json` and `hooks/session-start` output shape.
- Update Codex tool references to current schemas: `spawn_agent(agent_type=..., message=...)`, `wait_agent(targets=[id])`, `close_agent(target=id)`, and `request_user_input(questions=[...])`.
- Clarify that Codex must read/embed `agents/<role>.md` into spawned worker messages; these files are not auto-registered as Codex agent types.
- Treat SessionStart `additionalContext` as an optimization with a `docs_root` prompt fallback, because `codex exec` did not reliably surface hook context to the model in nonce testing.
- Update README / README-zh / CHANGELOG / `docs/testing/codex-compatibility.md` with current test results and caveats.

## Validation

- `python3 -m json.tool .codex-plugin/plugin.json`
- `python3 -m json.tool hooks.json`
- `python3 -m json.tool hooks/hooks.json`
- `python3 /home/ubuntu/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .`
- `bash hooks/session-start </dev/null`
- `CLAUDE_PLUGIN_ROOT=/tmp bash hooks/session-start </dev/null`
- Temporary Codex local marketplace install succeeded; cached plugin manifest has no inline `hooks`, and cached root `hooks.json` is present.
- `git diff --check`

## Review Notes

Important caveat for Claude review: standalone hook schema is valid for both runtimes, but Codex CLI v0.133 `codex exec` nonce testing did not prove that SessionStart `additionalContext` reaches model context. The workflow now treats it as optional and falls back to asking for `docs_root`.
