### PR TITLE
[codex] Use Codex-specific hook manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "roundtable",
   "version": "0.0.7",
   "description": "Multi-role AI development workflow. Bring analyst, architect, developer, tester, reviewer, and DBA to the same table. Minimal-by-design: 4 subagents, 5 skills, one SessionStart hook. Per-project CLAUDE.md (optional) drives toolchain + critical_modules.",
+  "hooks": "./hooks/hooks-codex.json",
   "author": {
     "name": "duktig666",
     "url": "https://github.com/duktig666"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **roundtable** will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Codex plugin hook discovery now uses an explicit `.codex-plugin/plugin.json` `hooks` entry pointing at `hooks/hooks-codex.json`, keeping the Codex `PLUGIN_ROOT` hook command separate from Claude Code's `CLAUDE_PLUGIN_ROOT` registration in `hooks/hooks.json`.
+
 ## [0.0.7] - 2026-06-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ analyst → architect → developer → tester → reviewer → dba.
 - `skills/` — 5 skills (analyst, architect, workflow, bugfix, lint), English prompts
 - `skills/*/references/` — per-skill `codex-tools.md` (Claude Code → Codex tool-mapping tables)
 - `commands/` — 3 thin command shells (workflow, bugfix, lint), each dispatching to the same-named skill
-- `hooks/` — `session-start` script (injects `docs_root` + `project_id`) + `hooks/hooks.json` (Claude Code-side registration, matcher `startup|clear|compact`)
-- `hooks.json` (root) — Codex-side hook declaration (matcher `*`); the fork from `hooks/hooks.json` is intentional: each runtime discovers its own file
+- `hooks/` — `session-start` script (injects `docs_root` + `project_id`), `hooks/hooks.json` (Claude Code registration), and `hooks/hooks-codex.json` (Codex registration)
+- `.codex-plugin/plugin.json` — Codex manifest; `hooks` explicitly points at `./hooks/hooks-codex.json` so Codex does not fall back to the Claude-side `hooks/hooks.json`
 - `tests/` — two hook test suites (`session-start.test.sh`, `session-start.adversarial.test.sh`)
 - `.codex-plugin/` — Codex manifest (`plugin.json`)
 - `AGENTS.md` — single-line pointer file (`CLAUDE.md`) for Codex

--- a/README-zh.md
+++ b/README-zh.md
@@ -47,7 +47,7 @@ codex plugin add github.com/duktig666/roundtable
 ### Codex troubleshooting
 
 - **`spawn_agent` 报 unknown tool** —— 检查 `~/.codex/config.toml` 含 `[features] multi_agent = true`（当前 Codex 默认值为 `true`）。
-- **SessionStart 注入的 `Roundtable context:` block 不见** —— 检查 `~/.codex/config.toml` 含 `[features] plugin_hooks = true`、plugin 根目录含 `hooks.json`，并确认 `hooks/session-start` 有执行权限。部分 Codex CLI build 可能不会在 `codex exec` 中暴露 hook 的 `additionalContext`；这种情况下 workflow 会 fallback 询问 `docs_root`。
+- **SessionStart 注入的 `Roundtable context:` block 不见** —— 检查 hooks 已启用、`.codex-plugin/plugin.json` 指向 `./hooks/hooks-codex.json`，并确认 `hooks/session-start` 有执行权限。部分 Codex CLI build 可能不会在 `codex exec` 中暴露 hook 的 `additionalContext`；这种情况下 workflow 会 fallback 询问 `docs_root`。
 - **TG MCP 在 Codex 下可选** —— 无 TG MCP 时 phase 广播自动降级到终端模式。如需启用：`codex mcp add telegram -- <你的 telegram MCP 命令>`，channel-aware 逻辑会自动路由到 Codex 侧 TG MCP 工具名（见 `codex /mcp` 输出）。
 
 ## 在任何项目里用

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In the Codex App plugin UI, add `github.com/duktig666/roundtable`. The App handl
 ### Codex troubleshooting
 
 - **`spawn_agent` reports unknown tool** — verify `~/.codex/config.toml` has `[features] multi_agent = true` (default `true` on current builds).
-- **SessionStart `Roundtable context:` block missing** — verify `~/.codex/config.toml` has `[features] plugin_hooks = true`, the plugin root contains `hooks.json`, and `hooks/session-start` is executable. Some Codex CLI builds may not surface hook `additionalContext` in `codex exec`; in that case the workflow asks for `docs_root` as a fallback.
+- **SessionStart `Roundtable context:` block missing** — verify hooks are enabled, `.codex-plugin/plugin.json` points at `./hooks/hooks-codex.json`, and `hooks/session-start` is executable. Some Codex CLI builds may not surface hook `additionalContext` in `codex exec`; in that case the workflow asks for `docs_root` as a fallback.
 - **TG MCP is optional under Codex** — phase broadcasts automatically degrade to terminal mode when no TG MCP server is configured. To enable: `codex mcp add telegram -- <your-telegram-mcp-command>`; channel-aware logic then routes via the Codex-side TG MCP tool name (visible in `codex /mcp`).
 
 ## Use it in any project

--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${PLUGIN_ROOT}/hooks/session-start\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/session-start.adversarial.test.sh
+++ b/tests/session-start.adversarial.test.sh
@@ -616,9 +616,8 @@ else
 fi
 
 # ============================================================
-# G. hook 声明一致性（hooks/hooks.json vs 根级 hooks.json）
-# upstream rc2 起 codex 改用根级 hooks.json 发现 hook，
-# .codex-plugin/plugin.json 不再内联 hooks 字段（matcher/async 分叉留档 PR-3）
+# G. hook 声明一致性（Claude hooks/hooks.json vs Codex hooks/hooks-codex.json）
+# Codex manifest 显式指向 hooks/hooks-codex.json，避免默认读取 Claude 侧 hooks/hooks.json。
 # ============================================================
 g_out="$("$PY" - "$REPO_ROOT" <<'PYEOF' 2>&1
 import json, os, sys
@@ -628,22 +627,26 @@ entries = hooks["hooks"]["SessionStart"]
 assert len(entries) == 1, "expect single SessionStart entry"
 cmd = entries[0]["hooks"][0]["command"]
 assert "hooks/session-start" in cmd, f"hooks.json command: {cmd}"
+assert "CLAUDE_PLUGIN_ROOT" in cmd, f"Claude hook command should use CLAUDE_PLUGIN_ROOT: {cmd}"
 assert entries[0]["matcher"] == "startup|clear|compact", f"matcher: {entries[0]['matcher']}"
 assert "async" not in entries[0]["hooks"][0], "non-standard async leaked back into hooks.json"
-codex = json.load(open(os.path.join(root, "hooks.json")))
-ccmd = codex["hooks"]["SessionStart"][0]["hooks"][0]["command"]
-assert "hooks/session-start" in ccmd, f"root hooks.json command: {ccmd}"
-assert "hooks" not in json.load(open(os.path.join(root, ".codex-plugin/plugin.json"))), \
-    "codex plugin.json should not carry inline hooks (moved to root hooks.json in rc2)"
+manifest = json.load(open(os.path.join(root, ".codex-plugin/plugin.json")))
+assert manifest["hooks"] == "./hooks/hooks-codex.json", f"Codex manifest hooks: {manifest.get('hooks')}"
+codex = json.load(open(os.path.join(root, "hooks/hooks-codex.json")))
+centry = codex["hooks"]["SessionStart"][0]
+ccmd = centry["hooks"][0]["command"]
+assert centry["matcher"] == "startup|resume|clear|compact", f"Codex matcher: {centry['matcher']}"
+assert "PLUGIN_ROOT" in ccmd and "hooks/session-start" in ccmd, f"Codex hook command: {ccmd}"
+assert "CLAUDE_PLUGIN_ROOT" not in ccmd, f"Codex hook command should not use CLAUDE_PLUGIN_ROOT: {ccmd}"
 print("OK")
 PYEOF
 )" || true
 if [ "$g_out" = "OK" ]; then
