### PR TITLE
docs: propose workspace-first setup

### DIFF
--- a/docs/analyze/mattpocock-skills-patterns.md
+++ b/docs/analyze/mattpocock-skills-patterns.md
@@ -1,0 +1,123 @@
+---
+slug: mattpocock-skills-patterns
+created: 2026-06-02
+---
+
+# Matt Pocock Skills 模式分析
+
+## 背景与目标
+
+用户希望 clone 并详细分析 `https://github.com/mattpocock/skills`，用于后续完善 Roundtable。
+
+仓库已 clone 到 `/home/ubuntu/rsw/pm/mattpocock-skills`，当前提交为 `aaf2453`。本报告对比该仓库的可观察模式与 Roundtable `v0.0.7-rc3`，Roundtable 当前提交为 `a91f3a4`。
+
+本报告只做事实和模式分析，不直接做架构选择。与 Roundtable 后续改造相关的决策点列在「开放问题」中，适合作为下一步设计输入。
+
+## 发现
+
+### 仓库形态
+
+`mattpocock/skills` 是一个 skill 库，不是一个固定流程编排器。它的 plugin manifest 只发布 `skills/engineering` 和 `skills/productivity` 下的技能；`misc`、`personal`、`in-progress`、`deprecated` 被明确排除在发布面之外。项目 `CLAUDE.md` 要求每个正式发布的 skill 同时出现在顶层 README 和 `.claude-plugin/plugin.json` 中。
+
+Roundtable 是一个 workflow plugin，公开面更小：`workflow`、`bugfix`、`lint`、`analyst`、`architect`，以及四个角色 agent。README 把 Roundtable 描述为一个带固定 Phase Matrix 的流程编排层。
+
+### setup-first 配置
+
+`setup-matt-pocock-skills` 是一个显式的一次性 setup skill。它会先探索当前 repo，展示发现，再逐个询问用户决策，最后写入：
+
+- 现有 `CLAUDE.md` 或 `AGENTS.md` 中的 `## Agent skills` 配置块
+- `docs/agents/issue-tracker.md`
+- `docs/agents/triage-labels.md`
+- `docs/agents/domain.md`
+
+这个 setup skill 把 issue tracker、triage label、domain docs layout 都当作项目拥有的持久配置。它不依赖启动 hook 去推断这些值。
+
+Roundtable 当前依靠 `SessionStart` 推断 `docs_root` 和 `project_id`；当 hook 上下文缺失或为 `needs-init` 时，`workflow`、`bugfix`、`lint` 再做 fallback。Roundtable 目前没有一个会写入持久项目配置的 setup skill。
+
+### hard dependency 与 soft dependency
+
+`0001-explicit-setup-pointer-only-for-hard-dependencies.md` 这份 ADR 把 skills 分成两类：
+
+- hard dependency：`to-issues`、`to-prd`、`triage`。如果缺少 issue tracker 或 label 映射，输出会是错误的。
+- soft dependency：`diagnose`、`tdd`、`improve-codebase-architecture`、`zoom-out`。缺少 domain docs 会降低输出质量，但 skill 仍然可以运行。
+
+Roundtable 实际上也有类似依赖分层，但当前 prompt 里没有明确命名。`docs_root` 对 artifact 写入是硬依赖；`critical_modules`、`lint_cmd`、`test_cmd`、项目语言约定则更像软依赖，可以自动检测或降级。
+
+### 域语言与 ADR 记忆
+
+`grill-with-docs` 会在用户访谈过程中创建或更新 `CONTEXT.md`。它把 `CONTEXT.md` 严格限定为 glossary，不允许写实现细节。只有当一个决策同时满足三个条件时才建议写 ADR：难以回滚、没有上下文会令人意外、确实存在 trade-off。ADR 也保持很短，放在 `docs/adr/` 下。
+
+Roundtable 当前把任务相关 artifact 放在 `docs/analyze`、`docs/design-docs`、`docs/exec-plans`、`docs/testing`、`docs/reviews`、`docs/bugfixes` 中。它没有把 domain glossary 或 ADR 目录作为一等概念。Roundtable 的 design-doc 会记录单个任务的决策，但没有一个要求后续任务读取的长期决策记忆层。
+
+### grilling loop 与 phase gate
+
+Matt Pocock 的 `grill-with-docs` 一次只问一个问题；如果问题能通过读代码回答，就先读代码而不是问用户；当决策逐步清晰时，会立即更新文档。它的交互重点是消除模糊语言和决策分支。
+
+Roundtable 的 architect skill 也会逐个询问架构决策点，并要求用户确认 design-doc 和 exec-plan。区别是 Roundtable 的交互是 phase-oriented：analyst 产事实，architect 产设计，用户确认，生成 exec-plan，再确认，然后 developer、tester、reviewer、dba 接力。
+
+### 反馈环诊断纪律
+
+`diagnose` 把快速、确定性的 pass/fail 信号视为调试核心资产。它要求先构建反馈环，再复现、提出 ranked hypotheses、一次只 instrument 一个变量、修复、补回归测试、清理 debug instrumentation。
+
+Roundtable 的 `bugfix` skill 要求回归测试，并有 Tier 0/1/2 分层。但它目前没有完整写出诊断循环，例如反馈环构建、可证伪假设排序、带唯一前缀的 debug instrumentation、清理检查等。
+
+### TDD 纪律
+
+`tdd` 强烈反对 horizontal slicing：不是先写一堆测试再写一堆实现，而是一个行为测试、一段最小实现、循环推进。它强调只测 public interface、只测行为、green 后再 refactor。
+
+Roundtable 的 developer 指令要求写测试，也说明非平凡行为要先写失败测试。但当前 workflow prompt 没有像 `tdd` 一样明确要求 one-test-at-a-time 的 vertical cycle，也没有把 public-interface-only tests 写成强约束。
+
+### 工作切片与 durable agent brief
+
+`to-issues` 会把计划拆成 independently grabbable 的 vertical slices，标记 HITL 或 AFK，检查依赖顺序，并把 issue body 写成耐久说明而不是文件路径清单。`triage` 使用 `Agent Brief` 模板，避免文件路径和行号，强调 key interfaces、acceptance criteria 和 out-of-scope。
+
+Roundtable 的 exec-plan 是本地文档，包含明确步骤、checkbox 和验证项。它通过 slug 串联同一任务的文档，也可能提到具体文件。Roundtable 目前没有定义 AFK-ready brief contract，因为它是 orchestrator 直接派发 subagent，而不是先发布到外部 issue tracker。
+
+### 独立的架构改进 skill
+
+`improve-codebase-architecture` 与 feature workflow 独立。它会读取 domain language 和 ADR，探索架构摩擦，把 HTML 报告写到临时目录，询问用户想深入哪个候选项，然后才进入 grilling loop。它有专门的架构词汇：Module、Interface、Implementation、Depth、Seam、Adapter、Leverage、Locality。
+
+Roundtable 有 analyst 和 architect 角色，但没有专门的 architecture review / deepening skill。Reviewer 主要审查 diff，architect 主要产任务级 design-doc。
+
+### Prompt 组织方式
+
+Matt Pocock 的多个 skill 使用 progressive disclosure：主 `SKILL.md` 保持短小，详细格式和例子放到同目录文件，例如 `CONTEXT-FORMAT.md`、`ADR-FORMAT.md`、`tests.md`、`mocking.md`、`HTML-REPORT.md`、`AGENT-BRIEF.md`。
+
+Roundtable 已经用 `references/codex-tools.md` 存放 runtime-specific tool mapping。除此之外，大多数 workflow 指令仍集中在 `SKILL.md` 和 agent prompt 文件中。
+
+### 失败模式
+
+把 Matt Pocock 模式搬进 Roundtable 的主要失败模式是机制膨胀。Roundtable 当前的价值主张是小型流程编排层和有限文档机制。如果不加范围控制就加入 setup、domain docs、ADR、issue tracker mapping、triage、architecture report，可能会重新形成 Roundtable 在 `v0.0.5` 前刻意删除的机制负担。
+
+相反的失败模式是 Roundtable 继续过度依赖 hook 来承载关键配置。`docs_root` 已经暴露了这个问题：当 runtime 没有把 hook context 传给模型，或者用户从父目录启动时，workflow 启动就需要 fallback。未来如果加入 issue tracker、domain docs、critical modules、toolchain overrides，也可能遇到类似问题。
+
+### 6 个月复盘视角
+
+六个月后最可能仍然有价值的 Matt Pocock 模式包括：hard/soft dependency 分层、对 load-bearing 配置使用显式 setup、用 domain vocabulary 作为简洁项目记忆、以及诊断反馈环纪律。这些模式概念较小，也容易跨 runtime 复用。
+
+六个月后最可能变成 Roundtable 技术债的模式包括：完整外部 issue tracker 编排、triage 状态机、富 HTML 架构报告。这些在原 repo 中有价值，是因为它是 composable skill collection；但在 Roundtable 中，如果没有作为可选能力隔离，可能会和现有 Phase Matrix 竞争。
+
+## 对比
+
+| 维度 | Matt Pocock Skills | Roundtable v0.0.7-rc3 |
+|---|---|---|
+| 主要形态 | 可组合 skill 库 | 固定多角色 workflow plugin |
+| 启动配置 | 显式 `/setup-matt-pocock-skills` 写项目文档 | `SessionStart` 检测 `docs_root`，skill 缺失时 fallback |
+| 持久记忆 | `CONTEXT.md`、`docs/adr/`、`docs/agents/*` | 任务 artifact：`docs/{analyze,design-docs,exec-plans,testing,reviews,bugfixes}` |
+| 决策方式 | grilling loop，文档 inline 更新 | architect gate，design-doc 再 exec-plan |
+| Bug 流程 | 以反馈信号为中心的 diagnose loop | bugfix tier + 必须回归测试 |
+| 测试流程 | vertical red-green-refactor | developer/tester prompt，vertical loop 不够显式 |
+| 工作发布 | issue tracker + durable agent brief | 本地 exec-plan + 直接 subagent dispatch |
+| 架构审查 | 独立 architecture-deepening skill + 可视报告 | 任务级 analyst / architect / reviewer |
+| Prompt 结构 | 多个小 skill + reference files | 小 public surface + role prompts + runtime references |
+
+## 开放问题
+
+1. Roundtable 是否应该新增 `/roundtable:setup` skill，用于 load-bearing project configuration？还是继续只使用 `SessionStart` + fallback？
+2. 如果有 setup，哪些字段属于 hard dependency？候选包括：`docs_root`、issue tracker、critical modules、lint/test command overrides、domain-doc layout。
+3. Roundtable 是否应该把 `CONTEXT.md` / `docs/adr/` 引入为一等项目记忆？还是继续把所有 durable decisions 放在任务级 design-doc 中？
+4. `bugfix` 是否应该吸收 `diagnose` 的严格诊断循环？还是保持 fast path，把深度 debugging 做成独立 skill？
+5. developer/tester prompt 是否应该加入显式 vertical TDD loop，包括 public-interface-only tests 和 one red-green cycle at a time？
+6. Roundtable 是否应该新增独立 architecture-review skill？还是这会和 analyst + architect + reviewer 重叠？
+7. 即使 Roundtable 不发布外部 issue，是否也应该为 subagent dispatch 定义 AFK-ready brief 格式？
+8. Roundtable 应该采纳多少 progressive disclosure？如果拆太多 reference 文件，维护成本是否会超过当前紧凑文件结构？

