### PR TITLE
fix(workflow): 流程一致性 — exec-plan 生命周期统一 + bugfix mini exec-plan + NEED-DECISION canonical 化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to **roundtable** will be documented in this file.
 
 ### Changed
 
+- exec-plan lifecycle single owner (#129): only the orchestrator moves an exec-plan from `active/` to `completed/`, at closeout (after `go-commit` / `go-all`). Removed `agents/developer.md` step 5 (developer self-move) and the "user moves it" wording in the plugin `CLAUDE.md`; `bugfix` closeout now states the same rule.
+- `bugfix` Step 3.5 (#129): writes a mini exec-plan (`<docs_root>/exec-plans/active/<slug>.md` — frontmatter + `## Solution` + checkboxes + `## Change Log`) for every tier; Step 4 dispatches developer with that path, so developer's exec-plan input holds in both workflows.
+- `[NEED-DECISION]` relay rule (#129): canonicalized in `skills/workflow/SKILL.md` Step 4; `bugfix` and the plugin `CLAUDE.md` now reference it instead of restating (drops the narrower "calls `AskUserQuestion`" wording).
+- workflow Step 4 (#129): reviewer (phase 8) dispatch must include the diff scope (git range or file list), matching `agents/reviewer.md` required inputs.
 - `hooks/session-start` output protocol: unconditionally emits one JSON line with **both** `additionalContext` and `hookSpecificOutput.additionalContext`; all runtime env-sniffing branches (`CURSOR_PLUGIN_ROOT` / `COPILOT_CLI`) removed. `hooks/hooks.json` drops the non-standard `"async"` field.
 
 ## [0.0.7-rc3] - 2026-06-02

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Inherit the four baselines from the parent CLAUDE.md at the workspace root: Thin
 
 Specific to this repo:
 - **Two artifacts per task** (medium / large): architect first writes a design-doc (problem + solution + decisions, iterates with user), then writes an exec-plan (steps + verification, stable after design confirm). Small tasks combine both into a single exec-plan with a `## Solution` section.
-- Subagents return short markdown summaries. If they need a decision, they print one line: `[NEED-DECISION] <topic> | options: A) <…> B) <…>`. The orchestrator parses it and calls `AskUserQuestion`.
+- Subagents return short markdown summaries. If they need a decision, they print one line: `[NEED-DECISION] <topic> | options: A) <…> B) <…>`. The orchestrator relays it per the canonical NEED-DECISION relay rule in `skills/workflow/SKILL.md` Step 4.
 - Channel-aware user prompts: if the telegram MCP server is loaded, skills + orchestrator post questions via TG `reply` (`a) … b) …` text protocol) and wait for a text reply; otherwise they call `AskUserQuestion`. The workflow orchestrator also broadcasts phase transitions to TG when the MCP is present (use `edit_message` for in-phase updates, new `reply` for phase completion so the device push-notifies).
 
 ## Toolchain
@@ -38,4 +38,4 @@ Specific to this repo:
 - New `.md` user-facing docs go under one of the 7 dirs above. `lint` will discover them and add to `INDEX.md`. Don't hand-edit INDEX.md.
 - One slug per task, kebab-case English (`user-auth`, `payment-idempotency`). The slug links design-doc → exec-plan → analyze → tests → reviews.
 - exec-plan frontmatter must include `source: design-docs/<slug>.md` when a design-doc exists, so reviewer / dba / lint can resolve the linkage.
-- When all checkboxes are ticked or an exec-plan is idle >30 days, lint suggests moving it from `active/` to `completed/`. The user moves it; lint never moves files.
+- When all checkboxes are ticked or an exec-plan is idle >30 days, lint suggests moving it from `active/` to `completed/`. The orchestrator moves it at closeout (only after `go-commit` / `go-all` — see `skills/workflow/SKILL.md` Step 5); lint never moves files.

--- a/agents/developer.md
+++ b/agents/developer.md
@@ -25,8 +25,7 @@ Implement what the exec-plan says. Write unit tests. Tick exec-plan checkboxes. 
 1. Read exec-plan end-to-end. If `source:` points to a design-doc, read it for context. Pick the next unchecked step.
 2. Write a failing test first when behavior is non-trivial; then implement.
 3. Run lint + tests. Use `lint_cmd` / `test_cmd` from project CLAUDE.md if declared. Otherwise auto-detect: Rust→`cargo clippy`+`cargo test`, JS/TS→`pnpm lint`+`pnpm test`, Python→`ruff check`+`pytest`, Go→`go vet`+`go test`.
-4. Tick the exec-plan checkbox.
-5. When all steps done, move the exec-plan from `active/` to `completed/`.
+4. Tick the exec-plan checkbox. Your responsibility ends at ticking checkboxes — the orchestrator moves the exec-plan to `completed/` at closeout.
 
 ## When you need a decision
 

--- a/docs/exec-plans/completed/process-consistency.md
+++ b/docs/exec-plans/completed/process-consistency.md
@@ -1,0 +1,65 @@
+---
+slug: process-consistency
+date: 2026-06-12
+status: active
+analysis: ../../reviews/2026-06-12-comprehensive-review.md
+issue: 129
+---
+
+# 流程一致性：exec-plan 生命周期 / bugfix mini exec-plan / NEED-DECISION canonical 化
+
+## Solution（PR-2，user 已确认按 PR-1 同流程执行）
+
+来源：[2026-06-12 全面审查报告](../../reviews/2026-06-12-comprehensive-review.md) 问题 2.1 / 2.2 / 2.3 / 2.7。纯 prompt/文档改动，无可执行代码。
+
+## 设计决策（已定，不要重开）
+
+- **DEC-1 exec-plan 生命周期单一 owner = orchestrator**：exec-plan 从 `active/` 移到 `completed/` 只由 orchestrator 在 closeout（workflow 的 `go-commit`/`go-all` 之后；bugfix 的 closeout）执行。
+  - `agents/developer.md:29` 第 5 步（developer 自己移动）删除，developer 职责止于勾完 checkbox
+  - 插件 `CLAUDE.md:41`「The user moves it」改为 orchestrator 在 closeout 移动；保留「lint never moves files」
+  - `skills/workflow/SKILL.md:139,155` 既有表述为准绳（canonical），如措辞需要可微调使三处口径一字不差地兼容
+- **DEC-2 bugfix 产 mini exec-plan**：`skills/bugfix/SKILL.md` 在 Step 3（tier 判定）与 Step 4（派 developer）之间新增 Step 3.5：orchestrator 写 `<docs_root>/exec-plans/active/<slug>.md`，内容最小化——frontmatter（slug/issue/tier，无 design-doc 故无 `source:`）+ `## Solution`（根因一句话 + 修法一句话）+ checkbox（至少 3 项：复现/回归测试、修复、验证）+ `## Change Log`。所有 tier 都写（与根工作流「小任务也写 exec-plan」对齐；tier 0 就是 4-5 行的事）。Step 4 派 developer 的参数改为传该 exec-plan path（消除 `agents/developer.md` 输入强依赖 exec-plan 与 bugfix 不产 exec-plan 的断裂）；closeout 按 DEC-1 移动。`skills/bugfix/references/codex-tools.md:9,16` 的 exec-plan 表述随之变为属实，核对无需改则不改。
+- **DEC-3 NEED-DECISION canonical 化**：`skills/workflow/SKILL.md:90` 已是最全表述（channel-aware 提问 + 答案落 exec-plan `## Change Log` + 续派同一角色），指定为 canonical：
+  - 该段落加显式标记（如 "(canonical NEED-DECISION relay rule)"）
+  - `skills/bugfix/SKILL.md:46` 改为一行引用 canonical 规则（bugfix 现在有 mini exec-plan，Change Log 落点成立）
+  - 插件 `CLAUDE.md:27` 缩成指针（协议细节见 workflow Step 5），删除「calls AskUserQuestion」的过窄表述
+  - `agents/*.md` 与 `references/codex-tools.md` 中只描述「子 agent 怎么打印 NEED-DECISION 行」的内容不动（那是子 agent 侧协议，无矛盾）
+- **DEC-4 reviewer 派发参数补 diff**：`skills/workflow/SKILL.md` phase 8 派 reviewer 的参数列表补「diff 范围（git range 或文件清单）」，与 `agents/reviewer.md:16` 的输入要求对齐。顺带核对 tester（phase 7）派发参数与 `agents/tester.md` 输入要求是否同样缺项，缺则一并补。
+- **DEC-5 范围外**：文档债（CLAUDE.md 的 2 skills 计数、CONTRIBUTING 死链等）归 PR-3；codex-tools 去重归 0.0.8；不动 hooks/、tests/ 下任何文件。
+
+## Phases
+
+### Phase 1: exec-plan 生命周期统一（DEC-1）
+
+- [x] 1.1 `agents/developer.md` 删第 5 步，确认无残余「developer 移动 exec-plan」表述
+- [x] 1.2 插件 `CLAUDE.md` Conventions 末条改为 orchestrator-at-closeout 口径
+- [x] 1.3 `skills/workflow/SKILL.md` 两处表述核对，必要时统一措辞
+
+### Phase 2: bugfix mini exec-plan（DEC-2）
+
+- [x] 2.1 `skills/bugfix/SKILL.md` 新增 Step 3.5（mini exec-plan 模板内联在该 step 里）
+- [x] 2.2 Step 4 派发参数改传 exec-plan path；Step 5/closeout 按 DEC-1 移动
+- [x] 2.3 `agents/developer.md` 输入段核对：bugfix 与 workflow 两来源现在都有 exec-plan path，消除歧义表述
+- [x] 2.4 `skills/bugfix/references/codex-tools.md` 核对（预期不改）
+
+### Phase 3: NEED-DECISION canonical（DEC-3）+ 派发参数（DEC-4）
+
+- [x] 3.1 workflow SKILL.md:90 段加 canonical 标记
+- [x] 3.2 bugfix SKILL.md:46 改引用
+- [x] 3.3 插件 CLAUDE.md:27 缩指针
+- [x] 3.4 workflow phase 8 派 reviewer 参数补 diff 范围；phase 7 tester 参数核对补齐
+
+### Phase 4: 自查
+
+- [x] 4.1 grep 验证：全仓不再存在「developer/user 移动 exec-plan」「orchestrator parses it and calls AskUserQuestion」类矛盾表述；CHANGELOG [Unreleased] 加条目
+
+## Verification
+
+- `grep -rn "move the exec-plan\|moves it" agents/ skills/ CLAUDE.md commands/` 输出全部指向 orchestrator-at-closeout 单一口径
+- bugfix SKILL 通读：Step 3.5 → Step 4 → closeout 链路完整，developer 输入不再有无源依赖
+- NEED-DECISION：canonical 标记唯一，bugfix/CLAUDE.md 均为引用
+
+## Change Log
+
+- 2026-06-12 user 确认 PR-2 按 PR-1 同流程执行
+- 2026-06-12 tester 复核（docs/testing/process-consistency.md）后修复：F1 `skills/workflow/SKILL.md:140` Path A handoff 末行改为 orchestrator-at-closeout 口径（下一个 orchestrator 会话在 closeout 移动，不再指示 user 移动）；F4 `skills/bugfix/SKILL.md` Step 4 派发参数补 `docs_root` + slug，对齐 workflow Step 4 与 agents/developer.md 输入要求。F2/F3/F5/F6 不修（PR-3 文档债 / 已知问题 1.6 / info）。

--- a/docs/reviews/2026-06-12-process-consistency.md
+++ b/docs/reviews/2026-06-12-process-consistency.md
@@ -1,0 +1,76 @@
+---
+slug: process-consistency
+date: 2026-06-12
+issue: 129
+scope: PR-2 代码审查（git diff main...HEAD，3 commits：308081c / 848dc12 / cfc9771）
+---
+
+# process-consistency — Review (2026-06-12)
+
+对象：纯 prompt/markdown 改动，7 文件（含 tester 报告），对照 exec-plan DEC-1~DEC-5 与 tester 发现项 F1~F6 处置。
+
+## Critical
+
+（无）
+
+## Warning
+
+- `skills/workflow/SKILL.md:140` — F1 修复消除了字面矛盾（不再指示 user 移动），但新承诺「the next orchestrator session moves it to completed/ at closeout」在全 prompt 图中**没有执行者指令**：workflow Step 5（:156）与 bugfix Step 7（:99）都只指示移动**当前任务**的 exec-plan，且 gate 在当前任务自己的 `go-commit`/`go-all` 上；没有任何 Step 指示后续 orchestrator 会话在 closeout 时清扫 active/ 下遗留的 fully-ticked exec-plan（lint :53-54 只 suggest，CLAUDE.md:41 明确 lint never moves）。Path A 任务永远不会发出自己的 `go-commit`/`go-all`，因此其 exec-plan 只能搭**别的任务**的 closeout 顺风车——与 CLAUDE.md:41 的全称限定「(only after go-commit/go-all)」勉强自洽（gate 属于另一个任务），但这层搭车语义无任何文字背书；若 user 此后不再跑 workflow，文件无限期滞留 active/。→ 建议一行修复：`skills/workflow/SKILL.md:156` 末尾补「at closeout, also move any leftover fully-ticked exec-plans in active/ (e.g. from a prior Path A handoff)」，bugfix Step 7 经「Same as workflow Step 5」自动继承。可本 PR 内改，也可随 PR-3 收口。
+
+## Suggestion
+
+- `skills/bugfix/SKILL.md:43` — mini exec-plan frontmatter 固化 `tier:`，而 developer 被禁改 exec-plan body（`agents/developer.md:39`），diff 后 tier 实际升级时无步骤指定 orchestrator 回写；Step 6 postmortem 触发依赖 `tier == 2`。即 tester F3，处置（归已知问题 1.6）合理，建议 1.6 修复时把 frontmatter 回写责任明确给 orchestrator。
+- `skills/bugfix/SKILL.md:61-71` — Step 4 的 runtime bullet 与参数 bullet 之间隔空行，渲染为两个独立列表，参数列表与 Claude Code 路径的从属关系靠推断；本 PR 在该列表追加了承重的 exec-plan path 三项，使既有结构性歧义负担加重（tester F5 定 pre-existing/info，成立）。建议 0.0.8 合并为单一 "with:" 引导列表。
+- `docs/usage.md:92,154`、`docs/roundtable.md:85` — CLAUDE.md:27 canonical 化后，这三处成为非 _archive 文档中仅存的窄口径「grep 后调 AskUserQuestion」（缺 channel-aware 分支）。矛盾相对 workflow:91 pre-existing，按 DEC-5 归 PR-3 文档债正确；备案确保 PR-3 范围包含这三行（tester F2 已记录）。
+- `skills/workflow/SKILL.md:156` / `skills/bugfix/SKILL.md:99` — 移动发生在 `go-commit` 之后，意味着 commit 进库的是 active/ 路径、移动产生一次未提交 rename。Pre-existing 模式（workflow :156 本 PR 未动，bugfix 仅如实镜像），不要求本 PR 处理，记录备查。
+
+## 审查维度核验
+
+### 1. DEC 符合度
+
+- **DEC-1** ✅：`agents/developer.md` 第 5 步已删，:28 改 orchestrator-at-closeout；`CLAUDE.md:41` 改口径且保留 lint never moves；workflow :140/:156 与 bugfix :99 三处口径兼容（:140 残留即 tester F1，已在 cfc9771 修复，残余执行者缺口见 Warning）。全仓 grep `completed/` 无 developer/user-move 残留。
+- **DEC-2** ✅：Step 3.5 模板含 frontmatter（slug/issue/tier，无 source:）+ Solution + 3 checkbox + Change Log，全 tier 适用；Step 4 改传 exec-plan path；`codex-tools.md:25` message 同步加 `exec-plan:` 行（Step 4 参数的 Codex 具体化，可追溯）；codex-tools :9,16 未改（核对属实，符合「无需改则不改」）。
+- **DEC-3** ✅：canonical 全量表述唯一（workflow:91，带显式标记且反向声明引用方）；`CLAUDE.md:27` 与 `bugfix:73` 均为引用式，「calls AskUserQuestion」窄表述已删；`agents/*.md` 子 agent 侧打印协议（developer:33,35 / tester:40 / reviewer:55 / dba:47）按设计未动；两个 codex-tools relay 节为 runtime 工具映射，语义与 canonical 一致（Change Log 落点 + 续派同角色齐备）。
+- **DEC-4** ✅：workflow:89 补 reviewer diff 范围，对齐 `agents/reviewer.md:16`；tester 输入（exec-plan path + docs_root，`agents/tester.md:13-14`）被 :88 通用参数覆盖，「无缺项不补」结论正确。
+- **DEC-5** ✅：diff 未触 hooks/、tests/、CONTRIBUTING、README 双语、CLAUDE.md Layout 计数（"2 skills" 旧账留给 PR-3，未夹带）。
+
+### 2. F1 修复质量（Path A 语境）
+
+方向正确：Path A 渲染 payload 时工作未 merge，exec-plan 留 active/ 是对的语义；新表述从「给 user 的指令」改为「状态陈述 + lint 兜底」，与 CLAUDE.md:41 单一 owner 不再字面冲突。但「下一个 orchestrator 会话执行」缺指令背书 → 见 Warning（一行可补）。
+
+### 3. 引用图完整性（逐一打开目标核对）
+
+| 引用 | 目标 | 结果 |
+|---|---|---|
+| `CLAUDE.md:27` → workflow Step 4 | `skills/workflow/SKILL.md:91`（位于 `## Step 4` :64 内） | ✅ |
+| `CLAUDE.md:41` → workflow Step 5 | :94/:156 | ✅ |
+| `bugfix:15` → workflow Step 1 canonical workspace rule | :18（自带 canonical 声明） | ✅ 未受本 PR 影响 |
+| `bugfix:17` → workflow Step 2 channel broadcast | :33-40 | ✅ |
+| `bugfix:73` → workflow Step 4 canonical relay | :91 | ✅ |
+| `bugfix:99` → workflow Step 5 | :94-156 | ✅ |
+| `workflow:89` → `agents/reviewer.md` inputs | reviewer.md:16 | ✅ |
+
+canonical NEED-DECISION 标记全仓唯一（workflow:91）；commands/*.md 均 thin wrapper 无独立口径。
+
+### 4. mini exec-plan 走查（tier 0 字面执行）
+
+Step 1（docs_root+slug，经 workflow Step 1 canonical 规则）→ Step 2（root cause 在此产出，Step 3.5 的一句话有来源）→ Step 3（tier 0）→ Step 3.5（写文件，前置全齐）→ Step 4（path/docs_root/slug/tier 全传，覆盖 `agents/developer.md:13-15` 全部输入）→ developer 按 3 checkbox 顺序（失败测试先行与 developer.md:26 吻合）→ Step 5 verify → Step 6 跳过 → Step 7 closeout 移动。**无死路**。lint 兼容（fully-checked :54 / stale :53 / INDEX slug+H1）成立；tier 回写缺口见 Suggestion 第 1 条。
+
+### 5. 二阶矛盾（改动句 vs 未改文件）
+
+- `README.md:81` / `README-zh.md:81`：NEED-DECISION 描述为泛化措辞（不点名 AskUserQuestion），与新口径无新矛盾 ✅
+- `agents/tester.md` / `reviewer.md` / `dba.md`：仅子 agent 侧打印协议，无 lifecycle/relay 口径 ✅
+- `AGENTS.md`、commands/：无相关表述 ✅
+- 仅存旧口径：`docs/usage.md` / `docs/roundtable.md`（pre-existing，PR-3 范畴，见 Suggestion 第 3 条）
+
+### 6. Surgical Changes 逐 hunk 溯源
+
+CHANGELOG 4 条目→Phase 4.1；CLAUDE.md:27→DEC-3；:41→DEC-1；developer.md:28→DEC-1；bugfix Step 3.5→DEC-2；Step 4 exec-plan path→DEC-2、docs_root/slug→F4；:73→DEC-3；:99→DEC-1/2.2；codex-tools:25→DEC-2；workflow:89→DEC-4；:91→DEC-3；:140→F1；docs/testing/→tester 产物（848dc12）。**全部可追溯，无夹带行**。CHANGELOG↔diff 对账与 tester 报告一致。
+
+### tester 发现项处置复核
+
+F1 修复 ✅（残余缺口降级为本报告 Warning）· F4 修复 ✅（参数对齐 workflow:88 与 developer.md 输入）· F2/F3/F5/F6 不修的理由（PR-3 / 已知 1.6 / pre-existing / 风格）均成立，且已回写 exec-plan Change Log ✅。
+
+## Verdict
+
+**CLEAN-WITH-NOTES**（can-merge）— 0 Critical · 1 Warning（workflow:140 承诺缺执行者指令，一行可补，可本 PR 顺手或 PR-3 收口）· 4 Suggestion（均 pre-existing / PR-3 / 已知问题范畴）。

--- a/docs/testing/process-consistency.md
+++ b/docs/testing/process-consistency.md
@@ -1,0 +1,93 @@
+---
+slug: process-consistency
+date: 2026-06-12
+issue: 129
+scope: 对抗核查（一致性与可执行性），非自动化测试
+---
+
+# process-consistency — Test Plan
+
+对象：PR-2（`308081c`，`feat/process-consistency-botB`，`git diff main...HEAD` 共 6 文件，纯 prompt/markdown）。
+方法：步骤引用逐一比对 + 三视角角色走查（workflow orchestrator / bugfix orchestrator / developer subagent）+ 全仓 grep 矩阵 + CHANGELOG↔diff 对账。
+
+## Coverage
+
+### 1. 步骤编号引用核对（4/4 通过）
+
+| 引用处 | 声称 | 实际 | 结论 |
+|---|---|---|---|
+| `CLAUDE.md:27` → workflow SKILL.md Step 4 | canonical NEED-DECISION relay | `skills/workflow/SKILL.md:91`，位于 `## Step 4: Run phases`（line 64） | ✅ |
+| `CLAUDE.md:41` → workflow SKILL.md Step 5 | closeout/go-commit 移动规则 | `skills/workflow/SKILL.md:156`，位于 `## Step 5: Closeout`（line 94） | ✅ |
+| `skills/bugfix/SKILL.md:71` → workflow Step 4 | canonical NEED-DECISION relay | 同上 line 91 | ✅ |
+| `skills/bugfix/SKILL.md:97` → workflow Step 5 | closeout 渲染 + go-* 等待 | 同上 line 94-156 | ✅ |
+
+### 2. canonical 唯一性
+
+- 全量表述唯一：`skills/workflow/SKILL.md:91`（带 "(canonical NEED-DECISION relay rule — `bugfix` and the plugin CLAUDE.md reference it)" 标记）。
+- 引用式：`CLAUDE.md:27`、`skills/bugfix/SKILL.md:71` ✅。
+- 子 agent 侧打印协议（`agents/developer.md:33`、`tester.md:40`、`reviewer.md:55`、`dba.md:47`）按 DEC-3 未动 ✅。
+- `skills/*/references/codex-tools.md` 仅作 runtime 工具映射（含 Change Log 落点 + 续派，workflow references:50 与 canonical 语义一致）✅。
+
+### 3. DEC-1/2/4 实施核对
+
+- DEC-1：`agents/developer.md` 第 5 步已删，line 28 改为 orchestrator-at-closeout，无残余 developer-move 表述 ✅；`CLAUDE.md:41` 改 orchestrator 口径且保留 lint never moves ✅。
+- DEC-2：Step 3.5 模板与根 CLAUDE.md 约定兼容 —— slug ✅ / 无 design-doc 故无 `source:` ✅（根 CLAUDE.md「小任务无 design-doc 则省」）/ `## Change Log` 存在（NEED-DECISION 答案落点成立）✅ / ≥3 checkbox ✅。`codex-tools.md:25` message 已加 `exec-plan:` 行，路径与 Step 3.5 一致 ✅；codex-tools 表格 :9,16 表述现属实（核对未改，符合 DEC-2 预期）✅。
+- DEC-4：`skills/workflow/SKILL.md:89` 已补 reviewer diff 范围，对齐 `agents/reviewer.md:16` ✅；tester 输入（exec-plan path + docs_root，`agents/tester.md:13-14`）已被通用派发参数（SKILL.md:88：exec-plan path / docs_root / slug / design-doc）覆盖，「无缺项不补」结论正确 ✅。
+
+### 4. lint 对 mini exec-plan 的兼容
+
+- fully-checked 判定（`skills/lint/SKILL.md:54`）：基于 `- [ ]`→`- [x]`，模板 3 个 checkbox 兼容 ✅。
+- stale 判定（lint:53）：基于 `git log -1 --format=%cs`，不依赖 frontmatter `date:`，模板无 date 字段无影响 ✅。
+- INDEX 重建（lint:31）：读 `slug` + 首个 H1，模板均有 ✅；无 `source:` 不触发断链 Critical ✅。
+
+### 5. 全仓 grep 矩阵（move/completed · NEED-DECISION · AskUserQuestion · exec-plan path）
+
+- `agents/` `skills/` `commands/` `CLAUDE.md` `AGENTS.md` `README*.md`：除下述 Found Bugs F1 外，全部为 orchestrator-at-closeout / canonical-引用单一口径。`commands/*.md` 均为 thin wrapper 无独立口径。
+- `CHANGELOG.md:108,128` 旧口径属历史版本记录，允许。
+- `docs/`：`pre.md` / `case-study-rewrite.md` 为历史记录，允许；`usage.md` / `roundtable.md` 见 F2。
+
+### 6. CHANGELOG ↔ diff 对账（一一对应 ✅）
+
+| CHANGELOG [Unreleased] 条目 | 对应 diff 文件 |
+|---|---|
+| exec-plan lifecycle single owner | `agents/developer.md`、`CLAUDE.md:41`、`skills/bugfix/SKILL.md:97` |
+| bugfix Step 3.5 mini exec-plan | `skills/bugfix/SKILL.md:35-57,66`、`skills/bugfix/references/codex-tools.md:25` |
+| NEED-DECISION canonicalized | `skills/workflow/SKILL.md:91`、`skills/bugfix/SKILL.md:71`、`CLAUDE.md:27` |
+| reviewer dispatch diff scope | `skills/workflow/SKILL.md:89` |
+
+6 个 diff 文件全部被 4 条覆盖，无漏报、无虚报条目。
+
+## New Cases (Adversarial / E2E / Benchmark)
+
+三视角字面走查：
+
+- **workflow orchestrator**：Step 1→5 链路无死路；Step 4 新增 reviewer diff 行位置正确（派发 bullet list 内）；NEED-DECISION 行自洽。
+- **bugfix orchestrator**：Step 1（docs_root 经 workflow Step 1 canonical 规则解析）→ Step 3.5（此时 docs_root 已解析，写文件不缺前置）→ Step 4（exec-plan path 来源明确）→ Step 7（移动条件与 workflow Step 5 一字不差）链路完整。
+- **developer subagent**：bugfix 与 workflow 两来源现在都传 exec-plan path，`agents/developer.md:13` 输入依赖在两条流程下均成立；step 4 止于勾 checkbox，与两 orchestrator closeout 口径无冲突。
+
+## Found Bugs / Gaps
+
+无 Blocker。按严重度：
+
+### Major
+
+- **F1** `skills/workflow/SKILL.md:140` — Path A handoff payload 末行 "Move the exec-plan to completed/ after the App finishes the branch / PR." 残留非单一 owner 口径：Path A 无 `go-commit`/`go-all`（sandbox-blocked，跳过 4-option menu），该句是渲染给 user 的指令，即 "user moves it" 在 Codex App detached-HEAD 路径下幸存；与 `CLAUDE.md:41` "(only after `go-commit` / `go-all`)" 的全称限定矛盾，exec-plan Phase 4.1「全仓不再存在 developer/user 移动 exec-plan 表述」的自查结论对该行不成立。溯源：DEC-1 把旧 SKILL.md:139（即此行）列为「既有表述为准绳」，设计输入本身未察觉该行就是 user-move 口径，实施如实沿袭——属设计盲点而非实施错误。修法建议（二选一，PR-2 内一行可改）：A) 改为 "The orchestrator moves the exec-plan to completed/ once the App finishes the branch / PR (Path A's closeout equivalent)"；B) 在 CLAUDE.md:41 的括号限定中补 Path A 例外。
+
+### Minor
+
+- **F2** `docs/usage.md:92,154`、`docs/roundtable.md:85` — 现行规范类文档（非 _archive）仍是窄口径「主会话 grep 后调 AskUserQuestion」，缺 channel-aware 分支，与 canonical 规则（workflow:91）不一致。usage.md:154 至少含 Change Log 落点，roundtable.md:85 同；usage.md:92 连落点都无。属 DEC-5 划给 PR-3 的文档债范畴，但 exec-plan 4.1 的「全仓」措辞与 Verification grep 范围（仅 agents/skills/CLAUDE.md/commands）不一致，记录备案，建议 PR-3 收口时一并改。
+- **F3** `skills/bugfix/SKILL.md:43` — Step 3.5 模板把 `tier:` 固化进 frontmatter，而 tier 判定（Step 3，LOC = `git diff --numstat`）发生在 developer 产生 diff **之前**（审查报告已知问题 1.6，范围外）；新增风险点：developer 被禁改 exec-plan body（`agents/developer.md:39`），diff 后 tier 实际升级（如 >80 LOC 或 critical hit）时无任何步骤指示 orchestrator 回写 frontmatter，而 Step 6 postmortem 触发依赖 `tier == 2`。已知问题被模板轻微固化，建议 1.6 修复时（预估 tier + 返回后复核）同步规定 frontmatter 回写责任归 orchestrator。
+- **F4** `skills/bugfix/SKILL.md:66-69` — Step 4 参数列表未列 `docs_root` / `slug`，而 `agents/developer.md:15` 输入需要 docs_root；Codex 路径由 `codex-tools.md:25` 显式传入兜底，Claude Code 路径靠 SessionStart hook 注入兜底，可运行但与 workflow Step 4（line 88 显式列 docs_root+slug）口径不一。
+
+### Info
+
+- **F5** `skills/bugfix/SKILL.md:63-69` — Step 4 两个 runtime bullet 与参数 bullet list 之间隔空行，Markdown 渲染为两个独立列表，参数列表与 Claude Code bullet 的从属关系靠读者推断。Pre-existing 结构，本 PR 仅追加一项，不计入本 PR 问题。
+- **F6** mini exec-plan 模板无 `date:` / `status:` 字段（本仓自身 exec-plan 均有）；lint 与根 CLAUDE.md 均不强制，无实际影响，仅风格不一。
+
+## Stats
+
+- 步骤引用核对：4/4 通过
+- DEC 实施核对：DEC-1 ✅（除 F1 边缘残留）· DEC-2 ✅ · DEC-3 ✅ · DEC-4 ✅ · DEC-5 边界遵守 ✅（未动 hooks/、tests/）
+- grep 矩阵：4 维度 × 全仓，残余 2 处（F1 in-scope 边缘、F2 PR-3 范畴）
+- CHANGELOG 对账：4 条 ↔ 6 文件，一一对应
+- 结论：**无 Blocker**；1 Major（F1，一行可修）+ 3 Minor + 2 Info

--- a/skills/bugfix/SKILL.md
+++ b/skills/bugfix/SKILL.md
@@ -64,6 +64,8 @@ Dispatch developer:
 - Codex: read `agents/developer.md`, then call `spawn_agent` with `agent_type: "worker"` and a `message` containing that role prompt plus:
 
 - exec-plan path (`<docs_root>/exec-plans/active/<slug>.md`, from Step 3.5)
+- `docs_root`
+- slug
 - bug description + root-cause analysis
 - tier (0 / 1 / 2)
 - explicit instruction: **must add a regression test**; do not refactor unrelated code

--- a/skills/bugfix/SKILL.md
+++ b/skills/bugfix/SKILL.md
@@ -32,6 +32,30 @@ SessionStart hook may inject `docs_root` + `project_id`. If the context shows `m
 
 LOC = `git diff --numstat` insertions + deletions. If unclear, ask the user.
 
+## Step 3.5: Write the mini exec-plan
+
+Write `<docs_root>/exec-plans/active/<slug>.md` for **every** tier (tier 0 included — it's a 4-5 line file). Keep it minimal; no design-doc exists, so no `source:` in the frontmatter:
+
+```
+---
+slug: <slug>
+issue: <N, if any>
+tier: <0|1|2>
+---
+
+# <slug>
+
+## Solution
+
+Root cause: <one line>. Fix: <one line>.
+
+- [ ] Reproduction / regression test
+- [ ] Fix
+- [ ] Verify (lint + tests pass)
+
+## Change Log
+```
+
 ## Step 4: Dispatch developer
 
 Dispatch developer:
@@ -39,11 +63,12 @@ Dispatch developer:
 - Claude Code: `Agent(subagent_type: "roundtable:developer", ...)`
 - Codex: read `agents/developer.md`, then call `spawn_agent` with `agent_type: "worker"` and a `message` containing that role prompt plus:
 
+- exec-plan path (`<docs_root>/exec-plans/active/<slug>.md`, from Step 3.5)
 - bug description + root-cause analysis
 - tier (0 / 1 / 2)
 - explicit instruction: **must add a regression test**; do not refactor unrelated code
 
-If developer returns `[NEED-DECISION]`, ask with the runtime's user-question tool and re-dispatch.
+If developer returns `[NEED-DECISION]`, follow the canonical NEED-DECISION relay rule in `/roundtable:workflow` Step 4: channel-aware ask, append the answer to the exec-plan's `## Change Log`, re-dispatch developer with the answer.
 
 ## Step 5: Verify + optional review
 
@@ -69,7 +94,7 @@ Before closeout, if `tier == 2` and `<docs_root>/bugfixes/<slug>.md` doesn't exi
 
 ## Step 7: Closeout
 
-Same as `/roundtable:workflow` Step 5 — render commit / PR draft, wait for `go-commit` / `go-pr` / `go-all` / `stop`. Never auto-run git or gh.
+Same as `/roundtable:workflow` Step 5 — render commit / PR draft, wait for `go-commit` / `go-pr` / `go-all` / `stop`. Never auto-run git or gh. Move the exec-plan from `active/` to `completed/` only after `go-commit` or `go-all`.
 
 ## Forbidden
 

--- a/skills/bugfix/references/codex-tools.md
+++ b/skills/bugfix/references/codex-tools.md
@@ -22,7 +22,7 @@ Codex:
 ```
 result = spawn_agent(
   agent_type="worker",
-  message="<contents of agents/developer.md>\n\nbug: <description>\ntier: <0|1|2>\nslug: <slug>\ndocs_root: <path>\n\nMust add a regression test. Do not refactor unrelated code.\nYou are not alone in the codebase; do not revert edits made by others."
+  message="<contents of agents/developer.md>\n\nexec-plan: <docs_root>/exec-plans/active/<slug>.md\nbug: <description>\ntier: <0|1|2>\nslug: <slug>\ndocs_root: <path>\n\nMust add a regression test. Do not refactor unrelated code.\nYou are not alone in the codebase; do not revert edits made by others."
 )
 wait_agent(targets=[result.id])
 close_agent(target=result.id)

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -86,8 +86,9 @@ On `accept`, architect proceeds to write the exec-plan, then pauses again for th
 Phase 6–9 are subagents. Dispatch one role per call:
 - Claude Code: use `Agent(subagent_type: "roundtable:<role>", prompt: ...)`.
 - Codex: first read `agents/<role>.md`, then call `spawn_agent` with `agent_type: "worker"` and a `message` containing that role prompt plus exec-plan path, `docs_root`, slug, optional design-doc path, and "You are not alone in the codebase; do not revert edits made by others." Keep the returned agent id for `wait_agent(targets: [id])` and `close_agent(target: id)`.
+- For reviewer (phase 8), the dispatch prompt/message must also include the diff scope (git range or file list), per `agents/reviewer.md` inputs.
 - Read return text. Tick matrix status.
-- **If return text contains `[NEED-DECISION]`**: parse the line, ask the user (TG `reply` with `a/b` options if telegram MCP is loaded; else the runtime's user-question tool, falling back to normal chat when needed), append answer to the exec-plan's `## Change Log`, then re-dispatch the same role with the answer.
+- **If return text contains `[NEED-DECISION]`** (canonical NEED-DECISION relay rule — `bugfix` and the plugin CLAUDE.md reference it): parse the line, ask the user (TG `reply` with `a/b` options if telegram MCP is loaded; else the runtime's user-question tool, falling back to normal chat when needed), append answer to the exec-plan's `## Change Log`, then re-dispatch the same role with the answer.
 - After phase 6 (developer), if the project's CLAUDE.md declares `critical_modules` and the diff hits one, phases 7 and 8 are mandatory; otherwise ask the user.
 
 ## Step 5: Closeout

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -153,7 +153,7 @@ suggested PR title / body: …
 reply: `go-commit` / `go-pr` / `go-all` / `modify: <…>` / `stop`
 ```
 
-Never auto-run `git commit` / `git push` / `gh pr create` without an explicit `go-*`. Move the exec-plan from `active/` to `completed/` only after `go-commit` or `go-all`.
+Never auto-run `git commit` / `git push` / `gh pr create` without an explicit `go-*`. Move the exec-plan from `active/` to `completed/` only after `go-commit` or `go-all`. At closeout, also move any leftover fully-ticked exec-plans in `active/` (e.g. from a prior Path A handoff whose branch / PR has since finished).
 
 ## Forbidden
 

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -137,7 +137,7 @@ Codex App cannot push from a sandboxed worktree. Use the App's native controls:
   - "Create branch" — names the branch, commits/pushes via App UI, opens PR
   - "Hand off to local" — transfers work to your local checkout
 
-Move the exec-plan to completed/ after the App finishes the branch / PR.
+The exec-plan stays in active/ for now; after the App finishes the branch / PR, the next orchestrator session moves it to completed/ at closeout (lint will suggest the move once all checkboxes are ticked).
 ```
 
 ### Standard closeout (other paths)


### PR DESCRIPTION
Closes #129

## 改动（纯 prompt/markdown，hooks/tests 不动）

1. **exec-plan 生命周期单一 owner = orchestrator**：developer.md 删自移步骤；CLAUDE.md「user moves it」改 orchestrator-at-closeout；Path A handoff 遗留 exec-plan 由后续 closeout 顺带清扫（reviewer Warning 修复）
2. **bugfix 产 mini exec-plan**（Step 3.5，全 tier）：消除 developer agent 输入强依赖 exec-plan 与 bugfix 不产 exec-plan 的断裂；派发参数补 exec-plan path / docs_root / slug
3. **NEED-DECISION canonical 化**：workflow Step 4 段落为唯一 canonical（channel-aware + Change Log 落点 + 续派同角色），bugfix 与 CLAUDE.md 改引用
4. **派发参数对齐**：workflow phase 8 派 reviewer 补 diff 范围

## 流程

exec-plan（confirmed）→ developer → tester（步骤编号引用 4/4 核对通过；抓到 Path A 残留 user-moves 语义等 1 major + 3 minor，major 已修）→ reviewer **CLEAN-WITH-NOTES**（唯一 Warning 已顺手修复）

来源：docs/reviews/2026-06-12-comprehensive-review.md 问题 2.1/2.2/2.3/2.7（PR-2/3 计划的第二个）

🤖 Generated with [Claude Code](https://claude.com/claude-code)