-    pass "G1 hooks/hooks.json + root hooks.json both reference hooks/session-start; hooks.json matcher/async per exec-plan 1.5"
+    pass "G1 Claude and Codex hook declarations are runtime-specific"
 else
     fail "G1 hook declarations consistency" "$g_out"
 fi
-# G2: codex plugin.json 直接 exec（不经 bash 前缀）→ 脚本必须可执行
+# G2: hook script remains executable for runtimes that execute it directly
 if [ -x "$HOOK" ]; then
     pass "G2 hook file executable (codex direct-exec)"
 else


### PR DESCRIPTION
## What changed

- Adds a Codex-specific hook declaration at `hooks/hooks-codex.json` using `PLUGIN_ROOT`.
- Points `.codex-plugin/plugin.json` at that Codex hook file via the manifest `hooks` field.
- Leaves `hooks/hooks.json` as the Claude Code registration using `CLAUDE_PLUGIN_ROOT`.
- Updates docs and adversarial tests to reflect the runtime-specific hook split.

## Why

Current Codex plugin docs say plugin-bundled hooks default to `hooks/hooks.json`, unless the Codex manifest explicitly overrides the hook path. Roundtable intended Codex and Claude Code to use separate hook declarations, but the Codex path could fall back to the Claude-side hook file. That made SessionStart startup sensitive to the wrong plugin-root variable and could surface as hook startup failures.

## Validation

- `python3 -m json.tool .codex-plugin/plugin.json hooks/hooks.json hooks/hooks-codex.json hooks.json`
- `bash tests/session-start.test.sh` -> 49 passed, 0 failed
- `bash tests/session-start.adversarial.test.sh` -> 301 passed, 0 failed, 0 known-bug
- `codex plugin add roundtable@personal` accepted the manifest hook entry and installed the plugin locally

## Notes

The local `plugin-creator` validator still rejects the manifest `hooks` field, but current Codex CLI 0.139.0 and the official Codex hooks docs support it.