--- a/docs/design-docs/workspace-first-setup.md
+++ b/docs/design-docs/workspace-first-setup.md
@@ -1,0 +1,295 @@
+---
+slug: workspace-first-setup
+created: 2026-06-03
+status: draft
+source: analyze/mattpocock-skills-patterns.md
+---
+
+# Workspace-First Setup — 系统设计
+
+## Background & Goals
+
+Roundtable 当前 `v0.0.7-rc3` 通过 `SessionStart` hook 轻量检测 `docs_root` 和 `project_id`。当用户从具体项目根目录启动时，这个路径工作正常；当用户从一个非 git workspace 根目录启动，并同时管理多个子项目时，hook 无法安全地自动选择目标项目。
+
+当前 `/home/ubuntu/rsw/pm` 就是这种形态：
+
+- workspace 根目录不是 git 仓库，但有跨项目 `CLAUDE.md` / `AGENTS.md`
+- 子目录 `pm-cup2026/`、`pm-cup2026-liquidity/`、`pm-sdk-go/`、`roundtable/` 才是具体 git 项目
+- 子项目各自有自己的 `docs/`、`CLAUDE.md` 或项目规则
+- 用户习惯从 workspace 根目录启动 agent，并在一次会话里处理多个项目
+
+目标：
+
+1. 支持从 workspace 根目录启动 Roundtable，并可靠路由到目标子项目。
+2. 保持 `SessionStart` hook 轻量，只探测事实，不替用户猜项目。
+3. 把 load-bearing 配置显式写入 workspace / project 配置，减少隐式推断。
+4. 保持 Roundtable 当前 Phase Matrix 和 artifact 目录结构，不重新引入过重机制。
+5. 先解决多项目路由，不急于引入 issue tracker、CONTEXT.md、ADR 等扩展能力。
+
+## Solution
+
+采用 **workspace-first + project-level setup**。
+
+核心思路：
+
+- workspace 层负责“当前任务属于哪个子项目”
+- project 层负责“这个子项目的 docs_root、lint/test、critical_modules 等规则”
+- hook 只输出当前 cwd 的探测结果和候选项目，不做最终选择
+- `workflow` / `bugfix` / `lint` 在启动时完成项目路由，然后进入现有流程
+
+### 1. Workspace Registry
+
+在 workspace 根目录增加：
+
+```text
+.roundtable/workspace.toml
+```
+
+示例：
+
+```toml
+[workspace]
+root = "/home/ubuntu/rsw/pm"
+default_docs_policy = "project-docs"
+
+[[projects]]
+id = "pm-cup2026"
+path = "pm-cup2026"
+docs_root = "pm-cup2026/docs"
+aliases = ["cup", "main"]
+
+[[projects]]
+id = "pm-cup2026-liquidity"
+path = "pm-cup2026-liquidity"
+docs_root = "pm-cup2026-liquidity/docs"
+aliases = ["liquidity", "mm", "做市"]
+
+[[projects]]
+id = "pm-sdk-go"
+path = "pm-sdk-go"
+docs_root = "pm-sdk-go/docs"
+aliases = ["sdk"]
+
+[[projects]]
+id = "roundtable"
+path = "roundtable"
+docs_root = "roundtable/docs"
+aliases = ["rt"]
+```
+
+字段含义：
+
+- `id`：稳定项目名，用于 prompt、日志、路由
+- `path`：相对 workspace root 的项目路径
+- `docs_root`：相对 workspace root 的 Roundtable artifact 写入路径
+- `aliases`：用户自然语言任务里的项目别名
+
+### 2. Project Config
+
+每个子项目可以选择增加：
+
+```text
+<project>/.roundtable/project.toml
+```
+
+MVP 阶段只定义少数字段：
+
+```toml
+[project]
+id = "pm-cup2026-liquidity"
+docs_root = "docs"
+default_branch = "dev"
+
+[toolchain]
+lint_cmd = "go test ./..."
+test_cmd = "go test ./..."
+
+[rules]
+critical_modules = ["services/liquidity-service", "internal/risk", "migrations"]
+```
+
+读取优先级：
+
+1. `<project>/.roundtable/project.toml`
+2. 子项目 `CLAUDE.md` / `AGENTS.md`
+3. 自动检测
+4. 用户确认
+
+MVP 可以先不实现全部字段，只把 schema 和读取顺序确定下来。
+
+### 3. `/roundtable:setup`
+
+新增 setup skill，分两个入口：
+
+```text
+/roundtable:setup workspace
+/roundtable:setup project <project-id>
+```
+
+#### workspace setup
+
+流程：
+
+1. 扫描当前目录下一级/二级 git 项目。
+2. 只保留存在 `docs/` 或 `documentation/` 的候选。
+3. 展示项目列表、docs_root、是否有 `CLAUDE.md` / `AGENTS.md`。
+4. 逐个询问用户确认项目 id 和 aliases。
+5. 写 `.roundtable/workspace.toml`。
+
+#### project setup
+
+流程：
+
+1. 读取目标项目 `CLAUDE.md` / `AGENTS.md`。
+2. 确认 `docs_root`、默认分支、critical_modules、lint/test 命令。
+3. 写 `<project>/.roundtable/project.toml`。
+
+setup 不自动改业务代码，不创建 issue，不迁移历史 docs。
+
+### 4. SessionStart Hook
+
+hook 保持轻量。
+
+当 cwd 位于具体项目内时：
+
+```text
+Roundtable context:
+workspace_root: /home/ubuntu/rsw/pm
+project_id: pm-cup2026-liquidity
+project_root: /home/ubuntu/rsw/pm/pm-cup2026-liquidity
+docs_root: /home/ubuntu/rsw/pm/pm-cup2026-liquidity/docs
+status: ok
+```
+
+当 cwd 位于 workspace 根目录时：
+
+```text
+Roundtable context:
+workspace_root: /home/ubuntu/rsw/pm
+project_id: <none>
+docs_root: <none>
+status: needs-project
+candidates:
+- pm-cup2026
+- pm-cup2026-liquidity
+- pm-sdk-go
+- roundtable
+```
+
+hook 不根据候选列表自动选项目。多个候选时，选择权交给 `workflow` / `bugfix` / `lint`。
+
+### 5. Workflow Routing
+
+`workflow` / `bugfix` / `lint` 启动顺序改为：
+
+1. 读取 `Roundtable context`。
+2. 如果 `status: ok`，直接使用 `project_root` 和 `docs_root`。
+3. 如果 `status: needs-project`：
+   - 读取 `.roundtable/workspace.toml`
+   - 用 `$ARGUMENTS` 匹配 `id`、`path`、`aliases`
+   - 精确唯一命中则使用
+   - 多命中或无命中则询问用户
+4. 选定项目后，后续所有 phase 都带上：
+   - `project_id`
+   - `project_root`
+   - `docs_root`
+5. 所有 artifact 写入目标项目的 `docs/`，不写 workspace 根目录。
+
+示例：
+
+用户在 `/home/ubuntu/rsw/pm` 输入：
+
+```text
+跑 liquidity 的库存风险控制 workflow
+```
+
+Roundtable 应路由到：
+
+```text
+project_id: pm-cup2026-liquidity
+project_root: /home/ubuntu/rsw/pm/pm-cup2026-liquidity
+docs_root: /home/ubuntu/rsw/pm/pm-cup2026-liquidity/docs
+```
+
+artifact 写入：
+
+```text
+pm-cup2026-liquidity/docs/analyze/<slug>.md
+pm-cup2026-liquidity/docs/design-docs/<slug>.md
+pm-cup2026-liquidity/docs/exec-plans/active/<slug>.md
+```
+
+### 6. Worktree Handling
+
+workspace registry 中的 `projects[].path` 指向 canonical 项目目录，不指向临时 worktree。
+
+如果用户任务明确指向 `worktrees/<name>`，Roundtable 可以把该 worktree 视为当前 `project_root`，但应从其 git common dir 或路径名反推出所属 project id。MVP 阶段可以不做复杂反推，只在命中不明确时询问用户。
+
+## Key Decisions
+
+### DEC-0001 — 不让 hook 自动选择子项目
+
+决策：hook 只探测 workspace 和候选项目，不从多个候选中自动选择。
+
+原因：hook 没有完整任务语义，也不能可靠交互。自动选择会把 design-doc / exec-plan 写错项目，代价高于多问一次用户。
+
+### DEC-0002 — workspace 配置与 project 配置分层
+
+决策：workspace registry 只负责项目路由；project config 负责子项目规则。
+
+原因：`/home/ubuntu/rsw/pm` 同时承载多个项目。把所有配置写在 workspace 根会造成项目规则混杂；只写在子项目又无法解决从 workspace 启动时的路由问题。
+
+### DEC-0003 — MVP 先做路由，不引入 issue tracker / ADR / CONTEXT
+
+决策：第一阶段只实现 workspace registry、setup workspace、workflow/bugfix/lint 路由。
+
+原因：当前痛点是多项目路由和 `docs_root` 选择。issue tracker、CONTEXT.md、ADR 是后续质量增强，不是路由 MVP 的必要条件。
+
+### DEC-0004 — artifact 仍写入子项目 docs
+
+决策：即使从 workspace 根启动，Roundtable artifact 仍写入目标子项目 `docs/`。
+
+原因：分析、设计、执行计划、测试和评审都属于具体项目。写到 workspace 根会降低可追溯性，也不符合现有 Roundtable docs 布局。
+
+## Non-Goals
+
+- 不把 Roundtable 改成完整 issue tracker / triage 系统。
+- 不在 MVP 中引入 `CONTEXT.md` 或 `docs/adr/` 作为必需机制。
+- 不迁移已有项目文档。
+- 不让 setup 自动修改业务代码。
+- 不让 hook 执行耗时递归扫描或复杂选择。
+
+## Alternatives
+
+### A. 只增强 hook 向下扫描
+
+优点：改动少。
+
+问题：hook 无法安全选择多个候选项目；最终仍需要 workflow 提问。扫描结果也不会形成持久配置。
+
+### B. 只在子项目写 project config
+
+优点：项目规则隔离清晰。
+
+问题：从 workspace 根启动时，仍然缺少“任务属于哪个子项目”的路由层。
+
+### C. workspace 根作为唯一项目
+
+优点：实现简单。
+
+问题：artifact 会混在 workspace 根目录，破坏子项目边界；不适合同时处理多个 repo。
+
+## Risks
+
+- workspace registry 可能过期：子项目改名或移动后，路由会失效。缓解方式：`/roundtable:setup workspace` 支持重新扫描并更新。
+- aliases 可能冲突：例如 `pm-cup2026` 和 `pm-cup2026-liquidity`。缓解方式：精确 basename 优先，短名嵌入长名时视为 ambiguous。
+- project config 与 `CLAUDE.md` 冲突：缓解方式：明确读取优先级，并在冲突时报告给用户。
+- worktree 路由复杂：MVP 不做自动深度反推，命中不明确时询问用户。
+
+## Review Questions
+
+1. `.roundtable/workspace.toml` 是否是合适的 workspace registry 文件名和位置？
+2. workspace setup 是否应该写根 `CLAUDE.md` 摘要，还是只写 `.roundtable/workspace.toml`？
+3. project config 是否应该在 MVP 中实现，还是先只做 workspace registry？
+4. hook 输出 `candidates` 是否足够，还是应该直接输出 workspace registry 的解析结果？
+5. worktree 是否需要 MVP 支持自动识别所属 canonical project？


### PR DESCRIPTION
## Summary

- add analysis of Matt Pocock skills patterns for Roundtable
- add a draft design-doc for workspace-first setup and multi-project routing
- keep this PR docs-only for review before implementation

## Review focus

- whether workspace registry + project config is the right shape for `/home/ubuntu/rsw/pm` style workspaces
- whether SessionStart should stay lightweight and avoid choosing projects
- whether MVP should stop at routing before adding issue tracker / CONTEXT / ADR support

## Verification

- docs-only change; no runtime verification required
