### PR TITLE
feat(hooks): SessionStart 双模式重写 — workspace 支持 + docs_root 越界修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ All notable changes to **roundtable** will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `hooks/session-start` **workspace mode** (#127): when cwd is not inside a git repo, the hook scans one level of subdirectories for git projects and injects `workspace_root` + the project list (`(docs)` marker); skills resolve `docs_root = <workspace_root>/<project>/docs` per task. Canonical resolution rule lives in `skills/workflow/SKILL.md` Step 1; bugfix / lint reference it (lint asks the user to pick **one** project, never sweeps all).
+- `<git_top>/.roundtable.json` (#127): flat JSON config with two optional string keys — `docs_root` (absolute or relative to the repo root) and `project_id` (overrides the default id). Sits between the `ROUNDTABLE_DOCS_ROOT` env override and the walk-up in the project-mode resolution chain.
+- `tests/session-start.test.sh` — pure-bash test harness for the hook (mktemp fixtures + python3 JSON assertions), 11 cases / 44 assertions including the #127 boundary-escape regression.
+
+### Fixed
+
+- `hooks/session-start` boundary escape (#127): in project mode the docs walk-up is now bounded by the git toplevel, so a repo without `docs/` reports `needs-init` instead of leaking a parent directory's `docs/` (observed: `docs_root: ~/docs` under Codex). Walk-up candidates are also structure-checked (must contain one of the seven roundtable dirs or `INDEX.md` to be `status: ok`).
+- `hooks/session-start` worktree identity: `project_id` now derives from the main repo root via `git rev-parse --git-common-dir`, so linked worktrees no longer report the worktree directory name.
+
 ### Changed
+
+- `hooks/session-start` output protocol: unconditionally emits one JSON line with **both** `additionalContext` and `hookSpecificOutput.additionalContext`; all runtime env-sniffing branches (`CURSOR_PLUGIN_ROOT` / `COPILOT_CLI`) removed. `hooks/hooks.json` drops the non-standard `"async"` field.
 
 - `commands/workflow.md` Step 2: replaced the abstract "every phase transition must be posted" sentence with an explicit checklist of broadcast points (workflow start / phase 1·2·4·6·7·8·9 completion / user gates 3·5 / closeout). The v0.0.6 rule was too easy to miss at runtime — observed in practice: workflow start posted to TG, phase 1 completion did not.
 - `commands/bugfix.md` Step 1: added a one-line reference to the workflow.md broadcast rule so bugfix runs don't go silent on TG either.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ All notable changes to **roundtable** will be documented in this file.
 
 - `hooks/session-start` **workspace mode** (#127): when cwd is not inside a git repo, the hook scans one level of subdirectories for git projects and injects `workspace_root` + the project list (`(docs)` marker); skills resolve `docs_root = <workspace_root>/<project>/docs` per task. Canonical resolution rule lives in `skills/workflow/SKILL.md` Step 1; bugfix / lint reference it (lint asks the user to pick **one** project, never sweeps all).
 - `<git_top>/.roundtable.json` (#127): flat JSON config with two optional string keys — `docs_root` (absolute or relative to the repo root) and `project_id` (overrides the default id). Sits between the `ROUNDTABLE_DOCS_ROOT` env override and the walk-up in the project-mode resolution chain.
-- `tests/session-start.test.sh` — pure-bash test harness for the hook (mktemp fixtures + python3 JSON assertions), 11 cases / 44 assertions including the #127 boundary-escape regression.
+- `tests/session-start.test.sh` — pure-bash test harness for the hook (mktemp fixtures + python3 JSON assertions), 12 cases / 49 assertions including the #127 boundary-escape regression (plain and symlinked-cwd variants).
 
 ### Fixed
 
-- `hooks/session-start` boundary escape (#127): in project mode the docs walk-up is now bounded by the git toplevel, so a repo without `docs/` reports `needs-init` instead of leaking a parent directory's `docs/` (observed: `docs_root: ~/docs` under Codex). Walk-up candidates are also structure-checked (must contain one of the seven roundtable dirs or `INDEX.md` to be `status: ok`).
+- `hooks/session-start` boundary escape (#127): in project mode the docs walk-up is now bounded by the git toplevel, so a repo without `docs/` reports `needs-init` instead of leaking a parent directory's `docs/` (observed: `docs_root: ~/docs` under Codex). Walk-up candidates are also structure-checked (must contain one of the six roundtable dirs or `INDEX.md` to be `status: ok`).
 - `hooks/session-start` worktree identity: `project_id` now derives from the main repo root via `git rev-parse --git-common-dir`, so linked worktrees no longer report the worktree directory name.
 
 ### Changed

--- a/README-zh.md
+++ b/README-zh.md
@@ -79,7 +79,7 @@ Claude Code 下用上面的 slash command。Codex CLI / App 下描述意图或�
 3. **逐决策弹窗** —— architect 每个关键决策当场调 `AskUserQuestion`，不积压成文字列表
 4. **交互角色 → skill / 自主角色 → subagent** —— analyst/architect 主会话执行（需要 `AskUserQuestion`）；developer/tester/reviewer/dba 独立 subagent 上下文
 5. **`[NEED-DECISION]` 模式** —— subagent 不能弹窗，在返回文本印一行，orchestrator grep 后调 `AskUserQuestion` 续派
-6. **SessionStart hook 注入 `docs_root`** —— bash 在 session 开始时检测 docs_root + project_id（env > 向上找 `docs/` > `needs-init` 兜底），所有角色从注入上下文读，不再 inline 检测
+6. **SessionStart hook 注入 `docs_root`** —— bash 在 session 开始时检测一次上下文，分两模式：**project**（cwd 在 git repo 内：env 覆盖 > `.roundtable.json` > 以 repo 根为界的向上查找）和 **workspace**（cwd 是多 git 项目的父级工作区：注入项目清单，docs_root 按任务延迟解析）。所有角色从注入上下文读，不再 inline 检测。详见 [SessionStart hook](#sessionstart-hookdocs_root-检测)
 7. **plugin 语言无关** —— prompt 全英文；输出语言由项目自己的 CLAUDE.md 决定（声明 `文档中文` 后所有产出自动中文）
 8. **无机制堆叠** —— 没有 decision-log / log.md / faq.md / progress JSONL / Monitor / `<escalation>` JSON。决策直接写进 exec-plan 的 `## Key Decisions`；FAQ 追加到对应 analyze/design-doc；INDEX.md 由 `/roundtable:lint` 重建
 
@@ -131,6 +131,27 @@ your-project/docs/
 ```
 
 每个主题用一个 slug 串起来。exec-plan 的 frontmatter 通过 `source: design-docs/<slug>.md` 链回设计文档。
+
+## SessionStart hook：docs_root 检测
+
+hook 在 `startup|clear|compact` 时运行，注入 `Roundtable context:` block。分两模式：
+
+**project 模式**（cwd 在 git repo 内）。`docs_root` 解析顺序：
+
+1. env `ROUNDTABLE_DOCS_ROOT` —— 目录存在则直接采用（不做结构校验）；不存在则输出 `warning:` 行并继续走下一级
+2. `<git_top>/.roundtable.json` —— 平铺 JSON，两个可选字符串键：`docs_root`（绝对路径，或相对 repo 根；不做结构校验）和 `project_id`（覆盖默认 id）
+
+   ```json
+   { "docs_root": "documents", "project_id": "my-project" }
+   ```
+
+3. 从 cwd 向上查找 `docs/`（其次 `documentation/`），**以 repo 根为界** —— 绝不越界爬到父级目录。候选目录须含七个 roundtable 目录之一或 `INDEX.md` 才算 `status: ok`；无结构的命中仍会报告，但状态为 `status: needs-init`。
+
+context 字段：`mode / docs_root / docs_root_source (env|config|walk-up) / project_id / git_top / status`。在 linked worktree 下 `project_id` 取**主仓**目录名。
+
+**workspace 模式**（cwd 不在 git repo 内，例如挂着多个项目的父级工作区）。hook 扫一层子目录找 git 项目，注入 `workspace_root` + 项目清单（带 docs 目录的项目标 `(docs)`）。skills 按任务解析 `docs_root = <workspace_root>/<project>/docs` —— 见 workflow Step 1。
+
+输出协议：单行 JSON 同时含 `additionalContext` 与 `hookSpecificOutput.additionalContext` 两键，各 runtime 读自己认识的键、忽略另一个。
 
 ## 与其它 plugin 协同
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -145,7 +145,7 @@ hook 在 `startup|clear|compact` 时运行，注入 `Roundtable context:` block�
    { "docs_root": "documents", "project_id": "my-project" }
    ```
 
-3. 从 cwd 向上查找 `docs/`（其次 `documentation/`），**以 repo 根为界** —— 绝不越界爬到父级目录。候选目录须含七个 roundtable 目录之一或 `INDEX.md` 才算 `status: ok`；无结构的命中仍会报告，但状态为 `status: needs-init`。
+3. 从 cwd 向上查找 `docs/`（其次 `documentation/`），**以 repo 根为界** —— 绝不越界爬到父级目录。候选目录须含六个 roundtable 目录之一或 `INDEX.md` 才算 `status: ok`；无结构的命中仍会报告，但状态为 `status: needs-init`。
 
 context 字段：`mode / docs_root / docs_root_source (env|config|walk-up) / project_id / git_top / status`。在 linked worktree 下 `project_id` 取**主仓**目录名。
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ That's the model:
 3. **Decision-by-decision popups** — architect fires `AskUserQuestion` at every key decision point, never piles them up at the end
 4. **Interactive roles → skills, autonomous roles → subagents** — analyst/architect run in main session (need `AskUserQuestion`); developer/tester/reviewer/dba run as isolated subagents (clean context)
 5. **`[NEED-DECISION]` pattern** — subagents can't pop dialogs; they print one line in their return text, the orchestrator parses it and asks the user, then re-dispatches
-6. **SessionStart hook for `docs_root`** — bash detects `docs_root` + `project_id` once at session start (env override → walk-up tree → `needs-init` fallback); all roles read from injected context, no inline detection
+6. **SessionStart hook for `docs_root`** — bash detects context once at session start, in two modes: **project** (cwd inside a git repo: env override → `.roundtable.json` → repo-bounded walk-up) and **workspace** (cwd above multiple git projects: inject the project list, resolve docs_root per task). All roles read from injected context, no inline detection. See [SessionStart hook](#sessionstart-hook-docs_root-detection)
 7. **Language-neutral plugin** — prompts in English; output language follows your project's CLAUDE.md (e.g. declare `文档中文` and all docs come out in Chinese)
 8. **No mechanism bloat** — no decision-log / log.md / faq.md / progress JSONL / Monitor / `<escalation>` JSON. Decisions live inside exec-plan `## Key Decisions`; FAQ appends to the relevant analyze/design-doc; INDEX.md is rebuilt by `/roundtable:lint`
 
@@ -131,6 +131,27 @@ your-project/docs/
 ```
 
 One slug per task (`user-auth`, `payment-idempotency`). exec-plan frontmatter carries `source: design-docs/<slug>.md` for linkage.
+
+## SessionStart hook: docs_root detection
+
+The hook runs on `startup|clear|compact` and injects a `Roundtable context:` block. Two modes:
+
+**Project mode** (cwd inside a git repo). `docs_root` resolution order:
+
+1. `ROUNDTABLE_DOCS_ROOT` env var — used as-is when the directory exists (no structure check); otherwise a `warning:` line is emitted and resolution falls through
+2. `<git_top>/.roundtable.json` — flat JSON with two optional string keys: `docs_root` (absolute, or relative to the repo root; no structure check) and `project_id` (overrides the default id)
+
+   ```json
+   { "docs_root": "documents", "project_id": "my-project" }
+   ```
+
+3. Walk-up from cwd looking for `docs/` (then `documentation/`), **bounded by the repo root** — it never escapes into parent directories. A candidate counts as `status: ok` only if it contains one of the seven roundtable dirs or `INDEX.md`; an unstructured hit is still reported, with `status: needs-init`.
+
+Context fields: `mode / docs_root / docs_root_source (env|config|walk-up) / project_id / git_top / status`. In a linked worktree, `project_id` is the **main** repo's directory name.
+
+**Workspace mode** (cwd not in a git repo, e.g. a parent dir holding several projects). The hook scans one level of subdirectories for git projects and injects `workspace_root` + the project list (`(docs)` marks projects that have a docs dir). Skills then resolve `docs_root = <workspace_root>/<project>/docs` per task — see workflow Step 1.
+
+Output protocol: a single JSON line carrying both `additionalContext` and `hookSpecificOutput.additionalContext`; each runtime reads the key it understands and ignores the other.
 
 ## Compose with other plugins
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The hook runs on `startup|clear|compact` and injects a `Roundtable context:` blo
    { "docs_root": "documents", "project_id": "my-project" }
    ```
 
-3. Walk-up from cwd looking for `docs/` (then `documentation/`), **bounded by the repo root** — it never escapes into parent directories. A candidate counts as `status: ok` only if it contains one of the seven roundtable dirs or `INDEX.md`; an unstructured hit is still reported, with `status: needs-init`.
+3. Walk-up from cwd looking for `docs/` (then `documentation/`), **bounded by the repo root** — it never escapes into parent directories. A candidate counts as `status: ok` only if it contains one of the six roundtable dirs or `INDEX.md`; an unstructured hit is still reported, with `status: needs-init`.
 
 Context fields: `mode / docs_root / docs_root_source (env|config|walk-up) / project_id / git_top / status`. In a linked worktree, `project_id` is the **main** repo's directory name.
 

--- a/docs/exec-plans/completed/hook-workspace-docs-root.md
+++ b/docs/exec-plans/completed/hook-workspace-docs-root.md
@@ -1,0 +1,76 @@
+---
+slug: hook-workspace-docs-root
+date: 2026-06-12
+status: active
+analysis: ../../reviews/2026-06-12-comprehensive-review.md
+issue: 127
+---
+
+# Hook 双模式重写：workspace 支持 + docs_root 越界修复
+
+## Solution（设计已与 user 确认，2026-06-12）
+
+线上 bug：codex 下 cwd 在无 `docs/` 的 git 项目内，hook walk-up 越过 git toplevel 爬到 `~/docs`（`project_id: pm` + `docs_root: /home/ubuntu/docs`）。同时 user 常在非 git 的父级工作区（如 `/data/rsw`，下挂多个 git 子项目）启动会话，会话级单一 docs_root 是伪命题。
+
+hook 改双模式：
+
+- **project 模式**（cwd 在 git repo 内）：解析顺序 env `ROUNDTABLE_DOCS_ROOT` > `<git_top>/.roundtable.json` > 以 git_top 为界的 walk-up（带结构校验）。
+- **workspace 模式**（cwd 不在 git repo 内）：扫一层子目录找 git 子项目，注入项目清单，docs_root 由 skills 按任务目标子项目延迟解析。
+
+输出协议改为单条 JSON 同时含 `additionalContext` + `hookSpecificOutput` 两键，删除全部 env 探测分支（`CURSOR_PLUGIN_ROOT` / `COPILOT_CLI` 无事实来源）。
+
+来源：[2026-06-12 全面审查报告](../../reviews/2026-06-12-comprehensive-review.md) 问题 1.1/1.2/1.3/1.4/5.1/5.2 + 「父级工作区场景」节。
+
+## 设计决策（已定，不要重开）
+
+- **DEC-1 双键输出**：无条件输出 `{"additionalContext":"<ctx>","hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"<ctx>"}}` 单行 JSON；各 runtime 忽略不认识的键。
+- **DEC-2 worktree project_id**：`git rev-parse --path-format=absolute --git-common-dir` 回推主仓根（common-dir basename 为 `.git` 时取其 dirname），project_id = 主仓根 basename。`.roundtable.json` 的 `project_id` 键可覆盖。
+- **DEC-3 `.roundtable.json` 解析**：位于 `<git_top>/`，平铺 JSON，仅认 `docs_root`（相对 git_top 或绝对路径）与 `project_id` 两个字符串键。有 python3 用 `json` 模块解析，否则 sed 提取平铺字符串值（注释说明限制）。指向不存在目录 → context 加 warning 行并继续走下一级。
+- **DEC-4 结构校验**：walk-up 命中的候选目录须含 `{analyze,design-docs,exec-plans,testing,reviews,bugfixes}` 之一或 `INDEX.md` 才算 `status: ok`；存在但无结构 → 仍报 docs_root 但 `status: needs-init` + note（workflow 可在确认后建骨架——建骨架本身不在本期范围）。env / config 显式指定的路径**不做**结构校验（用户显式配置即生效）。
+- **DEC-5 workspace 判定**：cwd 无 git_top → 扫 `<cwd>/*/` 一层，`-e <d>/.git`（兼容 worktree/submodule 的 .git 文件）即算项目；≥1 个 → `mode: workspace`；0 个 → 仅检查 `<cwd>/docs|documentation`（不向上爬，无边界可依），无则 needs-init。父级不引入配置文件。
+- **DEC-6 context 字段**：project 模式输出 `mode/docs_root/docs_root_source(env|config|walk-up)/project_id/git_top/status`；workspace 模式输出 `mode/workspace_root/projects（name 后缀 `(docs)` 标记有无）/status: ok`+ note 指示按任务解析 `<workspace_root>/<proj>/docs`。needs-init 的 note 改中性措辞 "prompt the user to set one"（不写死 AskUserQuestion，channel-aware）。
+- **DEC-7 健壮性**：`cwd="$(pwd 2>/dev/null || echo "$PWD")"`；escape 函数补 `\b` `\f`；消灭行尾 `[ ... ] && ...` 模式改 `if/fi`。
+- **DEC-8 范围外**：needs-init 建骨架、codex-tools 去重、lint orphan 修复、文档债清算均不做（归 PR-2/PR-3）。
+
+## Phases
+
+### Phase 1: hook 重写（hooks/session-start）
+
+- [x] 1.1 git 上下文前置：git_top + DEC-2 worktree-safe project_id
+- [x] 1.2 project 模式解析链：env（无效则 warning 继续）→ `.roundtable.json`（DEC-3）→ bounded walk-up（终止条件 `dir` 越出 git_top 即停，含 git_top 自身；`docs/` 优先 `documentation/`；DEC-4 结构校验）
+- [x] 1.3 workspace 模式（DEC-5/DEC-6）
+- [x] 1.4 双键输出 + 删 env 探测分支（DEC-1），escape 补 `\b\f`，DEC-7 健壮性
+- [x] 1.5 hooks.json：matcher 保持 `startup|clear|compact`，删除非标 `"async"` 字段
+
+### Phase 2: skills/docs 配套
+
+- [x] 2.1 `skills/workflow/SKILL.md` Step 1 重写：识别 `mode: workspace` → 从任务描述/issue/涉及文件推断目标子项目，推断不出按 channel-aware 规则问用户；解析出 `docs_root=<workspace_root>/<proj>/docs` 后带入所有角色派发参数。此段为 canonical，供 bugfix/lint 引用
+- [x] 2.2 `skills/bugfix/SKILL.md` Step 1：加一行引用 workflow Step 1 的 workspace 解析规则
+- [x] 2.3 `skills/lint/SKILL.md` Step 1：`mode: workspace` 且未传路径参数 → 列项目清单让用户选一个，不默认全量
+- [x] 2.4 `README.md`：文档化 `.roundtable.json`、workspace 模式、`ROUNDTABLE_DOCS_ROOT`、双键输出协议（替换原 hook 行为描述，README-zh 同步）
+- [x] 2.5 `CHANGELOG.md` [Unreleased] 加条目
+
+### Phase 3: 单测（developer 自带）
+
+- [x] 3.1 新建 `tests/session-start.test.sh`：纯 bash 测试 harness（mktemp -d 造 fixture，python3 校验 JSON 与断言字段），覆盖：
+  - project 模式命中 `docs/`（含结构）→ ok / source=walk-up
+  - **越界回归**：git 项目无 docs/、父级有 `docs/` → 不越界，needs-init（本 bug 的复现测试，先红后绿）
+  - docs/ 存在但无结构 → needs-init + docs_root 仍报
+  - env 有效 / env 指向不存在目录 → warning + 降级
+  - `.roundtable.json` 相对与绝对路径 → source=config；project_id 覆盖
+  - workspace 模式：非 git 父级 + 2 个 git 子项目（一个有 docs 一个没有）→ 清单正确
+  - 非 git 且无子项目 → needs-init
+  - `git worktree add` 场景 → project_id = 主仓名
+  - 所有 case 输出均为合法 JSON 且双键齐备
+- [x] 3.2 全部测试通过（`bash tests/session-start.test.sh` exit 0）
+
+## Verification
+
+- `bash tests/session-start.test.sh` 全绿
+- 手动：在 `/data/rsw`（workspace）、`/data/rsw/roundtable`（project）、`/data/rsw/dex-ui`（git 无 docs，需 needs-init 不得报 `/data/rsw/docs` 或 `~/docs`）三处跑 hook 验证输出
+
+## Change Log
+
+- 2026-06-12 user 确认 PR-1 范围与双模式设计（含「父级工作区」补充）
+- 2026-06-12 tester 发现 BUG-1（escape 未覆盖全部 C0 控制字符）/ BUG-2（GIT_DIR 污染误判 project 模式）/ GAP-1（ROUNDTABLE_DOCS_ROOT 相对路径透传），已修复；两套测试全绿（STRICT=1 含 known-bug 转正）
+- 2026-06-12 reviewer NEEDS-CHANGES（reviews/2026-06-12-hook-workspace-docs-root.md）：MAJOR-1 symlink cwd 致 walk-up 边界失效（DEC-7 spec 的逻辑路径洞，#127 边界目标优先于 DEC-7 字面）→ cwd 改 `pwd -P` 物理路径 + T9 symlink 越界回归 case（先红后绿已验证）；MINOR-1 README×2/CHANGELOG/hook 注释 "seven/七" 改 six/六（与 DEC-4 六目录一致）；MINOR-2 取改动更小方案——lint Step 1 加 canonical 引用（workflow Step 1）；MINOR-4 测试侧硬编码 `/usr/bin/bash` 改 `"$BASH"`，`${var@Q}` 替换代价大改为文件头声明需 bash ≥4.4（hook 本体 bash 3.2 兼容不动）。MINOR-3/MINOR-5 reviewer 定级可接受，不修。修后两套测试全绿（49 + 301，STRICT=1 0 known-bug）

--- a/docs/reviews/2026-06-12-comprehensive-review.md
+++ b/docs/reviews/2026-06-12-comprehensive-review.md
@@ -1,0 +1,91 @@
+---
+slug: comprehensive-review
+date: 2026-06-12
+reviewer: botB (主 agent + 2 子 agent)
+scope: 全插件（hooks / skills / agents / commands / manifests / docs）+ 参考项目 mattpocock/skills 对比
+---
+
+# Roundtable 全面审查报告
+
+触发背景：codex 下 SessionStart hook 报 `project_id: pm` 但 `docs_root: /home/ubuntu/docs` —— project_id 判定在项目级、docs_root 却落到了用户目录。本报告含该 bug 根因 + 全插件问题清单 + 可借鉴项（参考 https://github.com/mattpocock/skills ）。
+
+## 〇、报告 bug 根因（docs_root 越界）
+
+`hooks/session-start:17-25`：walk-up 循环从 cwd 向上找 `docs/` / `documentation/`，终止条件只有 `dir != "/"`，**不在 git toplevel 停**。pm 项目没有 `docs/`，循环越过仓库根爬到 `/home/ubuntu`，捡到无关的 `~/docs`。而 `git_top` 在第 29 行才计算（晚于循环），所以现有代码拿不到边界。
+
+三层修法（建议合一个 PR）：
+
+1. 把 `git rev-parse --show-toplevel` 挪到循环前，walk-up 不越过 `git_top`（无 git 时以 `$HOME` 为界）。
+2. 命中目录做结构校验：候选 `docs/` 须含 7 个规范子目录之一或 `INDEX.md` 才算 ok，否则继续 / 报 `needs-init`——防止 Docusaurus 类 `docs/` 误命中。
+3. `ROUNDTABLE_DOCS_ROOT` 设置了但目录不存在时（第 14 行）目前静默忽略，应在 context 里报 warning。
+
+## 一、正确性 bug
+
+| # | 问题 | 位置 | 严重度 |
+|---|------|------|--------|
+| 1.1 | docs_root walk-up 越界（见上） | session-start:17-25 | 高 |
+| 1.2 | Codex 协议分支与 design-doc 自相矛盾：design-doc:294 称 Codex 注入 `CLAUDE_PLUGIN_ROOT` 可复用 Claude 分支（`hookSpecificOutput` 包裹格式），但 design-doc §R6 / tester D2 又认定 Codex 期待裸 `{"additionalContext"}`。线上实况（codex 能看到 context）反推 fallback 分支生效，即 design-doc:294 是错的。**正解**：单条 JSON 同时输出 `additionalContext` + `hookSpecificOutput` 两个键，各 runtime 忽略不认识的键，整个 if/elif/else 环境探测（连同脆弱的 env 假设）可删 | session-start:53-58 | 高 |
+| 1.3 | `COPILOT_CLI` / `CURSOR_PLUGIN_ROOT` 判定无任何事实来源支撑（DEC-0010 明确 Copilot/Cursor out-of-scope，代码却有分支）；1.2 的双键方案可顺带消灭 | session-start:53,55 | 中 |
+| 1.4 | worktree 下 `basename "$git_top"` 返回 worktree 目录名（如 `feat-slug-botB`）而非仓库名；本插件 closeout 官方支持 Codex App worktree，即支持场景下 project_id 必错。修法：`git rev-parse --git-common-dir` 回推主仓 | session-start:29-33 | 中 |
+| 1.5 | lint 的 orphan 判定恒假：定义为「无链接 **且** 不在 INDEX」，但 rebuild 把所有 .md 都收进 INDEX，第二条件永不成立。应改为「除 INDEX.md 外无任何 doc 链接到它」 | skills/lint/SKILL.md:42 | 中 |
+| 1.6 | bugfix tier 用 `git diff --numstat` LOC 判定，但定 tier 在派 developer **之前**，此时 diff 不存在。应改为预估定 tier + 返回后用真实 diff 复核升级 | skills/bugfix/SKILL.md:27-33 | 中 |
+| 1.7 | hooks.json matcher `startup\|clear\|compact` vs codex manifest `*` 不一致；`"async": false` 非标准字段 | hooks/hooks.json:5 | 低 |
+
+## 二、一致性问题
+
+| # | 问题 | 位置 | 严重度 |
+|---|------|------|--------|
+| 2.1 | exec-plan「谁移到 completed/」三方互斥：developer.md:29 说 developer 移；workflow SKILL:136 说 orchestrator 在 go-commit 后移；插件 CLAUDE.md 说 user 移。developer 提前移会让 tester/reviewer 拿到失效路径。建议统一为 orchestrator closeout 后移 | 三处 | 高 |
+| 2.2 | bugfix 流程不产 exec-plan，但 developer agent 输入强依赖 exec-plan path（勾 checkbox、移 completed/）；bugfix/references/codex-tools.md:9,16 还写着传 exec-plan path。修法：bugfix 加 mini exec-plan（与根 CLAUDE.md「小任务也写 exec-plan」更对齐），或 developer.md 加无-exec-plan 模式 | agents/developer.md:13,25,28 | 高 |
+| 2.3 | NEED-DECISION 协议三种口径（workflow 有 TG 分支 + Change Log 落点；bugfix 只有 AskUserQuestion；CLAUDE.md 第三种）。应收敛成 canonical 一段，其余引用 | 三处 | 中 |
+| 2.4 | 元数据全面过时：CLAUDE.md 说 2 skills（实际 5）；两份 plugin.json 写「2 skills, 3 commands」（codex 下根本无 commands）；README「~760 lines」实测 1131；README 表与同文件 Codex 节自相矛盾 | 多处 | 中 |
+| 2.5 | CONTRIBUTING.md 引用已删除的 `docs/log.md`、`docs/decision-log.md`（v0.0.5 已删）和不存在的文件路径 | CONTRIBUTING.md:35-45 | 中 |
+| 2.6 | dogfood 欠账：本仓库自己没有 docs/INDEX.md；codex-compatibility exec-plan 全勾完仍躺 active/；2026-05-21 reviewer 报告的 W3/W4/W5 至今未修 | docs/ | 低 |
+| 2.7 | reviewer 输入要求 diff/git range，但 workflow 派发参数没列 | agents/reviewer.md:16 vs workflow SKILL:69 | 低 |
+
+## 三、跨平台问题
+
+| # | 问题 | 严重度 |
+|---|------|--------|
+| 3.1 | codex 工具映射表重复维护 7 处（5 份 references/codex-tools.md + developer/tester 的 Runtime Note）。建议 workflow 那份做 canonical 全表，其余砍成差异条目 + 一行指针 | 中 |
+| 3.2 | Codex hook 协议的 P0.1/P0.2/P0.3 验证层层 deferred 从未闭环（v0.0.7-rc1 已发），现实已撞上 1.2 协议歧义 + docs_root bug。建议列为 0.0.7 正式版硬门槛 | 中 |
+| 3.3 | AGENTS.md 一行指针「Codex 会去读 CLAUDE.md」是推断非事实；且 CLAUDE.md 本身内容过时（2.4） | 低 |
+| 3.4 | `documentation/` 备选目录名只活在 hook 里，所有文档零提及 | 低 |
+
+## 四、可优化项
+
+1. **`.roundtable.json` 项目级配置**（中价值）：hook 优先读 `<git_top>/.roundtable.json`（`{"docs_root": "docs", "project_id": "pm"}`），其次 env，最后 walk-up。同时是越界 bug 的正解路径 + monorepo 多 docs_root 口子 + TG/bot 场景（env 难注入）的解。
+2. **needs-init 引导**：三个入口行为不一致（workflow 问、bugfix 没提、lint 直接 abort）；无任何角色负责创建 7 目录骨架——建议 workflow Step 1 确认后 `mkdir -p` + 写空 INDEX.md；hook note 写死 AskUserQuestion 与自家 channel-aware 规则（TG 下不调）矛盾。
+3. **lint 细节**：broken-link 未定义相对路径基准/是否跳外链；stale 检测对未 commit 文件 `git log` 返回空串行为未定义（建议 fallback `stat`）；`[⏩]` 非标 checkbox 在 fully-checked 判定下属灰区。
+4. **hook 输出增强**：context 加 `git_top:` 行（skills 可自查 docs_root 是否越出仓库，对越界 bug 是廉价运行时护栏）+ `docs_root_source: env|config|walk-up`。
+5. **健壮性**：`set -euo pipefail` 下 cwd 被删（worktree prune 后）时 `pwd` 失败 → hook 零输出无提示；escape_for_json 不覆盖 `\b`/`\f` 等控制字符会产出非法 JSON（有 python3 时一行 `json.dumps` 替换）。
+6. **发布卫生**：0.0.7-rc1 挂 22 天，清完文档债出正式版。
+
+## 五、从 mattpocock/skills 可借鉴项（按价值排序）
+
+1. **静态配置落盘 + 动态注入叠加**（最有价值）：它的 setup skill 把配置写到 `docs/agents/` + CLAUDE.md 摘要块（静态、跨平台、可 diff），roundtable 的 hook 是动态注入（零配置、Claude Code 专属）。两者叠加：hook 失效/非 Claude 平台时回退读静态配置文件——直接解决跨平台 + 本次 bug。与上面第 1 条 `.roundtable.json` 是同一方案。
+2. **description 触发词工程**：每个 description 写 "Use when user says X / mentions Y"（用户原话短语）。roundtable 的 description 是名词列举，自动激活准确率低。最便宜的改进。
+3. **硬/软依赖分级**（其 ADR-0001）：缺 docs_root 就出错的角色（developer/lint）写显式 setup 指针；可降级的（analyst 直接回贴结果）静默降级。当前 roundtable 所有角色一刀切依赖 hook。
+4. **Phase gate**：phase 切换处加可验证的产物存在性 gate（如 exec-plan 缺 `source:` frontmatter 不得进 developer），比 Phase Matrix 表情符号约束力强。
+5. **PreToolUse 硬拦**：reviewer/dba 的「只读 src」目前纯 prompt 软约束；可照抄其 `block-dangerous-git.sh` 模式做 PreToolUse hook（拦 Edit/Write 到 src/），随 plugin 分发。
+6. **WRONG/RIGHT 反模式对照**：给 developer/reviewer 各加最常见违规的对照段（反例对 LLM 约束力强于正面规则）。
+7. **AI 产出署名**：文档 frontmatter 加 `generated-by: roundtable:<role>`，便于 lint 与溯源。
+8. **`docs/out-of-scope/`**：被否决的方案独立成清单（当前散在 DEC- 编号里），防后续 agent 重复提案。
+9. **SKILL.md ≤100 行 + references 单层不嵌套**：写进 CONTRIBUTING.md。
+10. **manifest 一致性检查并入 lint**：plugin.json / marketplace.json / README / CHANGELOG 四方同步作为 `/roundtable:lint` 检查项（治 2.4 类问题的长效药）。
+
+## 补充：父级工作区场景（user 2026-06-12 提出）
+
+user 常在非 git 的父级目录（如 `/data/rsw`，下挂 8 个 git 子项目、7 个有自己的 `docs/`）启动 claude/codex。会话级单一 docs_root 在此场景是伪命题——docs_root 应跟任务目标子项目走。hook 改双模式：
+
+- **project 模式**（cwd 在 git repo 内）：`.roundtable.json`（git_top 下）> env > 以 git_top 为界的 walk-up（带结构校验）。
+- **workspace 模式**（cwd 不在 git repo 内）：扫一层子目录找 git 子项目，注入 `mode: workspace` + `workspace_root` + 项目清单（name + 有无 docs/）；note 指示 skills 按任务目标子项目延迟解析 `<proj>/docs`，推断不出才问。skills 侧 workflow/bugfix Step 1 配套：解析后把 `<proj>/docs` 带进所有角色派发参数；lint 在 workspace 模式让用户指定项目，不默认全量。
+- 父级不放配置文件（扫 `*/.git` 足够；排除目录等需求出现再加）。
+- 该设计同时覆盖原 bug：cwd 在无 docs/ 的 git 项目内时，bounded walk-up 正确报 needs-init 而非爬到 `~/docs`。
+
+## 建议执行顺序
+
+1. **PR-1（hook 修复，治本次 bug）**：1.1 越界 + 1.2 双键输出（顺带删 1.3 分支）+ 1.4 worktree project_id + 五.1 的 `.roundtable.json` 回退链 + **双模式 workspace 支持（见上节）**。
+2. **PR-2（流程一致性）**：2.1 exec-plan 生命周期统一 + 2.2 bugfix mini exec-plan + 2.3 NEED-DECISION canonical 化。
+3. **PR-3（文档债清算 + 0.0.7 正式版）**：2.4/2.5/2.6 + W3/W4/W5 遗留 + 3.4。
+4. **0.0.8 方向**：3.1 codex-tools 去重、借鉴项 2/3/4/5。

--- a/docs/reviews/2026-06-12-hook-workspace-docs-root.md
+++ b/docs/reviews/2026-06-12-hook-workspace-docs-root.md
@@ -112,3 +112,30 @@ diff 中 11 个文件全部可追溯到 #127：hook 重写、hooks.json 删 asyn
 | minor | MINOR-3 | git<2.31 worktree project_id 静默降级 |
 | minor | MINOR-4 | 测试套件用 `${@Q}`/硬编码 `/usr/bin/bash`，macOS bash 3.2 跑不了 |
 | minor | MINOR-5 | workspace 清单 `, ` 分隔可被目录名伪造（建议级） |
+
+---
+
+## 复核记录（2026-06-12，commit c1b0899）
+
+逐项核对 developer 修复 commit `c1b0899` 并本机独立复跑全部验证：
+
+| 项 | 核对结果 |
+|----|---------|
+| MAJOR-1 | ✅ 已修。`hooks/session-start:22` 改为 `pwd -P 2>/dev/null \|\| pwd 2>/dev/null \|\| echo "$PWD"`，cwd 统一物理路径。复核时用修复前 hook（`c1b0899^`）独立复现原越界（symlink cwd → `docs_root: <t>/link/docs, status: ok`），同 fixture 在新 hook 上输出 `docs_root: <none>, status: needs-init` —— 先红后绿独立验证成立 |
+| MAJOR-1 回归 case | ✅ 真实。`tests/session-start.test.sh:255-271` 新增 T9：harness 经 `cd "$t/link/proj"` 让 hook 继承逻辑 symlink PWD（非物理路径规避），断言 not-contains 父级 docs 的物理/symlink 两种写法 + `docs_root: <none>` + `status: needs-init`，共 5 断言（44→49 对账一致） |
+| MINOR-1 | ✅ 已修。`README.md:148` / `README-zh.md:148` / `CHANGELOG.md:17` seven/七 → six/六，`hooks/session-start:24` 注释同步；全仓 grep 无残留 seven/七目录表述 |
+| MINOR-2 | ✅ 已修。`skills/lint/SKILL.md:13` 补 "(canonical rule: workflow Step 1)"，workflow/CHANGELOG 的交叉引用声明现为真 |
+| MINOR-4 | ✅ 已修（声明式）。两处硬编码 `/usr/bin/bash` 改 `"$BASH"`（`tests/session-start.adversarial.test.sh:68,388`）；`${var@Q}` 保留但两套测试文件头显式声明「需 bash ≥ 4.4，仅开发侧」，hook 本体 bash 3.2 兼容不受影响 —— 对开发侧资产可接受 |
+| MINOR-3 / MINOR-5 | 按前轮结论接受不修，维持原记录（git<2.31 worktree 降级安全；workspace 清单分隔符伪造为建议级） |
+
+修复自身无新引入问题：
+
+- 回退链核验：cwd 被删场景实测 hook 仍 exit 0、单行合法 JSON、降级 `needs-init`（`pwd -P` 失败 → `pwd` → `$PWD` 逐级兜底；stderr 的 shell-init 告警是 bash 进程启动自身行为，修复前已存在）
+- `pwd -P` 同时使 GAP-1 相对路径归一化受益，与前轮预期一致
+- CHANGELOG 测试计数更新（11/44 → 12/49）与实际一致
+
+测试复跑：`tests/session-start.test.sh` 49 passed / 0 failed；`STRICT=1 tests/session-start.adversarial.test.sh` 301 passed / 0 failed / 0 known-bug。
+
+### 终态结论：CLEAN-WITH-NOTES
+
+MAJOR-1 与 MINOR-1/2/4 全部确认修复且无新问题；notes 指已接受不修的 MINOR-3（git<2.31 worktree project_id 静默降级）与 MINOR-5（workspace 清单分隔符可伪造，建议级），均不阻塞 merge。

--- a/docs/reviews/2026-06-12-hook-workspace-docs-root.md
+++ b/docs/reviews/2026-06-12-hook-workspace-docs-root.md
@@ -1,0 +1,114 @@
+---
+slug: hook-workspace-docs-root
+date: 2026-06-12
+role: reviewer
+issue: 127
+source: exec-plans/active/hook-workspace-docs-root.md
+---
+
+# hook-workspace-docs-root — Code Review（2026-06-12）
+
+审查范围：`git diff main...HEAD`（4 commits：ebdaa56 / 4476e36 / 43d270a / 0b570dd），对照 exec-plan DEC-1~DEC-8 与测试报告 `testing/hook-workspace-docs-root.md`。两套测试本机复跑全绿（44 + 301 断言，`STRICT=1` 下 0 known-bug）。
+
+## 结论：NEEDS-CHANGES
+
+MAJOR-1 一条修掉即可 merge（一行改动 + 一个回归 case）；minor 均可随本 PR 顺手修或归 follow-up。
+
+## Major
+
+### MAJOR-1：symlink 路径下 walk-up 边界失效，#127 越界 bug 可复现回归
+
+- `hooks/session-start:21`（根因）+ `hooks/session-start:139`（失效的边界比较）
+
+`cwd` 取自 `pwd`（逻辑路径，含 symlink），而 `git_top` 来自 `git rev-parse --show-toplevel`（git 返回物理路径）。当 cwd 路径中含任何 symlink 时两者永不相等，walk-up 的终止条件 `[ "$dir" = "$git_top" ]` 永不触发，循环一路爬到 `/` —— 这正是本 PR 要消灭的越界行为。复现（已实测）：
+
+```bash
+t=$(mktemp -d)
+mkdir -p "$t/real/proj/src" "$t/real/docs/design-docs"
+git -C "$t/real/proj" init -q
+ln -s "$t/real" "$t/link"
+(cd "$t/link/proj" && bash hooks/session-start)
+# → docs_root: <t>/link/docs（repo 外的父级 docs！）, status: ok, git_top: <t>/real/proj
+```
+
+触发条件现实存在：macOS 上 `/tmp → /private/tmp`、用户惯用 symlink 工作目录；Claude Code/Codex 子进程继承 shell 的逻辑 `PWD`，bash 启动时校验 inode 一致即沿用逻辑路径。与 exec-plan「绝不越过 repo 边界」的核心目标直接冲突（exec-plan Solution 节 + DEC-7）。
+
+修法：`hooks/session-start:21` 改 `cwd="$(pwd -P 2>/dev/null || pwd 2>/dev/null || echo "$PWD")"`，统一为物理路径（GAP-1 的相对路径归一化同时受益）。DEC-7 原文规定的 `pwd || echo $PWD` 本身留了这个洞，属于 spec 缺陷而非实现偷懒——但 #127 的边界目标优先级高于 DEC-7 字面。
+
+佐证：两套测试 harness 的 `new_tmp` 都用 `pwd -P` 并注释「消除符号链接，避免与 git rev-parse 物理路径不一致」（`tests/session-start.test.sh:27`、`tests/session-start.adversarial.test.sh:34`）——问题已被意识到，却只在测试侧归一化，把洞留在了被测对象里。修复时请补一个 symlinked-cwd 越界回归 case（上面的复现即可直接转 case）。
+
+## Minor
+
+### MINOR-1：README/CHANGELOG 写 "seven roundtable dirs"，代码只校验六个
+
+- `hooks/session-start:27`（`analyze design-docs exec-plans testing reviews bugfixes`，共 6 个）
+- `README.md:148` / `README-zh.md:148` / `CHANGELOG.md:17` 均写 "seven"/「七个」
+
+DEC-4 列的就是这 6 个（无 `prd`），实现与 DEC-4 一致；文档数错了。改文档为 six/六个（或在 DEC 层面决定把 `prd/` 加进 `has_structure`，但那要改 exec-plan，不建议本 PR 扩）。
+
+### MINOR-2：workflow 声称 lint 引用 canonical 规则，lint 实际未引用
+
+- `skills/workflow/SKILL.md:18`："This paragraph is the canonical workspace-resolution rule — `bugfix` and `lint` reference it."
+- `skills/bugfix/SKILL.md:15` 确实引用了 ✓；`skills/lint/SKILL.md:13` 是自含的内联规则（列清单让用户选一个），无任何指向 workflow Step 1 的引用
+- `CHANGELOG.md:11` 重复了同样的说法
+
+lint 的行为本身符合 exec-plan 2.3（列项目清单、不默认全量）✓，只是交叉引用声明不实。要么 lint Step 1 加半句 "（canonical rule: workflow Step 1）"，要么 workflow/CHANGELOG 改成只说 bugfix references it。
+
+### MINOR-3：git < 2.31 时 DEC-2 worktree project_id 静默降级
+
+- `hooks/session-start:74`：`--path-format=absolute` 是 git 2.31+ 选项，老 git 整条命令失败，fallback `echo "$git_top/.git"` 使 linked worktree 的 project_id 退化为 worktree 目录名（DEC-2 要的是主仓名）。降级安全不崩，可接受；如要彻底，可用无版本要求的 `git rev-parse --git-common-dir` 再手动绝对化。记录在案即可。
+
+### MINOR-4：测试套件本身不可在 macOS 系统 bash 3.2 下运行
+
+- `tests/session-start.test.sh:68`（及多处）/ `tests/session-start.adversarial.test.sh:78`（及多处）：`${var@Q}` 是 bash 4.4+ 特性
+- `tests/session-start.adversarial.test.sh:67,387`：硬编码 `/usr/bin/bash`（macOS 为 `/bin/bash`，NixOS 亦无此路径）
+
+测试是开发侧资产，CI/Linux 跑没问题，故仅 minor。**hook 本体已逐特性核对**：`printf -v`（3.1+）、`${s//pat/rep}`、`$'\n'` 于模式与替换位、`${var%$'\n'}`、`shopt nullglob`、`break 2`、heredoc、无数组/`declare -A`/`mapfile`/`@Q` —— bash 3.2 兼容 ✓。C0 转义循环的替换串含 `\u00XX` 反斜杠，在双引号上下文中各版本（含 5.2 patsub_replacement）均按字面保留，无版本分叉。
+
+### MINOR-5：workspace 项目清单分隔符可被目录名伪造
+
+- `hooks/session-start:169-173`：清单用 `, ` 拼接，子目录名本身含 `, `（如 `evil, fake (docs)`）会伪造出不存在的清单条目。消费方是 LLM 展示层、无执行语义，建议级；如要修可对 name 中的 `,` 做标注或改行分隔。
+
+## DEC 符合度核对
+
+| DEC | 结论 |
+|-----|------|
+| DEC-1 双键输出 | ✓ `hooks/session-start:253` 单行双键，两份 context 一致（测试逐 case 断言）；env 探测分支已全删 |
+| DEC-2 worktree project_id | ✓ `:74-79` common-dir 回推 + config 覆盖（T8/D1）；老 git 降级见 MINOR-3 |
+| DEC-3 config 解析 | ✓ python3 优先 / sed 退化（限制有注释，D2/D5 特征化）；不存在目录 → warning 继续 ✓ |
+| DEC-4 结构校验 | ✓ env/config 不校验、walk-up 校验、无结构报 needs-init 仍给 docs_root；目录集 6 个与 DEC-4 一致（文档数字错，见 MINOR-1） |
+| DEC-5 workspace 判定 | ✓ `-e .git` 兼容 gitfile（E2）、0 项目仅查 cwd 不向上爬（`:183-199`） |
+| DEC-6 context 字段 | ✓ 两模式字段齐；needs-init note 用中性 "prompt the user" 措辞 ✓ |
+| DEC-7 健壮性 | 字面 ✓（pwd 回退、`\b\f`、无行尾 `&&` 模式），但 spec 本身的逻辑路径洞见 MAJOR-1 |
+| DEC-8 范围外 | ✓ 未见建骨架/codex-tools/lint orphan 等越界实现 |
+
+walk-up 解析链优先级（env > config > walk-up）、env 失效降级、config project_id 独立于 docs_root 生效，均与 exec-plan 1.2 一致。
+
+## 双消费端契约
+
+- Claude Code：`hookSpecificOutput.hookEventName: "SessionStart"` + `additionalContext` 符合 schema；多出的顶层键被忽略 ✓
+- Codex：顶层裸 `additionalContext` ✓
+- 退出码 0 / stdout 单行 / stderr 静默由对抗套件逐 case 强校验 ✓
+- `hooks/hooks.json` 仅删非标 `async`、matcher 保持，符合 1.5 ✓（codex plugin.json 的 matcher `*` 分叉为存量问题，测试报告 INFO-1 已记，DEC-8 范围外）
+
+## 测试质量
+
+- 断言真实：contains/not-contains 均带具体 needle，contract 检查非恒真；T2/W4 是真越界回归（构造父级带结构 docs 并断言 not-contains）✓
+- known-bug 机制：BUG-1/BUG-2 修复后 A12/F1 自动转绿，实测 `STRICT=1` 0 known-bug ✓
+- fixture 清理：两套各自 `trap cleanup EXIT` + chmod 恢复（B7）✓；互不共享状态、可独立运行 ✓
+- 缺口：无 symlinked-cwd case（被 `new_tmp` 的 `pwd -P` 主动规避，归 MAJOR-1）；`/tmp/pwned` 哨兵若宿主机预存在同名文件会假阳性失败（极次要）
+
+## Surgical Changes
+
+diff 中 11 个文件全部可追溯到 #127：hook 重写、hooks.json 删 async、3 个 skill Step 1、README×2 同节、CHANGELOG Unreleased、两套测试、测试报告。无夹带重构、无无关格式改动 ✓。
+
+## 问题清单汇总
+
+| 级别 | 编号 | 一句话 |
+|------|------|--------|
+| major | MAJOR-1 | symlink cwd 下 walk-up 边界失效，#127 越界可复现（`pwd -P` 一行修） |
+| minor | MINOR-1 | 文档 "seven dirs" vs 代码六个 |
+| minor | MINOR-2 | lint 未引用 canonical 规则，workflow/CHANGELOG 声明不实 |
+| minor | MINOR-3 | git<2.31 worktree project_id 静默降级 |
+| minor | MINOR-4 | 测试套件用 `${@Q}`/硬编码 `/usr/bin/bash`，macOS bash 3.2 跑不了 |
+| minor | MINOR-5 | workspace 清单 `, ` 分隔可被目录名伪造（建议级） |

--- a/docs/testing/hook-workspace-docs-root.md
+++ b/docs/testing/hook-workspace-docs-root.md
@@ -1,0 +1,97 @@
+---
+slug: hook-workspace-docs-root
+date: 2026-06-12
+role: tester
+issue: 127
+source: exec-plans/active/hook-workspace-docs-root.md
+---
+
+# hook-workspace-docs-root — 测试报告（对抗）
+
+被测对象：`hooks/session-start`（双模式重写）+ `hooks/hooks.json` / `.codex-plugin/plugin.json` 声明。
+
+测试文件：
+
+- `tests/session-start.test.sh` — developer 自带，11 case / 44 断言，全绿（回归确认）
+- `tests/session-start.adversarial.test.sh` — 本次新增对抗套件，**297 断言通过 / 0 失败 / 2 known-bug**（`STRICT=1` 时 known-bug 计入失败、exit 1）
+
+每个 case 均强制校验输出契约：退出码 0、stdout 单行非空、stderr 静默、合法 JSON、双键 context 一致、`hookEventName: SessionStart`。
+
+## Coverage（覆盖矩阵）
+
+| 组 | 攻击面 | case | 结果 |
+|----|--------|------|------|
+| A1–A10 | 敌意路径名：空格 / 中文 / 单引号 / `$VAR` / `$(…)` / 反引号 / `*` / `[…]` / 双引号 / 反斜杠，project_id 与 docs_root 必须字面输出且无副作用 | 10 | 全过，无注入 |
+| A11 | 目录名含换行 → `\n` 转义后 JSON 合法 | 1 | 过 |
+| A12 | 目录名含 `\x0b`（vertical tab）等未覆盖控制字符 | 1 | **KNOWN-BUG-1** |
+| B1–B15 | `.roundtable.json`：非法 JSON、值为数组/数字/null/空串、嵌套同名键、空文件、chmod 000、10k 超长值、转义引号、project_id 带引号、`../` 逃逸、config 是目录、`$(…)` 注入载荷、值含换行 | 15 | 全过（B12 逃逸为 DEC-3 显式信任语义，特征化） |
+| C1–C5 | `ROUNDTABLE_DOCS_ROOT`：相对路径、尾斜杠、指向文件、空串、含空格 | 5 | 过（C1 见 GAP-1） |
+| D0–D5 | sed fallback（PATH 藏掉 python3）：平铺提取、嵌套键误取、walk-up/needs-init、workspace 模式、破损 JSON 仍提取 | 6 | 过（D2/D5 为退化语义特征化，见 GAP-2） |
+| E1–E4 | workspace：50 子项目全量枚举、`-` 开头 / 字面 `*` / 空格 / 中文子目录、`.git` 文件（submodule 形态）、悬空与有效 symlink、根目录名含 glob 字符 | 4 组 | 全过 |
+| F1–F4 | git 环境异常：GIT_DIR 污染、GIT_WORK_TREE 单独污染、bare repo、git 不在 PATH | 4 | F1 **KNOWN-BUG-2**，其余过 |
+| W1–W6 | walk-up 补充：仅 `documentation/`、同级结构优先、docs 是文件、边界内 fallback 不越界（比 T2 强）、就近结构化目录优先、幂等性 | 6 | 全过 |
+| G1–G2 | hooks.json 与 codex plugin.json 声明、可执行位 | 2 | 过（声明分叉见 INFO-1） |
+
+## New Cases (Adversarial / E2E / Benchmark)
+
+新增 `tests/session-start.adversarial.test.sh`，独立可跑：
+
+```
+bash tests/session-start.adversarial.test.sh          # known-bug 不计失败
+STRICT=1 bash tests/session-start.adversarial.test.sh # known-bug 计失败（修复验证用）
+```
+
+## Found Bugs / Gaps（按严重度）
+
+### BUG-1（低，契约破坏）：未覆盖的控制字符产生非法 JSON，hook 哑火
+
+`escape_for_json` 只转义 `\n \r \t \b \f`，其余 <0x20 控制字符（如 `\x0b`、`\x1b`）随路径名原样进入 JSON 字符串 → 严格 JSON 解析器拒绝 → SessionStart 输出整体不可用，所有角色拿不到 context。触发概率低（需目录名含控制字符），但违反「hook 任何情况下不得哑火」契约。
+
+复现：
+
+```bash
+t=$(mktemp -d); repo="$t/ev"$'\x0b'"il"; mkdir -p "$repo/docs/analyze"
+git -C "$repo" init -q
+(cd "$repo" && bash hooks/session-start) | python3 -c 'import json,sys; json.loads(sys.stdin.read())'
+# json.decoder.JSONDecodeError: Invalid control character
+```
+
+测试：A12（KNOWN-BUG 标记，修复后自动转绿）。建议修法：escape 函数兜底把 <0x20 其余字符替换为 `\u00XX` 或直接剔除。
+
+### BUG-2（中，环境污染误判）：继承的 GIT_DIR 使非 git cwd 误报 project 模式
+
+hook 不清洗 `GIT_DIR` / `GIT_WORK_TREE`。父进程环境若带 `GIT_DIR`（脚本/CI/工具常见导出），git 会把任意 cwd 当作该仓的 worktree 顶层：`git rev-parse --show-toplevel` 返回 cwd 本身 → hook 报 `mode: project`、`git_top: <非 git 的 cwd>`、`project_id: <外部仓名>`，与 #127 要修的「注入错误上下文」同类。
+
+复现：
+
+```bash
+t=$(mktemp -d); mkdir -p "$t/foreign" "$t/plain"; git -C "$t/foreign" init -q
+(cd "$t/plain" && GIT_DIR="$t/foreign/.git" bash hooks/session-start)
+# → "mode: project ... project_id: foreign ... git_top: <plain>"，实际 plain 不是 git 仓
+```
+
+测试：F1（KNOWN-BUG 标记）。建议修法：hook 开头 `unset GIT_DIR GIT_WORK_TREE`（hook 语义始终基于 cwd 物理位置，按 cwd 探测不应受调用方 env 影响）。注：`GIT_WORK_TREE` 单独污染（F2）git 自身会报错退出，hook 安全降级，无此问题。
+
+### GAP-1（低）：`ROUNDTABLE_DOCS_ROOT` 相对路径原样透传
+
+`ROUNDTABLE_DOCS_ROOT=docs` 时 `-d` 按 hook 进程 cwd 判真，context 输出 `docs_root: docs`（相对路径）。消费方（subagent / skill）cwd 不同时解析会落空。建议在接受时归一化为绝对路径（`cd && pwd` 或前缀 `$cwd/`）。测试：C1（特征化，记录现状）。尾斜杠（C2）原样保留，纯外观，不重要。
+
+### GAP-2（信息，已在代码注释声明）：sed fallback 会误取嵌套同名键
+
+无 python3 环境下 `{"nested": {"docs_root": "evil"}}` 被 sed 提取出 `evil`；若该路径恰好存在则以 `status: ok` 误报（D2 实测）。破损 JSON 中的合法形态键值行也会被提取（D5）。DEC-3 注释已声明此限制，维持现状可接受；若要收紧可在 README `.roundtable.json` 一节明示「无 python3 时仅支持平铺单层」。
+
+### INFO-1：hooks.json 与 .codex-plugin/plugin.json 的 hook 声明分叉
+
+- matcher：`startup|clear|compact`（hooks.json） vs `*`（codex）
+- codex 侧保留 `"async": false`（exec-plan 1.5 只从 hooks.json 删了非标 `async`）
+- codex 侧直接 exec 脚本（无 `bash` 前缀）——依赖可执行位，已验证 `rwxr-xr-x`（G2）
+
+两份声明指向同一脚本（G1 过）。分叉可能是 #124 codex schema 故意为之；若非故意，建议下个 codex 相关 PR 顺手对齐。不阻塞本 PR。
+
+### INFO-2：config `../` 逃逸 repo 被信任
+
+`{"docs_root": "../outside"}` 解析为 `<git_top>/../outside` 且 `status: ok`（B12）。符合 DEC-3/DEC-4「显式配置即生效」语义，按设计放行；记录在案以防后续误判为越界 bug。
+
+## 结论
+
+walk-up 边界（#127 核心修复）、敌意路径转义、配置畸形输入、sed 降级、workspace 扫描、输出契约均稳健；发现 2 个真实 bug（BUG-1 低 / BUG-2 中）已留失败复现断言（KNOWN-BUG 标记，`STRICT=1` 可见红），2 个 gap + 2 条信息项供后续决策。

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,8 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start\"",
-            "async": false
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start\""
           }
         ]
       }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,43 +1,223 @@
 #!/usr/bin/env bash
-# SessionStart hook for roundtable plugin.
+# roundtable plugin 的 SessionStart hook（issue #127 重写为双模式）。
 #
-# Detects docs_root + project_id and injects them into Claude Code session
-# context via the standard SessionStart hook JSON protocol. Skills, agents, and
-# commands read this context at runtime — no inline 4-step detection needed.
+# - project 模式（cwd 在 git repo 内）：按 env ROUNDTABLE_DOCS_ROOT >
+#   <git_top>/.roundtable.json > 以 git_top 为界的 walk-up 顺序解析 docs_root，
+#   绝不越过 repo 边界爬到父级目录。
+# - workspace 模式（cwd 不在 git repo 内且有 git 子项目）：扫一层子目录注入
+#   项目清单，docs_root 由 skills 按任务的目标子项目延迟解析。
+#
+# 输出协议（DEC-1）：单行 JSON 无条件同时含 additionalContext +
+# hookSpecificOutput 两键，各 runtime 各取所需、忽略不认识的键。
 
 set -euo pipefail
 
-cwd="$(pwd)"
+# DEC-7: pwd 失败时回退 $PWD
+cwd="$(pwd 2>/dev/null || echo "$PWD")"
 
-docs_root=""
-status="ok"
-if [ -n "${ROUNDTABLE_DOCS_ROOT:-}" ] && [ -d "${ROUNDTABLE_DOCS_ROOT}" ]; then
-    docs_root="${ROUNDTABLE_DOCS_ROOT}"
-else
-    dir="$cwd"
-    while [ "$dir" != "/" ]; do
-        if [ -d "$dir/docs" ]; then
-            docs_root="$dir/docs"; break
-        elif [ -d "$dir/documentation" ]; then
-            docs_root="$dir/documentation"; break
+# DEC-4: 候选目录须含七目录之一或 INDEX.md 才算结构完整
+has_structure() {
+    local d sub
+    d="$1"
+    for sub in analyze design-docs exec-plans testing reviews bugfixes; do
+        if [ -d "$d/$sub" ]; then
+            return 0
         fi
-        dir="$(dirname "$dir")"
     done
-fi
-[ -z "$docs_root" ] && status="needs-init"
+    if [ -f "$d/INDEX.md" ]; then
+        return 0
+    fi
+    return 1
+}
+
+# DEC-3: 从 .roundtable.json 提取平铺字符串键（仅认 docs_root / project_id）。
+# 有 python3 走标准 json 解析；否则退化为 sed，仅支持平铺的 "key": "value"
+# 形式（不支持转义引号与嵌套对象）。
+read_config_key() {
+    local file key
+    file="$1"
+    key="$2"
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - "$file" "$key" 2>/dev/null <<'PYEOF' || true
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        v = json.load(f).get(sys.argv[2], "")
+except Exception:
+    v = ""
+if isinstance(v, str):
+    sys.stdout.write(v)
+PYEOF
+    else
+        sed -n 's/.*"'"$key"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$file" 2>/dev/null | head -n 1 || true
+    fi
+}
+
+mode="project"
+git_top=""
+project_id=""
+docs_root=""
+docs_root_source=""
+projects=""
+status="ok"
+warnings=""
+note=""
 
 if git_top="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"; then
-    project_id="$(basename "$git_top")"
+    # ---- project 模式 ----
+    # DEC-2: worktree 下用 common-dir 回推主仓根，project_id 取主仓根 basename
+    common_dir="$(git -C "$cwd" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "$git_top/.git")"
+    if [ "$(basename "$common_dir")" = ".git" ]; then
+        project_id="$(basename "$(dirname "$common_dir")")"
+    else
+        project_id="$(basename "$git_top")"
+    fi
+
+    # 解析链 1: env 显式指定（DEC-4: 不做结构校验；无效则 warning 后继续）
+    if [ -n "${ROUNDTABLE_DOCS_ROOT:-}" ]; then
+        if [ -d "${ROUNDTABLE_DOCS_ROOT}" ]; then
+            docs_root="${ROUNDTABLE_DOCS_ROOT}"
+            docs_root_source="env"
+        else
+            warnings="${warnings}warning: ROUNDTABLE_DOCS_ROOT=${ROUNDTABLE_DOCS_ROOT} does not exist; ignored.
+"
+        fi
+    fi
+
+    # 解析链 2: <git_top>/.roundtable.json（DEC-3）
+    config_file="$git_top/.roundtable.json"
+    if [ -f "$config_file" ]; then
+        cfg_project_id="$(read_config_key "$config_file" project_id)"
+        if [ -n "$cfg_project_id" ]; then
+            project_id="$cfg_project_id"
+        fi
+        if [ -z "$docs_root" ]; then
+            cfg_docs_root="$(read_config_key "$config_file" docs_root)"
+            if [ -n "$cfg_docs_root" ]; then
+                # 相对路径以 git_top 为基准
+                case "$cfg_docs_root" in
+                    /*) : ;;
+                    *) cfg_docs_root="$git_top/$cfg_docs_root" ;;
+                esac
+                if [ -d "$cfg_docs_root" ]; then
+                    docs_root="$cfg_docs_root"
+                    docs_root_source="config"
+                else
+                    warnings="${warnings}warning: .roundtable.json docs_root=${cfg_docs_root} does not exist; ignored.
+"
+                fi
+            fi
+        fi
+    fi
+
+    # 解析链 3: walk-up，终止边界为 git_top（含自身），修 #127 越界 bug。
+    # 带结构的候选直接 ok；全程无结构候选则取最先命中者并报 needs-init（DEC-4）。
+    if [ -z "$docs_root" ]; then
+        fallback=""
+        dir="$cwd"
+        while :; do
+            for cand in docs documentation; do
+                if [ -d "$dir/$cand" ]; then
+                    if has_structure "$dir/$cand"; then
+                        docs_root="$dir/$cand"
+                        break 2
+                    fi
+                    if [ -z "$fallback" ]; then
+                        fallback="$dir/$cand"
+                    fi
+                fi
+            done
+            if [ "$dir" = "$git_top" ] || [ "$dir" = "/" ]; then
+                break
+            fi
+            dir="$(dirname "$dir")"
+        done
+        if [ -n "$docs_root" ]; then
+            docs_root_source="walk-up"
+        elif [ -n "$fallback" ]; then
+            docs_root="$fallback"
+            docs_root_source="walk-up"
+            status="needs-init"
+            note="docs_root exists but lacks roundtable structure; prompt the user to confirm initialization."
+        fi
+    fi
+
+    if [ -z "$docs_root" ]; then
+        status="needs-init"
+        note="docs_root not found; prompt the user to set one."
+    fi
 else
-    project_id="$(basename "$cwd")"
+    # ---- cwd 不在 git repo 内 ----
+    # DEC-5: 扫一层子目录，-e <d>/.git 兼容 worktree / submodule 的 .git 文件
+    shopt -s nullglob
+    for d in "$cwd"/*/; do
+        d="${d%/}"
+        if [ -e "$d/.git" ]; then
+            name="$(basename "$d")"
+            if [ -d "$d/docs" ] || [ -d "$d/documentation" ]; then
+                name="$name (docs)"
+            fi
+            if [ -n "$projects" ]; then
+                projects="$projects, $name"
+            else
+                projects="$name"
+            fi
+        fi
+    done
+    shopt -u nullglob
+
+    if [ -n "$projects" ]; then
+        # workspace 模式：docs_root 留给 skills 按任务目标子项目解析（DEC-6）
+        mode="workspace"
+        note="resolve docs_root per task as <workspace_root>/<project>/docs; see workflow Step 1."
+    else
+        # 无 git 子项目：仅检查 cwd 自身的 docs|documentation，不向上爬（无边界可依）
+        project_id="$(basename "$cwd")"
+        for cand in docs documentation; do
+            if [ -d "$cwd/$cand" ]; then
+                docs_root="$cwd/$cand"
+                docs_root_source="walk-up"
+                break
+            fi
+        done
+        if [ -z "$docs_root" ]; then
+            status="needs-init"
+            note="docs_root not found; prompt the user to set one."
+        elif ! has_structure "$docs_root"; then
+            status="needs-init"
+            note="docs_root exists but lacks roundtable structure; prompt the user to confirm initialization."
+        fi
+    fi
 fi
 
-context="Roundtable context:
-docs_root: ${docs_root:-<none>}
-project_id: ${project_id}
+# ---- 组装 context（字段集见 DEC-6） ----
+if [ "$mode" = "workspace" ]; then
+    context="Roundtable context:
+mode: workspace
+workspace_root: ${cwd}
+projects: ${projects}
 status: ${status}"
-[ "$status" = "needs-init" ] && context="${context}
-note: docs_root not found; commands should AskUserQuestion to set one."
+else
+    context="Roundtable context:
+mode: project
+docs_root: ${docs_root:-<none>}"
+    if [ -n "$docs_root_source" ]; then
+        context="${context}
+docs_root_source: ${docs_root_source}"
+    fi
+    context="${context}
+project_id: ${project_id}
+git_top: ${git_top:-<none>}
+status: ${status}"
+fi
+if [ -n "$warnings" ]; then
+    context="${context}
+${warnings%$'\n'}"
+fi
+if [ -n "$note" ]; then
+    context="${context}
+note: ${note}"
+fi
 
 escape_for_json() {
     local s="$1"
@@ -46,14 +226,11 @@ escape_for_json() {
     s="${s//$'\n'/\\n}"
     s="${s//$'\r'/\\r}"
     s="${s//$'\t'/\\t}"
+    s="${s//$'\b'/\\b}"
+    s="${s//$'\f'/\\f}"
     printf '%s' "$s"
 }
 escaped="$(escape_for_json "$context")"
 
-if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
-    printf '{"additional_context":"%s"}\n' "$escaped"
-elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
-    printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$escaped"
-else
-    printf '{"additionalContext":"%s"}\n' "$escaped"
-fi
+# DEC-1: 双键单行输出，不再做任何 runtime env 探测
+printf '{"additionalContext":"%s","hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$escaped" "$escaped"

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -17,10 +17,11 @@ set -euo pipefail
 # hook 语义始终基于 cwd 物理位置探测，不受调用方 env 影响。
 unset GIT_DIR GIT_WORK_TREE
 
-# DEC-7: pwd 失败时回退 $PWD
-cwd="$(pwd 2>/dev/null || echo "$PWD")"
+# DEC-7: pwd 失败时回退 $PWD。MAJOR-1(#127): 用 -P 取物理路径——git_top 来自
+# git rev-parse（物理路径），逻辑 cwd 含 symlink 时两者永不相等，walk-up 边界失效。
+cwd="$(pwd -P 2>/dev/null || pwd 2>/dev/null || echo "$PWD")"
 
-# DEC-4: 候选目录须含七目录之一或 INDEX.md 才算结构完整
+# DEC-4: 候选目录须含六目录之一或 INDEX.md 才算结构完整
 has_structure() {
     local d sub
     d="$1"

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -12,6 +12,11 @@
 
 set -euo pipefail
 
+# BUG-2(#127): 清洗父进程可能继承的 git env 污染——带 GIT_DIR 时 git 会把任意
+# cwd 当作外部仓的 worktree 顶层，致非 git 目录误判为 project 模式。
+# hook 语义始终基于 cwd 物理位置探测，不受调用方 env 影响。
+unset GIT_DIR GIT_WORK_TREE
+
 # DEC-7: pwd 失败时回退 $PWD
 cwd="$(pwd 2>/dev/null || echo "$PWD")"
 
@@ -76,7 +81,11 @@ if git_top="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"; then
     # 解析链 1: env 显式指定（DEC-4: 不做结构校验；无效则 warning 后继续）
     if [ -n "${ROUNDTABLE_DOCS_ROOT:-}" ]; then
         if [ -d "${ROUNDTABLE_DOCS_ROOT}" ]; then
-            docs_root="${ROUNDTABLE_DOCS_ROOT}"
+            # GAP-1(#127): 相对路径基于 cwd 归一化为绝对路径，避免消费方 cwd 不同时解析落空
+            case "${ROUNDTABLE_DOCS_ROOT}" in
+                /*) docs_root="${ROUNDTABLE_DOCS_ROOT}" ;;
+                *) docs_root="$cwd/${ROUNDTABLE_DOCS_ROOT}" ;;
+            esac
             docs_root_source="env"
         else
             warnings="${warnings}warning: ROUNDTABLE_DOCS_ROOT=${ROUNDTABLE_DOCS_ROOT} does not exist; ignored.
@@ -228,6 +237,14 @@ escape_for_json() {
     s="${s//$'\t'/\\t}"
     s="${s//$'\b'/\\b}"
     s="${s//$'\f'/\\f}"
+    # BUG-1(#127): 其余 C0 控制字符（0x01-0x1F 中未具名处理者）兜底转为 \u00XX，
+    # 防止原样进入 JSON 字符串致输出不可解析（NUL 在 bash 字符串中不存在，无需处理）
+    local i ch esc
+    for i in 1 2 3 4 5 6 7 11 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31; do
+        printf -v ch '%b' "\\$(printf '%03o' "$i")"
+        printf -v esc '\\u%04x' "$i"
+        s="${s//$ch/$esc}"
+    done
     printf '%s' "$s"
 }
 escaped="$(escape_for_json "$context")"

--- a/skills/bugfix/SKILL.md
+++ b/skills/bugfix/SKILL.md
@@ -12,7 +12,7 @@ Fast path for fixing a bug. Skip analyst, design-doc, and user gates around desi
 
 ## Step 1: Read context
 
-SessionStart hook injects `docs_root` + `project_id`. Pick a slug.
+SessionStart hook injects `docs_root` + `project_id`. If the context shows `mode: workspace`, resolve the target subproject and `docs_root` per the canonical rule in `/roundtable:workflow` Step 1. Pick a slug.
 
 **Channel broadcast**: same rule as `/roundtable:workflow` Step 2 — if telegram MCP is loaded, post a new `reply` at workflow start, each phase completion (Step 4 developer / Step 5 reviewer or dba / Step 6 postmortem), and closeout. Terminal-only output is a bug.
 

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -10,7 +10,7 @@ Read-only docs sweep. Rebuilds `<docs_root>/INDEX.md`. Reports issues; does not 
 
 ## Step 1: Read context
 
-If `$ARGUMENTS` is an absolute path or `.`, use that as `target_project`. Otherwise read `docs_root` from session start context. If `docs_root` isn't set, abort with a one-line message asking the user to invoke from inside the target project or pass a path.
+If `$ARGUMENTS` is an absolute path or `.`, use that as `target_project`. Otherwise read `docs_root` from session start context. If the context shows `mode: workspace` and no path argument was given, list the projects from the context and ask the user to pick **one** target project (never default to sweeping all), then use `<workspace_root>/<project>/docs`. If `docs_root` isn't set, abort with a one-line message asking the user to invoke from inside the target project or pass a path.
 
 ## Step 2: Rebuild INDEX.md
 

--- a/skills/lint/SKILL.md
+++ b/skills/lint/SKILL.md
@@ -10,7 +10,7 @@ Read-only docs sweep. Rebuilds `<docs_root>/INDEX.md`. Reports issues; does not 
 
 ## Step 1: Read context
 
-If `$ARGUMENTS` is an absolute path or `.`, use that as `target_project`. Otherwise read `docs_root` from session start context. If the context shows `mode: workspace` and no path argument was given, list the projects from the context and ask the user to pick **one** target project (never default to sweeping all), then use `<workspace_root>/<project>/docs`. If `docs_root` isn't set, abort with a one-line message asking the user to invoke from inside the target project or pass a path.
+If `$ARGUMENTS` is an absolute path or `.`, use that as `target_project`. Otherwise read `docs_root` from session start context. If the context shows `mode: workspace` and no path argument was given, list the projects from the context and ask the user to pick **one** target project (never default to sweeping all), then use `<workspace_root>/<project>/docs` (canonical workspace-resolution rule: workflow Step 1). If `docs_root` isn't set, abort with a one-line message asking the user to invoke from inside the target project or pass a path.
 
 ## Step 2: Rebuild INDEX.md
 

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -12,7 +12,12 @@ Orchestrate the workflow. Don't design or code — dispatch each substantive ste
 
 ## Step 1: Read context
 
-The SessionStart hook injects roundtable context (`Roundtable context:` block). Extract `docs_root`, `project_id`, `status`. If `status: needs-init`, call `AskUserQuestion` to confirm where to put `docs/`. Pick a kebab-case `slug` for this task (or ask).
+The SessionStart hook injects roundtable context (`Roundtable context:` block). Check `mode` first:
+
+- **`mode: project`** — extract `docs_root`, `project_id`, `status`. If `status: needs-init`, ask the user (channel-aware: TG `reply` if telegram MCP is loaded, else `AskUserQuestion`) where to put `docs/` before proceeding.
+- **`mode: workspace`** — cwd is a parent workspace, not a single project; the context lists the git subprojects under `workspace_root` (`(docs)` marks those with a docs dir). Infer the **target subproject** from the task description / issue / files involved; if it can't be inferred, ask the user (channel-aware, options = the project list). Then resolve `docs_root = <workspace_root>/<project>/docs` and pass that `docs_root` in **every** role dispatch. This paragraph is the canonical workspace-resolution rule — `bugfix` and `lint` reference it.
+
+Pick a kebab-case `slug` for this task (or ask).
 
 ## Step 2: Phase Matrix
 

--- a/tests/session-start.adversarial.test.sh
+++ b/tests/session-start.adversarial.test.sh
@@ -326,14 +326,13 @@ fi
 # ============================================================
 # C. ROUNDTABLE_DOCS_ROOT 边界
 # ============================================================
-# C1 相对路径（相对 cwd 存在）→ 当前实现原样接受并输出相对路径（特征化；
-# 报告中列为 gap：消费方 cwd 不同会解析失败）
+# C1 相对路径（相对 cwd 存在）→ 基于 cwd 归一化为绝对路径（GAP-1 已修）
 t="$(new_tmp)"
 mkdir -p "$t/repo/docs/analyze"
 git_init "$t/repo"
 run_hook "$t/repo" ROUNDTABLE_DOCS_ROOT=docs
 if contract "C1 [relative env path]"; then
-    assert_contains "C1 relative value accepted as-is (characterization)" "$CTX" $'docs_root: docs\n'
+    assert_contains "C1 [GAP-1 fixed] relative value normalized to absolute" "$CTX" "docs_root: $t/repo/docs"$'\n'
     assert_contains "C1 source=env" "$CTX" $'docs_root_source: env\n'
 fi
 
@@ -504,19 +503,16 @@ fi
 # ============================================================
 # F. git 环境异常
 # ============================================================
-# F1 [BUG-2]: GIT_DIR 污染 → 非 git 的 cwd 被 git 当作 worktree 顶层，
-# hook 误报 project 模式（git_top=cwd、project_id 取自外部仓）
+# F1 [BUG-2 已修]: GIT_DIR 污染 → hook 开头 unset，git 探测只看 cwd 物理位置，
+# 不得把 cwd 报成外部仓的 worktree 顶层（git_top=cwd、project_id 取自外部仓）
 t="$(new_tmp)"
 mkdir -p "$t/foreign" "$t/plain"
 git_init "$t/foreign"
 run_hook "$t/plain" GIT_DIR="$t/foreign/.git"
 if contract "F1 [GIT_DIR pollution]"; then
-    if [[ "$CTX" != *$'mode: project\n'* ]]; then
-        pass "F1 [BUG-2 fixed] GIT_DIR pollution ignored"
-    else
-        known_bug "F1 GIT_DIR pollution ignored" \
-            "非 git cwd + 外部 GIT_DIR 被误判为 project 模式: git_top=$t/plain, project_id=foreign"
-    fi
+    assert_not_contains "F1 [BUG-2 fixed] foreign repo not claimed" "$CTX" "project_id: foreign"
+    assert_not_contains "F1 [BUG-2 fixed] cwd not claimed as git_top" "$CTX" "git_top: $t/plain"
+    assert_contains "F1 needs-init (non-git path)" "$CTX" $'status: needs-init\n'
 fi
 
 # F2: GIT_WORK_TREE 单独污染（无 GIT_DIR）→ git 报错退出，应安全落入非 git 分支

--- a/tests/session-start.adversarial.test.sh
+++ b/tests/session-start.adversarial.test.sh
@@ -1,0 +1,656 @@
+#!/usr/bin/env bash
+# hooks/session-start 对抗测试（slug: hook-workspace-docs-root, issue #127）。
+# 与 tests/session-start.test.sh（developer 自带）互补，专攻边界与异常输入：
+#   敌意路径名 / .roundtable.json 畸形输入 / sed fallback（无 python3）/
+#   workspace 规模与怪名 / git 环境污染 / 输出契约逐 case 强校验。
+#
+# 已知 bug 的复现断言用 KNOWN-BUG 标记：默认不影响退出码（便于 CI），
+# STRICT=1 时计入失败。bug 清单见 docs/testing/hook-workspace-docs-root.md。
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/session-start"
+PY="$(command -v python3)"   # harness 自身固定用绝对路径，不受 PATH 篡改测试影响
+
+PASS=0
+FAIL=0
+KNOWN_BUGS=0
+TMP_DIRS=()
+
+cleanup() {
+    local d
+    for d in "${TMP_DIRS[@]:-}"; do
+        if [ -n "$d" ]; then
+            chmod -R u+rwX "$d" 2>/dev/null || true
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+new_tmp() {
+    local d
+    d="$(cd "$(mktemp -d)" && pwd -P)"
+    TMP_DIRS+=("$d")
+    printf '%s' "$d"
+}
+
+pass() { PASS=$((PASS + 1)); printf 'ok   - %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf 'FAIL - %s\n      %s\n' "$1" "$2"; }
+known_bug() {
+    KNOWN_BUGS=$((KNOWN_BUGS + 1))
+    printf 'KNOWN-BUG - %s\n      %s\n' "$1" "$2"
+    if [ "${STRICT:-0}" = "1" ]; then FAIL=$((FAIL + 1)); fi
+}
+
+# 运行 hook：捕获 stdout/stderr/退出码到全局 OUT/ERR/RC。
+# 默认清掉 ROUNDTABLE_DOCS_ROOT 与 GIT_* 污染源；额外 KEY=VALUE 透传（后者覆盖 -u）。
+ERR_FILE=""
+run_hook() {
+    local dir="$1"
+    shift
+    RC=0
+    OUT="$( (cd "$dir" && env -u ROUNDTABLE_DOCS_ROOT -u CLAUDE_PLUGIN_ROOT \
+        -u GIT_DIR -u GIT_WORK_TREE -u GIT_CEILING_DIRECTORIES \
+        "$@" bash "$HOOK") 2>"$ERR_FILE" )" || RC=$?
+    ERR="$(cat "$ERR_FILE")"
+}
+
+# 同上，但以受限 PATH 运行（用于藏掉 python3 / git）
+run_hook_path() {
+    local dir="$1" path="$2"
+    shift 2
+    RC=0
+    OUT="$( (cd "$dir" && env -u ROUNDTABLE_DOCS_ROOT -u CLAUDE_PLUGIN_ROOT \
+        -u GIT_DIR -u GIT_WORK_TREE -u GIT_CEILING_DIRECTORIES \
+        PATH="$path" "$@" /usr/bin/bash "$HOOK") 2>"$ERR_FILE" )" || RC=$?
+    ERR="$(cat "$ERR_FILE")"
+}
+
+# 输出契约（DEC-1 + hook 不得哑火）：退出码 0、stdout 单行非空、stderr 静默、
+# 合法 JSON、双键 context 一致、hookEventName 正确。解码后的 context 存入 CTX。
+contract() {
+    local name="$1"
+    if [ "$RC" -eq 0 ]; then
+        pass "$name exit code 0"
+    else
+        fail "$name exit code 0" "rc=$RC stderr=${ERR@Q} out=${OUT@Q}"
+    fi
+    if [ -n "$OUT" ] && [[ "$OUT" != *$'\n'* ]]; then
+        pass "$name single-line non-empty stdout"
+    else
+        fail "$name single-line non-empty stdout" "out=${OUT@Q}"
+    fi
+    if [ -z "$ERR" ]; then
+        pass "$name silent stderr"
+    else
+        fail "$name silent stderr" "stderr=${ERR@Q}"
+    fi
+    if CTX="$(printf '%s' "$OUT" | "$PY" -c '
+import json, sys
+out = json.loads(sys.stdin.read())
+top = out["additionalContext"]
+hso = out["hookSpecificOutput"]
+assert hso["hookEventName"] == "SessionStart", "bad hookEventName"
+assert hso["additionalContext"] == top, "context mismatch between the two keys"
+sys.stdout.write(top)
+' 2>/dev/null)"; then
+        pass "$name valid dual-key JSON"
+        return 0
+    fi
+    fail "$name valid dual-key JSON" "out=${OUT@Q}"
+    CTX=""
+    return 1
+}
+
+assert_contains() {
+    local name="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$name"
+    else
+        fail "$name" "expected to contain: ${needle@Q}; actual: ${haystack@Q}"
+    fi
+}
+
+assert_not_contains() {
+    local name="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        pass "$name"
+    else
+        fail "$name" "expected NOT to contain: ${needle@Q}; actual: ${haystack@Q}"
+    fi
+}
+
+git_init() { git -C "$1" init -q; }
+
+ERR_FILE="$(new_tmp)/stderr"
+
+# ============================================================
+# A. 敌意路径名（project 模式：repo 目录名本身就是攻击载荷）
+# ============================================================
+hostile_names=(
+    'pa th'
+    '中文项目'
+    "o'brien"
+    'x$HOME-y'
+    'x$(echo pwned)y'
+    'a`id`b'
+    'st*ar'
+    'br[ack]et'
+    'qu"ote'
+    'back\slash'
+)
+i=0
+for name in "${hostile_names[@]}"; do
+    i=$((i + 1))
+    t="$(new_tmp)"
+    repo="$t/$name"
+    mkdir -p "$repo/docs/design-docs"
+    git_init "$repo"
+    run_hook "$repo"
+    if contract "A$i [$name]"; then
+        assert_contains "A$i [$name] docs_root literal" "$CTX" "docs_root: $repo/docs"$'\n'
+        assert_contains "A$i [$name] project_id literal" "$CTX" "project_id: $name"$'\n'
+        assert_contains "A$i [$name] status=ok" "$CTX" "status: ok"
+    fi
+done
+# 注入哨兵：路径里的 $(echo pwned) / `id` / $HOME 若被求值，输出会失真（上面的
+# literal 断言已覆盖）；这里再确认没有产生副作用文件
+if [ ! -e "$REPO_ROOT/pwned" ] && [ ! -e "/tmp/pwned" ]; then
+    pass "A-inject no side-effect file created"
+else
+    fail "A-inject no side-effect file created" "pwned file exists"
+fi
+
+# A11: 目录名含换行 → \n 已转义，JSON 应合法
+t="$(new_tmp)"
+repo="$t/nl"$'\n'"name"
+mkdir -p "$repo/docs/design-docs"
+git_init "$repo"
+run_hook "$repo"
+if contract "A11 [newline-in-name]"; then
+    assert_contains "A11 docs_root spans escaped newline" "$CTX" "docs_root: $repo/docs"
+fi
+
+# A12 [BUG-1]: 目录名含未覆盖的控制字符（\x0b vertical tab）→ escape 函数只处理
+# \n\r\t\b\f，\x0b 原样进入 JSON 字符串 → 非法 JSON，hook 哑火
+t="$(new_tmp)"
+repo="$t/ev"$'\x0b'"il"
+mkdir -p "$repo/docs/design-docs"
+git_init "$repo"
+run_hook "$repo"
+if printf '%s' "$OUT" | "$PY" -c 'import json,sys; json.loads(sys.stdin.read())' 2>/dev/null; then
+    pass "A12 [BUG-1 fixed] control char \\x0b in path yields valid JSON"
+else
+    known_bug "A12 control char \\x0b in path yields valid JSON" \
+        "escape_for_json 未覆盖 <0x20 的其余控制字符，JSON 解析失败 → hook 输出不可用"
+fi
+
+# ============================================================
+# B. .roundtable.json 畸形输入（repo 均带 docs/analyze 作 walk-up 兜底）
+# ============================================================
+mk_cfg_repo() {  # $1=tmp 根；stdout 返回 repo 路径
+    local t="$1"
+    mkdir -p "$t/repo/docs/analyze"
+    git_init "$t/repo"
+    printf '%s' "$t/repo"
+}
+
+# B1 非法 JSON
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+printf '{not json' > "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B1 [invalid JSON]"; then
+    assert_contains "B1 degrades to walk-up" "$CTX" $'docs_root_source: walk-up\n'
+    assert_contains "B1 status=ok" "$CTX" "status: ok"
+fi
+
+# B2/B3/B4 docs_root 为数组 / 数字 / null → 非字符串一律忽略
+for pair in 'B2-array:{"docs_root": ["a","b"]}' 'B3-number:{"docs_root": 42}' 'B4-null:{"docs_root": null}'; do
+    name="${pair%%:*}"; payload="${pair#*:}"
+    t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+    printf '%s\n' "$payload" > "$repo/.roundtable.json"
+    run_hook "$repo"
+    if contract "$name"; then
+        assert_contains "$name non-string ignored, walk-up" "$CTX" $'docs_root_source: walk-up\n'
+    fi
+done
+
+# B5 嵌套对象里有同名键 + 顶层真键 → python3 路径只认顶层
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+mkdir -p "$repo/evil" "$repo/mydocs"
+printf '{"o": {"docs_root": "evil"}, "docs_root": "mydocs"}\n' > "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B5 [nested same-name key]"; then
+    assert_contains "B5 top-level key wins" "$CTX" "docs_root: $repo/mydocs"$'\n'
+    assert_not_contains "B5 nested key not picked" "$CTX" "$repo/evil"
+fi
+
+# B6 空文件
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+: > "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B6 [empty file]"; then
+    assert_contains "B6 walk-up" "$CTX" $'docs_root_source: walk-up\n'
+fi
+
+# B7 无读权限（chmod 000；root 下跳过）
+if [ "$(id -u)" -ne 0 ]; then
+    t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+    printf '{"docs_root": "docs"}\n' > "$repo/.roundtable.json"
+    chmod 000 "$repo/.roundtable.json"
+    run_hook "$repo"
+    if contract "B7 [unreadable config]"; then
+        assert_contains "B7 walk-up" "$CTX" $'docs_root_source: walk-up\n'
+    fi
+    chmod 644 "$repo/.roundtable.json"
+else
+    printf 'skip - B7 (running as root)\n'
+fi
+
+# B8 超长值（10k 字符）→ warning 不崩、JSON 合法
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+long="$(printf 'x%.0s' $(seq 1 10000))"
+printf '{"docs_root": "%s"}\n' "$long" > "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B8 [10k-char value]"; then
+    assert_contains "B8 warning emitted" "$CTX" "warning:"
+    assert_contains "B8 walk-up" "$CTX" $'docs_root_source: walk-up\n'
+fi
+
+# B9 值含转义引号 → python 解出 my"docs，不存在 → warning 带引号仍合法 JSON
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+printf '{"docs_root": "my\\"docs"}\n' > "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B9 [escaped quote in value]"; then
+    assert_contains "B9 warning carries raw quote" "$CTX" 'my"docs'
+fi
+
+# B10 project_id 含双引号 → 进 context 后仍合法 JSON
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+printf '{"project_id": "pr\\"id"}\n' > "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B10 [quote in project_id]"; then
+    assert_contains "B10 project_id literal" "$CTX" 'project_id: pr"id'$'\n'
+fi
+
+# B11 docs_root 为空字符串 → 视为未配置，静默走 walk-up（不应有 warning）
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+printf '{"docs_root": ""}\n' > "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B11 [empty-string value]"; then
+    assert_contains "B11 walk-up" "$CTX" $'docs_root_source: walk-up\n'
+    assert_not_contains "B11 no warning" "$CTX" "warning:"
+fi
+
+# B12 相对路径 ../ 逃逸出 repo → 显式配置按 DEC-3/DEC-4 信任（特征化）
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+mkdir -p "$t/outside"
+printf '{"docs_root": "../outside"}\n' > "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B12 [../ escape]"; then
+    assert_contains "B12 explicit config trusted (characterization)" "$CTX" "docs_root: $repo/../outside"$'\n'
+    assert_contains "B12 source=config" "$CTX" $'docs_root_source: config\n'
+fi
+
+# B13 .roundtable.json 是目录 → [ -f ] 不命中，无视
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+mkdir "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B13 [config is a directory]"; then
+    assert_contains "B13 walk-up" "$CTX" $'docs_root_source: walk-up\n'
+fi
+
+# B14 值含 $(...) 注入载荷 → 仅字面拼接，不求值、无副作用
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+printf '{"docs_root": "$(touch %s/hacked)"}\n' "$repo" > "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B14 [command substitution payload]"; then
+    assert_contains "B14 warning carries literal payload" "$CTX" '$(touch'
+fi
+if [ ! -e "$repo/hacked" ]; then
+    pass "B14 no side-effect file"
+else
+    fail "B14 no side-effect file" "config value was evaluated"
+fi
+
+# B15 值含换行（JSON \n）→ warning 跨行仍合法 JSON
+t="$(new_tmp)"; repo="$(mk_cfg_repo "$t")"
+printf '{"docs_root": "a\\nb"}\n' > "$repo/.roundtable.json"
+run_hook "$repo"
+if contract "B15 [newline in value]"; then
+    assert_contains "B15 warning emitted" "$CTX" "warning:"
+fi
+
+# ============================================================
+# C. ROUNDTABLE_DOCS_ROOT 边界
+# ============================================================
+# C1 相对路径（相对 cwd 存在）→ 当前实现原样接受并输出相对路径（特征化；
+# 报告中列为 gap：消费方 cwd 不同会解析失败）
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs/analyze"
+git_init "$t/repo"
+run_hook "$t/repo" ROUNDTABLE_DOCS_ROOT=docs
+if contract "C1 [relative env path]"; then
+    assert_contains "C1 relative value accepted as-is (characterization)" "$CTX" $'docs_root: docs\n'
+    assert_contains "C1 source=env" "$CTX" $'docs_root_source: env\n'
+fi
+
+# C2 尾斜杠 → 原样保留（特征化，纯外观）
+t="$(new_tmp)"
+mkdir -p "$t/repo" "$t/ext"
+git_init "$t/repo"
+run_hook "$t/repo" ROUNDTABLE_DOCS_ROOT="$t/ext/"
+if contract "C2 [trailing slash]"; then
+    assert_contains "C2 kept verbatim" "$CTX" "docs_root: $t/ext/"$'\n'
+fi
+
+# C3 指向文件而非目录 → warning + 降级
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs/reviews"
+git_init "$t/repo"
+touch "$t/afile"
+run_hook "$t/repo" ROUNDTABLE_DOCS_ROOT="$t/afile"
+if contract "C3 [env points to file]"; then
+    assert_contains "C3 warning" "$CTX" "warning:"
+    assert_contains "C3 degraded to walk-up" "$CTX" "docs_root: $t/repo/docs"$'\n'
+fi
+
+# C4 空字符串 → 视为未设置，无 warning
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs/testing"
+git_init "$t/repo"
+run_hook "$t/repo" ROUNDTABLE_DOCS_ROOT=
+if contract "C4 [empty env]"; then
+    assert_not_contains "C4 no warning" "$CTX" "warning:"
+    assert_contains "C4 walk-up" "$CTX" $'docs_root_source: walk-up\n'
+fi
+
+# C5 含空格的绝对路径
+t="$(new_tmp)"
+mkdir -p "$t/repo" "$t/my docs"
+git_init "$t/repo"
+run_hook "$t/repo" ROUNDTABLE_DOCS_ROOT="$t/my docs"
+if contract "C5 [space in env path]"; then
+    assert_contains "C5 docs_root with space" "$CTX" "docs_root: $t/my docs"$'\n'
+fi
+
+# ============================================================
+# D. sed fallback（PATH 藏掉 python3）
+# ============================================================
+FAKEBIN="$(new_tmp)/bin"
+mkdir -p "$FAKEBIN"
+for b in git sed head basename dirname; do
+    ln -s "$(command -v "$b")" "$FAKEBIN/$b"
+done
+# 守卫：确认该 PATH 下 python3 不可见
+if env PATH="$FAKEBIN" /usr/bin/bash -c 'command -v python3' >/dev/null 2>&1; then
+    fail "D0 guard python3 hidden" "python3 still resolvable in FAKEBIN PATH"
+else
+    pass "D0 guard python3 hidden"
+fi
+
+# D1 平铺 config：sed 提取 docs_root + project_id
+t="$(new_tmp)"
+mkdir -p "$t/repo/mydocs"
+git_init "$t/repo"
+printf '{"docs_root": "mydocs", "project_id": "sed-id"}\n' > "$t/repo/.roundtable.json"
+run_hook_path "$t/repo" "$FAKEBIN"
+if contract "D1 [sed flat config]"; then
+    assert_contains "D1 docs_root" "$CTX" "docs_root: $t/repo/mydocs"$'\n'
+    assert_contains "D1 source=config" "$CTX" $'docs_root_source: config\n'
+    assert_contains "D1 project_id" "$CTX" $'project_id: sed-id\n'
+fi
+
+# D2 嵌套键：sed 退化实现会误取嵌套值（DEC-3 注释已声明的限制，特征化以证明
+# sed 分支真被执行；python3 路径下 B5 已验证只认顶层）
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs/analyze" "$t/repo/evil"
+git_init "$t/repo"
+printf '{"nested": {"docs_root": "evil"}}\n' > "$t/repo/.roundtable.json"
+run_hook_path "$t/repo" "$FAKEBIN"
+if contract "D2 [sed nested-key limitation]"; then
+    assert_contains "D2 sed picks nested value (documented limitation)" "$CTX" "docs_root: $t/repo/evil"$'\n'
+fi
+
+# D3 无 python3 时 walk-up / 结构校验 / needs-init 全链路
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs"
+git_init "$t/repo"
+run_hook_path "$t/repo" "$FAKEBIN"
+if contract "D3 [sed-mode walk-up needs-init]"; then
+    assert_contains "D3 docs_root reported" "$CTX" "docs_root: $t/repo/docs"$'\n'
+    assert_contains "D3 needs-init" "$CTX" $'status: needs-init\n'
+fi
+
+# D4 无 python3 时 workspace 模式
+t="$(new_tmp)"
+mkdir -p "$t/ws/alpha/.git" "$t/ws/beta/docs"
+mkdir -p "$t/ws/beta/.git"
+run_hook_path "$t/ws" "$FAKEBIN"
+if contract "D4 [sed-mode workspace]"; then
+    assert_contains "D4 mode=workspace" "$CTX" $'mode: workspace\n'
+    assert_contains "D4 projects" "$CTX" "projects: alpha, beta (docs)"
+fi
+
+# D5 非法 JSON 但含合法形态的键值行 → sed 照样提取（特征化退化语义）
+t="$(new_tmp)"
+mkdir -p "$t/repo/mydocs"
+git_init "$t/repo"
+printf 'garbage {{{ "docs_root": "mydocs" oops\n' > "$t/repo/.roundtable.json"
+run_hook_path "$t/repo" "$FAKEBIN"
+if contract "D5 [sed extracts from broken JSON]"; then
+    assert_contains "D5 extracted anyway (characterization)" "$CTX" "docs_root: $t/repo/mydocs"$'\n'
+fi
+
+# ============================================================
+# E. workspace 模式压力与怪名
+# ============================================================
+# E1: 50 个 git 子项目（.git 目录存在即算，DEC-5）
+t="$(new_tmp)"
+ws="$t/ws"
+for n in $(seq -w 1 50); do
+    mkdir -p "$ws/p$n/.git"
+done
+run_hook "$ws"
+if contract "E1 [50 subprojects]"; then
+    assert_contains "E1 mode=workspace" "$CTX" $'mode: workspace\n'
+    assert_contains "E1 first listed" "$CTX" "projects: p01,"
+    assert_contains "E1 last listed" "$CTX" "p49, p50"
+    commas="${CTX//[^,]/}"
+    if [ "${#commas}" -ge 49 ]; then
+        pass "E1 all 50 enumerated"
+    else
+        fail "E1 all 50 enumerated" "comma count=${#commas}, expected >=49"
+    fi
+fi
+
+# E2: 子目录名以 - 开头 / 名为 * / 含空格与中文 / .git 是文件（submodule 形态）
+t="$(new_tmp)"
+ws="$t/ws"
+mkdir -p "$ws/-dash/.git" "$ws/*/.git" "$ws/sp ace/.git" "$ws/中文proj/docs"
+printf 'gitdir: ../somewhere/.git\n' > "$ws/中文proj/.git"
+run_hook "$ws"
+if contract "E2 [hostile subdir names]"; then
+    assert_contains "E2 -dash listed" "$CTX" "-dash"
+    assert_contains "E2 literal * listed" "$CTX" "*"
+    assert_contains "E2 space name listed" "$CTX" "sp ace"
+    assert_contains "E2 gitfile submodule listed with docs tag" "$CTX" "中文proj (docs)"
+fi
+
+# E3: 悬空 symlink 子目录 → 忽略不崩；指向 git 仓的 symlink → 计入（特征化）
+t="$(new_tmp)"
+ws="$t/ws"
+mkdir -p "$ws" "$t/real/.git"
+ln -s "$t/nonexistent" "$ws/dangling"
+ln -s "$t/real" "$ws/linked"
+run_hook "$ws"
+if contract "E3 [symlink subdirs]"; then
+    assert_not_contains "E3 dangling ignored" "$CTX" "dangling"
+    assert_contains "E3 symlink-to-repo listed (characterization)" "$CTX" "linked"
+fi
+
+# E4: workspace 根目录名本身含 glob 字符
+t="$(new_tmp)"
+ws="$t/ws*[1]"
+mkdir -p "$ws/proj/.git"
+run_hook "$ws"
+if contract "E4 [glob chars in workspace root]"; then
+    assert_contains "E4 workspace_root literal" "$CTX" "workspace_root: $ws"$'\n'
+    assert_contains "E4 project listed" "$CTX" "projects: proj"
+fi
+
+# ============================================================
+# F. git 环境异常
+# ============================================================
+# F1 [BUG-2]: GIT_DIR 污染 → 非 git 的 cwd 被 git 当作 worktree 顶层，
+# hook 误报 project 模式（git_top=cwd、project_id 取自外部仓）
+t="$(new_tmp)"
+mkdir -p "$t/foreign" "$t/plain"
+git_init "$t/foreign"
+run_hook "$t/plain" GIT_DIR="$t/foreign/.git"
+if contract "F1 [GIT_DIR pollution]"; then
+    if [[ "$CTX" != *$'mode: project\n'* ]]; then
+        pass "F1 [BUG-2 fixed] GIT_DIR pollution ignored"
+    else
+        known_bug "F1 GIT_DIR pollution ignored" \
+            "非 git cwd + 外部 GIT_DIR 被误判为 project 模式: git_top=$t/plain, project_id=foreign"
+    fi
+fi
+
+# F2: GIT_WORK_TREE 单独污染（无 GIT_DIR）→ git 报错退出，应安全落入非 git 分支
+t="$(new_tmp)"
+mkdir -p "$t/plain"
+run_hook "$t/plain" GIT_WORK_TREE="$t/plain"
+if contract "F2 [GIT_WORK_TREE pollution]"; then
+    assert_contains "F2 needs-init (non-git path)" "$CTX" $'status: needs-init\n'
+fi
+
+# F3: cwd 在 bare repo 内 → rev-parse 失败，落入非 git 分支不崩
+t="$(new_tmp)"
+git init -q --bare "$t/bare.git"
+run_hook "$t/bare.git"
+if contract "F3 [bare repo]"; then
+    assert_contains "F3 needs-init" "$CTX" $'status: needs-init\n'
+    assert_not_contains "F3 no git_top claimed" "$CTX" "git_top: $t/bare.git"
+fi
+
+# F4: git 不在 PATH（真 git 仓内）→ 静默降级为非 git 分支，契约不破
+NOGIT="$(new_tmp)/bin"
+mkdir -p "$NOGIT"
+for b in sed head basename dirname python3; do
+    ln -s "$(command -v "$b")" "$NOGIT/$b"
+done
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs/analyze"
+git_init "$t/repo"
+run_hook_path "$t/repo" "$NOGIT"
+if contract "F4 [git missing from PATH]"; then
+    assert_contains "F4 degrades to non-git docs detection" "$CTX" "docs_root: $t/repo/docs"$'\n'
+    assert_contains "F4 status=ok" "$CTX" "status: ok"
+fi
+
+# ============================================================
+# W. walk-up / 结构校验补充（developer 未覆盖的次序语义）
+# ============================================================
+# W1: 仅有 documentation/（带结构）→ 也能命中
+t="$(new_tmp)"
+mkdir -p "$t/repo/documentation/reviews"
+git_init "$t/repo"
+run_hook "$t/repo"
+if contract "W1 [documentation/ only]"; then
+    assert_contains "W1 docs_root=documentation" "$CTX" "docs_root: $t/repo/documentation"$'\n'
+    assert_contains "W1 status=ok" "$CTX" "status: ok"
+fi
+
+# W2: 同级 docs/（无结构）+ documentation/（有结构）→ 结构优先于字面次序
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs" "$t/repo/documentation/exec-plans"
+git_init "$t/repo"
+run_hook "$t/repo"
+if contract "W2 [structured documentation beats bare docs]"; then
+    assert_contains "W2 picks structured" "$CTX" "docs_root: $t/repo/documentation"$'\n'
+    assert_contains "W2 status=ok" "$CTX" "status: ok"
+fi
+
+# W3: docs 是文件而非目录 → 跳过，needs-init
+t="$(new_tmp)"
+mkdir -p "$t/repo"
+git_init "$t/repo"
+touch "$t/repo/docs"
+run_hook "$t/repo"
+if contract "W3 [docs is a file]"; then
+    assert_contains "W3 needs-init" "$CTX" $'status: needs-init\n'
+    assert_contains "W3 docs_root=<none>" "$CTX" $'docs_root: <none>\n'
+fi
+
+# W4: 边界变体——repo 内 docs 无结构 + 父级 docs 有结构 → 取 repo 内 + needs-init，
+# 绝不越界（比 T2 更强：repo 内存在 fallback 时也不越界）
+t="$(new_tmp)"
+mkdir -p "$t/parent/docs/design-docs" "$t/parent/repo/docs"
+git_init "$t/parent/repo"
+run_hook "$t/parent/repo"
+if contract "W4 [fallback inside boundary]"; then
+    assert_contains "W4 in-repo fallback" "$CTX" "docs_root: $t/parent/repo/docs"$'\n'
+    assert_contains "W4 needs-init" "$CTX" $'status: needs-init\n'
+    assert_not_contains "W4 parent never touched" "$CTX" "$t/parent/docs"
+fi
+
+# W5: cwd 深三层、结构化 docs 离 cwd 更近时优先于 repo 根（就近原则特征化）
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs/analyze" "$t/repo/sub/docs/testing" "$t/repo/sub/deep"
+git_init "$t/repo"
+run_hook "$t/repo/sub/deep"
+if contract "W5 [nearest structured docs wins]"; then
+    assert_contains "W5 picks nearest" "$CTX" "docs_root: $t/repo/sub/docs"$'\n'
+fi
+
+# W6: 幂等性——同一 fixture 连跑两次输出完全一致
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs/bugfixes"
+git_init "$t/repo"
+run_hook "$t/repo"; out1="$OUT"
+run_hook "$t/repo"; out2="$OUT"
+if [ "$out1" = "$out2" ] && [ -n "$out1" ]; then
+    pass "W6 idempotent output"
+else
+    fail "W6 idempotent output" "run1=${out1@Q} run2=${out2@Q}"
+fi
+
+# ============================================================
+# G. hook 声明一致性（hooks/hooks.json vs .codex-plugin/plugin.json）
+# ============================================================
+g_out="$("$PY" - "$REPO_ROOT" <<'PYEOF' 2>&1
+import json, os, sys
+root = sys.argv[1]
+hooks = json.load(open(os.path.join(root, "hooks/hooks.json")))
+entries = hooks["hooks"]["SessionStart"]
+assert len(entries) == 1, "expect single SessionStart entry"
+cmd = entries[0]["hooks"][0]["command"]
+assert "hooks/session-start" in cmd, f"hooks.json command: {cmd}"
+assert entries[0]["matcher"] == "startup|clear|compact", f"matcher: {entries[0]['matcher']}"
+assert "async" not in entries[0]["hooks"][0], "non-standard async leaked back into hooks.json"
+codex = json.load(open(os.path.join(root, ".codex-plugin/plugin.json")))
+ccmd = codex["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+assert "hooks/session-start" in ccmd, f"codex command: {ccmd}"
+print("OK")
+PYEOF
+)" || true
+if [ "$g_out" = "OK" ]; then
+    pass "G1 hooks.json + codex plugin.json both reference hooks/session-start; hooks.json matcher/async per exec-plan 1.5"
+else
+    fail "G1 hook declarations consistency" "$g_out"
+fi
+# G2: codex plugin.json 直接 exec（不经 bash 前缀）→ 脚本必须可执行
+if [ -x "$HOOK" ]; then
+    pass "G2 hook file executable (codex direct-exec)"
+else
+    fail "G2 hook file executable (codex direct-exec)" "$(ls -l "$HOOK")"
+fi
+
+# ---------- 汇总 ----------
+printf '\n%d passed, %d failed, %d known-bug\n' "$PASS" "$FAIL" "$KNOWN_BUGS"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/session-start.adversarial.test.sh
+++ b/tests/session-start.adversarial.test.sh
@@ -6,6 +6,7 @@
 #
 # 已知 bug 的复现断言用 KNOWN-BUG 标记：默认不影响退出码（便于 CI），
 # STRICT=1 时计入失败。bug 清单见 docs/testing/hook-workspace-docs-root.md。
+# 注意：本测试套件用 ${var@Q} 需 bash ≥ 4.4（仅开发侧；hook 本体兼容 bash 3.2）。
 
 set -euo pipefail
 
@@ -64,7 +65,7 @@ run_hook_path() {
     RC=0
     OUT="$( (cd "$dir" && env -u ROUNDTABLE_DOCS_ROOT -u CLAUDE_PLUGIN_ROOT \
         -u GIT_DIR -u GIT_WORK_TREE -u GIT_CEILING_DIRECTORIES \
-        PATH="$path" "$@" /usr/bin/bash "$HOOK") 2>"$ERR_FILE" )" || RC=$?
+        PATH="$path" "$@" "$BASH" "$HOOK") 2>"$ERR_FILE" )" || RC=$?
     ERR="$(cat "$ERR_FILE")"
 }
 
@@ -384,7 +385,7 @@ for b in git sed head basename dirname; do
     ln -s "$(command -v "$b")" "$FAKEBIN/$b"
 done
 # 守卫：确认该 PATH 下 python3 不可见
-if env PATH="$FAKEBIN" /usr/bin/bash -c 'command -v python3' >/dev/null 2>&1; then
+if env PATH="$FAKEBIN" "$BASH" -c 'command -v python3' >/dev/null 2>&1; then
     fail "D0 guard python3 hidden" "python3 still resolvable in FAKEBIN PATH"
 else
     pass "D0 guard python3 hidden"

--- a/tests/session-start.test.sh
+++ b/tests/session-start.test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # hooks/session-start 单元测试（slug: hook-workspace-docs-root, issue #127）。
 # 纯 bash harness：mktemp -d 造 fixture，python3 校验 JSON 与断言字段。
+# 注意：本测试套件用 ${var@Q} 需 bash ≥ 4.4（仅开发侧；hook 本体兼容 bash 3.2）。
 
 set -euo pipefail
 
@@ -249,6 +250,24 @@ if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
     assert_contains "T8 docs_root inside worktree" "$ctx" "docs_root: $t/wt/docs"$'\n'
 else
     json_fail "T8" "$out"
+fi
+
+# ---------- T9: symlink cwd 越界回归（MAJOR-1）：经 symlink 进入 repo，repo 无
+# docs/、父级有结构化 docs/ → 必须 needs-init，不得报父级（逻辑 cwd 与 git
+# rev-parse 物理路径不等会致 walk-up 边界失效） ----------
+t="$(new_tmp)"
+mkdir -p "$t/real/proj/src" "$t/real/docs/design-docs"
+git_init "$t/real/proj"
+ln -s "$t/real" "$t/link"
+out="$(run_hook "$t/link/proj")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T9"
+    assert_not_contains "T9 no parent escape (physical)" "$ctx" "$t/real/docs"
+    assert_not_contains "T9 no parent escape (symlinked)" "$ctx" "$t/link/docs"
+    assert_contains "T9 docs_root=<none>" "$ctx" $'docs_root: <none>\n'
+    assert_contains "T9 status=needs-init" "$ctx" $'status: needs-init\n'
+else
+    json_fail "T9" "$out"
 fi
 
 # ---------- 汇总 ----------

--- a/tests/session-start.test.sh
+++ b/tests/session-start.test.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# hooks/session-start 单元测试（slug: hook-workspace-docs-root, issue #127）。
+# 纯 bash harness：mktemp -d 造 fixture，python3 校验 JSON 与断言字段。
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/session-start"
+
+PASS=0
+FAIL=0
+TMP_DIRS=()
+
+cleanup() {
+    local d
+    for d in "${TMP_DIRS[@]:-}"; do
+        if [ -n "$d" ]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+# 造临时 fixture 目录（pwd -P 消除符号链接，避免与 git rev-parse 物理路径不一致）
+new_tmp() {
+    local d
+    d="$(cd "$(mktemp -d)" && pwd -P)"
+    TMP_DIRS+=("$d")
+    printf '%s' "$d"
+}
+
+# 在指定目录运行 hook；先清掉运行时 env 保证确定性，额外 KEY=VALUE 参数透传给 env
+run_hook() {
+    local dir="$1"
+    shift
+    (cd "$dir" && env -u ROUNDTABLE_DOCS_ROOT -u CLAUDE_PLUGIN_ROOT -u CURSOR_PLUGIN_ROOT -u COPILOT_CLI "$@" bash "$HOOK")
+}
+
+# DEC-1 校验：输出须为合法 JSON 且双键齐备、两份 context 一致；打印 context 文本。
+# 注意：调用方必须在父 shell 里用 json_ok / json_fail 计数（命令替换是子 shell）。
+get_ctx() {
+    python3 -c '
+import json, sys
+out = json.loads(sys.stdin.read())
+top = out["additionalContext"]
+hso = out["hookSpecificOutput"]
+assert hso["hookEventName"] == "SessionStart", "bad hookEventName"
+assert hso["additionalContext"] == top, "context mismatch between the two keys"
+sys.stdout.write(top)
+'
+}
+
+pass() {
+    PASS=$((PASS + 1))
+    printf 'ok   - %s\n' "$1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    printf 'FAIL - %s\n      %s\n' "$1" "$2"
+}
+
+json_ok() {
+    pass "$1 valid dual-key JSON"
+}
+
+json_fail() {
+    fail "$1 valid dual-key JSON" "raw output: ${2@Q}"
+}
+
+assert_contains() {
+    local name="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$name"
+    else
+        fail "$name" "expected to contain: ${needle@Q}; actual: ${haystack@Q}"
+    fi
+}
+
+assert_not_contains() {
+    local name="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        pass "$name"
+    else
+        fail "$name" "expected NOT to contain: ${needle@Q}; actual: ${haystack@Q}"
+    fi
+}
+
+git_init() {
+    git -C "$1" init -q
+}
+
+# ---------- T1: project 模式，walk-up 命中含结构的 docs/ ----------
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs/design-docs" "$t/repo/sub"
+git_init "$t/repo"
+out="$(run_hook "$t/repo/sub")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T1"
+    assert_contains "T1 mode=project" "$ctx" $'mode: project\n'
+    assert_contains "T1 docs_root" "$ctx" "docs_root: $t/repo/docs"$'\n'
+    assert_contains "T1 source=walk-up" "$ctx" $'docs_root_source: walk-up\n'
+    assert_contains "T1 project_id" "$ctx" $'project_id: repo\n'
+    assert_contains "T1 status=ok" "$ctx" "status: ok"
+else
+    json_fail "T1" "$out"
+fi
+
+# ---------- T2: 越界回归（#127 复现）：git 项目无 docs/，父级有 docs/ → 不越界 ----------
+t="$(new_tmp)"
+mkdir -p "$t/parent/docs/design-docs" "$t/parent/proj/src"
+git_init "$t/parent/proj"
+out="$(run_hook "$t/parent/proj")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T2"
+    assert_not_contains "T2 no parent escape" "$ctx" "$t/parent/docs"
+    assert_contains "T2 docs_root=<none>" "$ctx" $'docs_root: <none>\n'
+    assert_contains "T2 status=needs-init" "$ctx" $'status: needs-init\n'
+else
+    json_fail "T2" "$out"
+fi
+
+# ---------- T3: docs/ 存在但无结构 → needs-init 且 docs_root 仍报 ----------
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs"
+git_init "$t/repo"
+out="$(run_hook "$t/repo")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T3"
+    assert_contains "T3 docs_root reported" "$ctx" "docs_root: $t/repo/docs"$'\n'
+    assert_contains "T3 status=needs-init" "$ctx" $'status: needs-init\n'
+else
+    json_fail "T3" "$out"
+fi
+
+# ---------- T4a: env 有效 → source=env，显式配置不做结构校验 ----------
+t="$(new_tmp)"
+mkdir -p "$t/repo" "$t/ext-docs"
+git_init "$t/repo"
+out="$(run_hook "$t/repo" ROUNDTABLE_DOCS_ROOT="$t/ext-docs")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T4a"
+    assert_contains "T4a docs_root=env value" "$ctx" "docs_root: $t/ext-docs"$'\n'
+    assert_contains "T4a source=env" "$ctx" $'docs_root_source: env\n'
+    assert_contains "T4a status=ok" "$ctx" "status: ok"
+else
+    json_fail "T4a" "$out"
+fi
+
+# ---------- T4b: env 指向不存在目录 → warning + 降级走 walk-up ----------
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs/analyze"
+git_init "$t/repo"
+out="$(run_hook "$t/repo" ROUNDTABLE_DOCS_ROOT="$t/nonexistent")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T4b"
+    assert_contains "T4b warning emitted" "$ctx" "warning:"
+    assert_contains "T4b degraded to walk-up" "$ctx" "docs_root: $t/repo/docs"$'\n'
+    assert_contains "T4b source=walk-up" "$ctx" $'docs_root_source: walk-up\n'
+else
+    json_fail "T4b" "$out"
+fi
+
+# ---------- T5a: .roundtable.json 相对路径 → source=config（显式配置不做结构校验） ----------
+t="$(new_tmp)"
+mkdir -p "$t/repo/mydocs"
+git_init "$t/repo"
+printf '{"docs_root": "mydocs"}\n' > "$t/repo/.roundtable.json"
+out="$(run_hook "$t/repo")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T5a"
+    assert_contains "T5a docs_root resolved" "$ctx" "docs_root: $t/repo/mydocs"$'\n'
+    assert_contains "T5a source=config" "$ctx" $'docs_root_source: config\n'
+    assert_contains "T5a status=ok" "$ctx" "status: ok"
+else
+    json_fail "T5a" "$out"
+fi
+
+# ---------- T5b: .roundtable.json 绝对路径 + project_id 覆盖 ----------
+t="$(new_tmp)"
+mkdir -p "$t/repo" "$t/shared-docs"
+git_init "$t/repo"
+printf '{"docs_root": "%s", "project_id": "custom-id"}\n' "$t/shared-docs" > "$t/repo/.roundtable.json"
+out="$(run_hook "$t/repo")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T5b"
+    assert_contains "T5b absolute docs_root" "$ctx" "docs_root: $t/shared-docs"$'\n'
+    assert_contains "T5b source=config" "$ctx" $'docs_root_source: config\n'
+    assert_contains "T5b project_id override" "$ctx" $'project_id: custom-id\n'
+else
+    json_fail "T5b" "$out"
+fi
+
+# ---------- T5c: .roundtable.json 指向不存在目录 → warning + 继续走下一级 ----------
+t="$(new_tmp)"
+mkdir -p "$t/repo/docs/reviews"
+git_init "$t/repo"
+printf '{"docs_root": "gone"}\n' > "$t/repo/.roundtable.json"
+out="$(run_hook "$t/repo")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T5c"
+    assert_contains "T5c warning emitted" "$ctx" "warning:"
+    assert_contains "T5c degraded to walk-up" "$ctx" "docs_root: $t/repo/docs"$'\n'
+else
+    json_fail "T5c" "$out"
+fi
+
+# ---------- T6: workspace 模式：非 git 父级 + 2 个 git 子项目（一有 docs 一没有） ----------
+t="$(new_tmp)"
+mkdir -p "$t/ws/alpha/docs" "$t/ws/beta" "$t/ws/gamma"
+git_init "$t/ws/alpha"
+git_init "$t/ws/beta"
+out="$(run_hook "$t/ws")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T6"
+    assert_contains "T6 mode=workspace" "$ctx" $'mode: workspace\n'
+    assert_contains "T6 workspace_root" "$ctx" "workspace_root: $t/ws"$'\n'
+    assert_contains "T6 project list" "$ctx" "projects: alpha (docs), beta"
+    assert_not_contains "T6 non-git dir excluded" "$ctx" "gamma"
+    assert_contains "T6 status=ok" "$ctx" $'status: ok\n'
+else
+    json_fail "T6" "$out"
+fi
+
+# ---------- T7: 非 git 且无子项目 → needs-init ----------
+t="$(new_tmp)"
+mkdir -p "$t/empty"
+out="$(run_hook "$t/empty")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T7"
+    assert_contains "T7 status=needs-init" "$ctx" $'status: needs-init\n'
+    assert_contains "T7 docs_root=<none>" "$ctx" $'docs_root: <none>\n'
+else
+    json_fail "T7" "$out"
+fi
+
+# ---------- T8: git worktree → project_id = 主仓名 ----------
+t="$(new_tmp)"
+mkdir -p "$t/main/docs/analyze"
+git_init "$t/main"
+touch "$t/main/docs/analyze/seed.md"
+git -C "$t/main" add -A
+git -C "$t/main" -c user.email=t@t -c user.name=t commit -q -m init
+git -C "$t/main" worktree add -q "$t/wt" -b test-wt
+out="$(run_hook "$t/wt")"
+if ctx="$(get_ctx <<<"$out" 2>/dev/null)"; then
+    json_ok "T8"
+    assert_contains "T8 project_id=main repo name" "$ctx" $'project_id: main\n'
+    assert_contains "T8 docs_root inside worktree" "$ctx" "docs_root: $t/wt/docs"$'\n'
+else
+    json_fail "T8" "$out"
+fi
+
+# ---------- 汇总 ----------
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
Closes #127

## 改动

**hook 重写（hooks/session-start，60→约 230 行）**
- **project 模式**：解析链 `ROUNDTABLE_DOCS_ROOT` env（相对路径归一化、无效报 warning 降级）→ `<git_top>/.roundtable.json`（`docs_root`/`project_id` 两键，python3 解析 + sed fallback）→ 以 git_top 为界的 walk-up（带 6 目录/INDEX.md 结构校验）
- **workspace 模式**（新增）：cwd 不在 git repo 时扫一层子目录注入 git 子项目清单，docs_root 由 skills 按任务目标子项目延迟解析——支持在多项目父级目录启动会话的场景
- **worktree-safe project_id**：git-common-dir 回推主仓名
- **双键 JSON 输出**：单条同时含 `additionalContext` + `hookSpecificOutput`，删除无事实来源的 `CURSOR_PLUGIN_ROOT`/`COPILOT_CLI` env 探测分支
- 健壮性：`unset GIT_DIR GIT_WORK_TREE` 防 env 污染、`pwd -P` 物理路径（symlink 场景边界）、C0 控制字符全量转义、cwd 被删优雅降级

**skills 配套**：workflow Step 1 canonical workspace 解析规则；bugfix/lint 引用；README/README-zh/CHANGELOG 同步

**测试**：tests/ 新增两套（单测 49 断言 + 对抗 301 断言，全绿；shellcheck 零告警）

## 流程

analysis（docs/reviews/2026-06-12-comprehensive-review.md）→ exec-plan（confirmed）→ developer → tester（发现 GIT_DIR 污染等 3 项，已修）→ reviewer（NEEDS-CHANGES：symlink 越界回归等 4 项，已修）→ re-review **CLEAN-WITH-NOTES**

修复了线上实际发生的 codex 误报（`project_id: pm` + `docs_root: /home/ubuntu/docs`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)